### PR TITLE
Feature-584 - expose `matchingName` in `SearchResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+## [1.0.0-beta.23] - 2022-02-01
+
 ### Added
 
-- [CORE] New properties are available: `SearchResult.matchingName`.
+- [CORE] New property is available: `SearchResult.matchingName`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Added
+
+- [CORE] New properties are available: `SearchResult.matchingName`.
+
 ### Fixed
 
 - ConstantCategoryDataProvider reference [#18](https://github.com/mapbox/search-ios/issues/18)

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-events-ios/MapboxMobileEvents.json" ~> 1.0.0
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" ~> 0.46.1
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 21.0.0
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" ~> 0.47.0
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 21.1.0-rc.1

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-events-ios/MapboxMobileEvents.json" ~> 1.0.0
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" ~> 0.47.0
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 21.1.0-rc.1
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" ~> 0.49.0
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 21.1.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "21.0.0"
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "21.1.0-rc.1"
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-events-ios/MapboxMobileEvents.json" "1.0.7"
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "0.46.1"
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "0.47.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "21.1.0-rc.1"
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "21.1.0"
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-events-ios/MapboxMobileEvents.json" "1.0.7"
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "0.47.0"
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "0.49.0"

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -25,6 +25,6 @@ Some iOS platform specifics applies.
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
   s.dependency "MapboxMobileEvents", "~> 1.0.0"
-  s.dependency "MapboxCommon", "~> 21.0.0"
+  s.dependency "MapboxCommon", "~> 21.1.0"
 
 end

--- a/MapboxSearch.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
+++ b/MapboxSearch.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1310"
+   LastUpgradeVersion = "1320"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MapboxSearch.xcodeproj/xcshareddata/xcschemes/MapboxSearch.xcscheme
+++ b/MapboxSearch.xcodeproj/xcshareddata/xcschemes/MapboxSearch.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1310"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MapboxSearch.xcodeproj/xcshareddata/xcschemes/MapboxSearchTests.xcscheme
+++ b/MapboxSearch.xcodeproj/xcshareddata/xcschemes/MapboxSearchTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1310"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MapboxSearch.xcodeproj/xcshareddata/xcschemes/MapboxSearchUI.xcscheme
+++ b/MapboxSearch.xcodeproj/xcshareddata/xcschemes/MapboxSearchUI.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1310"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MapboxSearch.xcodeproj/xcshareddata/xcschemes/MapboxSearchUIResources.xcscheme
+++ b/MapboxSearch.xcodeproj/xcshareddata/xcschemes/MapboxSearchUIResources.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1310"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
-          "revision": "3dabe41278e9b88e3eb2851dd3967493d21f08af",
-          "version": "21.0.1"
+          "revision": "d0adb996dfad19ed1edc611ee640e6c7506951a0",
+          "version": "21.1.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 import Foundation
 
 let registry = SDKRegistry()
-let (coreSearchVersion, coreSearchVersionHash) = ("0.46.1", "181ee9cc21a9c1887fec0a660421e00ce123b16a5c915c694b49b7181c845a6c")
+let (coreSearchVersion, coreSearchVersionHash) = ("0.49.0", "817045733ead06315dcad7cd6090736e8f371745199597dca71dd0c5a9652556")
 
 let package = Package(
     name: "MapboxSearch",
@@ -24,7 +24,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(name: "MapboxMobileEvents", url: "https://github.com/mapbox/mapbox-events-ios.git", from: "1.0.0"),
-        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", from: "21.1.0-rc.1"),
+        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", from: "21.1.0"),
         .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", from: "2.0.0")
     ],
     targets: [
@@ -45,7 +45,7 @@ let package = Package(
             dependencies: ["MapboxSearch"],
             exclude: ["Info.plist", "Resources-Info.plist"]
         ),
-        
+
         registry.mapboxCoreSearchTarget(version: coreSearchVersion,
                                         checksum: coreSearchVersionHash),
         .testTarget(
@@ -63,19 +63,19 @@ let package = Package(
 
 struct SDKRegistry {
     let host = "api.mapbox.com"
-    
+
     func binaryTarget(name: String, version: String, path: String, filename: String, checksum: String) -> Target {
         var url = "https://\(host)/downloads/v2/\(path)/releases/ios/packages/\(version)/\(filename)"
-        
+
         if let token = netrcToken {
             url += "?access_token=\(token)"
         } else {
             debugPrint("Mapbox token wasn't founded in ~/.netrc. Fix this issue to integrate Mapbox SDK. Otherwise, you will see 'invalid status code 401' or 'no XCFramework found. To clean issue in Xcode, remove ~/Library/Developer/Xcode/DerivedData folder")
         }
-        
+
         return .binaryTarget(name: name, url: url, checksum: checksum)
     }
-    
+
     var netrcToken: String? {
         var mapboxToken: String?
         do {
@@ -84,7 +84,7 @@ struct SDKRegistry {
         } catch {
             // Do nothing on client machines
         }
-        
+
         return mapboxToken
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(name: "MapboxMobileEvents", url: "https://github.com/mapbox/mapbox-events-ios.git", from: "1.0.0"),
-        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", from: "21.0.0"),
+        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", from: "21.1.0-rc.1"),
         .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", from: "2.0.0")
     ],
     targets: [

--- a/Sources/MapboxSearch/InternalAPI/CoreSearchResultProtocol.swift
+++ b/Sources/MapboxSearch/InternalAPI/CoreSearchResultProtocol.swift
@@ -17,6 +17,8 @@ protocol CoreSearchResultProtocol {
     var addresses: [CoreAddress]? { get }
     
     var addressDescription: String? { get }
+    
+    var matchingName: String? { get }
 
     var center: CLLocation? { get }
 

--- a/Sources/MapboxSearch/PublicAPI/FavoriteRecord.swift
+++ b/Sources/MapboxSearch/PublicAPI/FavoriteRecord.swift
@@ -9,6 +9,13 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
     /// Displayable name of the record.
     public var name: String
     
+    /**
+        The feature name, as matched by the search algorithm.
+        
+        - Warning: The field is exposed for compatibility only, will be removed soon.
+    */
+    public var matchingName: String?
+    
     /// address formatted with medium style.
     public var descriptionText: String? { address?.formattedAddress(style: .medium) }
     
@@ -60,9 +67,21 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
     ///   - makiIcon:Favorite  icon name
     ///   - categories: Favorite categories list
     ///   - resultType: Favorite result type
-    public init(id: String? = nil, name: String, coordinate: CLLocationCoordinate2D, address: Address?, makiIcon: Maki?, categories: [String]?, routablePoints: [RoutablePoint]? = nil, resultType: SearchResultType, metadata: SearchResultMetadata? = nil) {
+    public init(
+        id: String? = nil,
+        name: String,
+        matchingName: String?,
+        coordinate: CLLocationCoordinate2D,
+        address: Address?,
+        makiIcon: Maki?,
+        categories: [String]?,
+        routablePoints: [RoutablePoint]? = nil,
+        resultType: SearchResultType,
+        metadata: SearchResultMetadata? = nil
+    ) {
         self.id = id ?? UUID().uuidString
         self.name = name
+        self.matchingName = matchingName
         self.coordinateCodable = .init(coordinate)
         self.address = address
         self.icon = makiIcon
@@ -76,9 +95,14 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
     ///   - id: UUID used by default
     ///   - name: Favorite name
     ///   - searchResult: search result to use for FavoriteRecord
-    public init(id: String? = nil, name: String, searchResult: SearchResult) {
+    public init(
+        id: String? = nil,
+        name: String,
+        searchResult: SearchResult
+    ) {
         self.init(id: id,
                   name: name,
+                  matchingName: searchResult.matchingName,
                   coordinate: searchResult.coordinate,
                   address: searchResult.address,
                   makiIcon: searchResult.iconName.flatMap(Maki.init),

--- a/Sources/MapboxSearch/PublicAPI/HistoryRecord.swift
+++ b/Sources/MapboxSearch/PublicAPI/HistoryRecord.swift
@@ -20,10 +20,18 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
     }
     
     /// Unique identifier
-    public private(set) var id: String
+    public var id: String
     
     /// Record's name
     public private(set) var name: String
+    
+    /**
+        The feature name, as matched by the search algorithm.
+        
+        - Warning: The field is exposed for compatibility only, will be removed soon.
+    */
+    public private(set) var matchingName: String?
+    
     /// Address formatted with medium style
     public var descriptionText: String? { address?.formattedAddress(style: .medium) }
     
@@ -80,9 +88,22 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
     ///   - metadata: Associated metadata
     ///   - categories: Categories of original object
     ///   - routablePoints: Coordinates of building entries
-    public init(id: String = UUID().uuidString, name: String, coordinate: CLLocationCoordinate2D, timestamp: Date = Date(), historyType: HistoryRecord.HistoryType, type: SearchResultType, address: Address?, metadata: SearchResultMetadata? = nil, categories: [String]? = nil, routablePoints: [RoutablePoint]? = nil) {
+    public init(
+        id: String = UUID().uuidString,
+        name: String,
+        matchingName: String?,
+        coordinate: CLLocationCoordinate2D,
+        timestamp: Date = Date(),
+        historyType: HistoryRecord.HistoryType,
+        type: SearchResultType,
+        address: Address?,
+        metadata: SearchResultMetadata? = nil,
+        categories: [String]? = nil,
+        routablePoints: [RoutablePoint]? = nil
+    ) {
         self.id = id
         self.name = name
+        self.matchingName = matchingName
         self.coordinateCodable = .init(coordinate)
         self.timestamp = timestamp
         self.historyType = historyType
@@ -98,9 +119,14 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
     ///   - historyType: Type of history result
     ///   - searchResult: Prototype result
     ///   - timestamp: creating timestamp. Calling time by default
-    public init(historyType: HistoryRecord.HistoryType = .result, searchResult: SearchResult, timestamp: Date = Date()) {
+    public init(
+        historyType: HistoryRecord.HistoryType = .result,
+        searchResult: SearchResult,
+        timestamp: Date = Date()
+    ) {
         self.id = searchResult.id
         self.name = searchResult.name
+        self.matchingName = searchResult.matchingName
         self.coordinateCodable = .init(searchResult.coordinate)
         self.timestamp = timestamp
         self.historyType = historyType

--- a/Sources/MapboxSearch/PublicAPI/HistoryRecord.swift
+++ b/Sources/MapboxSearch/PublicAPI/HistoryRecord.swift
@@ -20,7 +20,7 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
     }
     
     /// Unique identifier
-    public var id: String
+    public private(set) var id: String
     
     /// Record's name
     public private(set) var name: String

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchResult.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchResult.swift
@@ -19,6 +19,9 @@ public protocol SearchResult {
     /// Result coordinates.
     var coordinate: CLLocationCoordinate2D { get }
     
+    /// The feature name, as matched by the search algorithm.
+    var matchingName: String? { get }
+    
     /// Result address.
     var address: Address? { get }
     

--- a/Sources/MapboxSearch/PublicAPI/Search Results/ServerSearchResult.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/ServerSearchResult.swift
@@ -19,6 +19,8 @@ class ServerSearchResult: SearchResult, SearchResultSuggestion, CoreResponseProv
     
     var metadata: SearchResultMetadata?
     
+    var serverIndex: Int?
+    
     var coordinateCodable: CLLocationCoordinate2DCodable
     
     var address: Address?
@@ -32,6 +34,8 @@ class ServerSearchResult: SearchResult, SearchResultSuggestion, CoreResponseProv
     var id: String
     
     var name: String
+    
+    var matchingName: String?
     
     var descriptionText: String?
     
@@ -56,9 +60,11 @@ class ServerSearchResult: SearchResult, SearchResultSuggestion, CoreResponseProv
         
         self.id = coreResult.id
         self.name = coreResult.names[0]
+        self.matchingName = coreResult.matchingName
         self.iconName = coreResult.icon
         self.estimatedTime = coreResult.estimatedTime
         self.metadata = coreResult.metadata.map(SearchResultMetadata.init)
+        self.serverIndex = coreResult.serverIndex?.intValue
         self.address = coreResult.addresses?.first.map(Address.init)
         self.categories = coreResult.categories
         self.coordinateCodable = .init(coordinate)

--- a/Tests/MapboxSearchTests/CodablePersistentServiceTests.swift
+++ b/Tests/MapboxSearchTests/CodablePersistentServiceTests.swift
@@ -31,6 +31,7 @@ class CodablePersistentServiceTests: XCTestCase {
                               country: "None")
         let record = FavoriteRecord(id: UUID().uuidString,
                                     name: "Say My Name",
+                                    matchingName: nil,
                                     coordinate: coordinate,
                                     address: address,
                                     makiIcon: nil,
@@ -51,6 +52,7 @@ class CodablePersistentServiceTests: XCTestCase {
         let coordinate = CLLocationCoordinate2D(latitude: 10.0, longitude: 10.0)
         let record = HistoryRecord(id: UUID().uuidString,
                                    name: "DaName",
+                                   matchingName: nil,
                                    coordinate: coordinate,
                                    timestamp: Date(),
                                    historyType: .category,

--- a/Tests/MapboxSearchTests/Data Samples/SearchResultStub+Samples.swift
+++ b/Tests/MapboxSearchTests/Data Samples/SearchResultStub+Samples.swift
@@ -4,6 +4,7 @@ extension SearchResultStub {
     static let sample1 = SearchResultStub(id: "sample-1",
                                           categories: ["sample-1", "sample-2"],
                                           name: "Sample No 1",
+                                          matchingName: nil,
                                           iconName: Maki.bar.name,
                                           resultType: .POI,
                                           routablePoints: [.routablePointForSample1],

--- a/Tests/MapboxSearchTests/HistoryRecordTests.swift
+++ b/Tests/MapboxSearchTests/HistoryRecordTests.swift
@@ -5,6 +5,7 @@ class HistoryRecordTests: XCTestCase {
     func testHistoryRecordCategories() throws {
         let record = HistoryRecord(id: UUID().uuidString,
                                    name: "DaName",
+                                   matchingName: nil,
                                    coordinate: .sample1,
                                    timestamp: Date(),
                                    historyType: .category,
@@ -16,6 +17,7 @@ class HistoryRecordTests: XCTestCase {
     func testHistoryRecordCoordinates() {
         var record = HistoryRecord(id: UUID().uuidString,
                                    name: "DaName",
+                                   matchingName: nil,
                                    coordinate: .sample1,
                                    timestamp: Date(),
                                    historyType: .category,
@@ -31,6 +33,7 @@ class HistoryRecordTests: XCTestCase {
     func testHistoryRecordDescriptionText() {
         let record = HistoryRecord(id: UUID().uuidString,
                                    name: "DaName",
+                                   matchingName: nil,
                                    coordinate: .sample1,
                                    timestamp: Date(),
                                    historyType: .category,

--- a/Tests/MapboxSearchTests/SearchResultTests.swift
+++ b/Tests/MapboxSearchTests/SearchResultTests.swift
@@ -3,7 +3,14 @@ import XCTest
 
 class SearchResultTests: XCTestCase {
     func testPlacemarkGeneration() throws {
-        let resultStub = SearchResultStub(id: "unit-test-random", name: "Unit Test", resultType: .POI, coordinate: .init(latitude: 12, longitude: -35), metadata: .pizzaMetadata)
+        let resultStub = SearchResultStub(
+            id: "unit-test-random",
+            name: "Unit Test",
+            matchingName: nil,
+            resultType: .POI,
+            coordinate: .init(latitude: 12, longitude: -35),
+            metadata: .pizzaMetadata
+        )
         
         XCTAssertEqual(resultStub.placemark.location?.coordinate.latitude, 12)
         XCTAssertEqual(resultStub.placemark.location?.coordinate.longitude, -35)

--- a/Tests/MapboxSearchTests/Stubs&Models/CoreSearchResultStub.swift
+++ b/Tests/MapboxSearchTests/Stubs&Models/CoreSearchResultStub.swift
@@ -9,6 +9,7 @@ class CoreSearchResultStub: CoreSearchResultProtocol {
         languages: [String] = ["sample-language1", "sample-language2"],
         addresses: [CoreAddress]? = [Address.mapboxDCOffice.coreAddress()],
         addressDescription: String? = nil,
+        matchingName: String? = nil,
         center: CLLocation? = .sample1,
         categories: [String]? = nil,
         routablePoints: [CoreRoutablePoint]? = nil,
@@ -56,6 +57,7 @@ class CoreSearchResultStub: CoreSearchResultProtocol {
     var languages: [String]
     var addresses: [CoreAddress]?
     var addressDescription: String?
+    var matchingName: String?
     var center: CLLocation?
     var categories: [String]?
     var routablePoints: [CoreRoutablePoint]?
@@ -116,6 +118,7 @@ extension CoreSearchResultProtocol {
                          languages: languages,
                          addresses: addresses,
                          descrAddress: addressDescription,
+                         matchingName: matchingName,
                          distance: distance,
                          eta: nil,
                          center: center,

--- a/Tests/MapboxSearchTests/Stubs&Models/IndexableRecordStub.swift
+++ b/Tests/MapboxSearchTests/Stubs&Models/IndexableRecordStub.swift
@@ -18,7 +18,17 @@ struct IndexableRecordStub: IndexableRecord {
     var additionalTokens: Set<String>?
     
     var asResolved: SearchResult {
-        SearchResultStub(id: id, categories: nil, name: name, iconName: nil, resultType: .address(subtypes: [.address]), coordinate: .init(coordinate), address: address, metadata: nil)
+        SearchResultStub(
+            id: id,
+            categories: nil,
+            name: name,
+            matchingName: nil,
+            iconName: nil,
+            resultType: .address(subtypes: [.address]),
+            coordinate: .init(coordinate),
+            address: address,
+            metadata: nil
+        )
     }
     
     init(id: String, name: String, coordinate: CLLocationCoordinate2DCodable, address: Address? = nil, additionalTokens: Set<String>? = nil) {

--- a/Tests/MapboxSearchTests/Stubs&Models/SearchResultStub.swift
+++ b/Tests/MapboxSearchTests/Stubs&Models/SearchResultStub.swift
@@ -7,6 +7,7 @@ class SearchResultStub: SearchResult {
         id: String,
         categories: [String]? = nil,
         name: String,
+        matchingName: String?,
         iconName: String? = nil,
         resultType: SearchResultType,
         routablePoints: [RoutablePoint]? = nil,
@@ -18,6 +19,7 @@ class SearchResultStub: SearchResult {
         self.id = id
         self.categories = categories
         self.name = name
+        self.matchingName = matchingName
         self.iconName = iconName
         self.type = resultType
         self.routablePoints = routablePoints
@@ -32,6 +34,7 @@ class SearchResultStub: SearchResult {
     var id: String
     var categories: [String]?
     var name: String
+    var matchingName: String?
     var iconName: String?
     var type: SearchResultType
     var routablePoints: [RoutablePoint]?

--- a/Tests/MapboxSearchTests/Stubs&Models/TestDataProviderRecord.swift
+++ b/Tests/MapboxSearchTests/Stubs&Models/TestDataProviderRecord.swift
@@ -5,6 +5,7 @@ struct TestDataProviderRecord: IndexableRecord, SearchResult {
     var type: SearchResultType
     var id: String = UUID().uuidString
     var name: String
+    var matchingName: String?
     var coordinate: CLLocationCoordinate2D
     var iconName: String?
     var categories: [String]?


### PR DESCRIPTION
### Description
Exposed `matchingName` field to the `SearchResult` protocol.

`matchingName` field is also exposed to the `HistoryRecord` and `FavoriteRecord` only for compatibility reasons and will be removed soon.

### Checklist
- [x] Update `CHANGELOG`
