### PR TITLE
Release: v1.0.0-beta.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+## [1.0.0-beta.30] - 2022-05-03
+
+## Public API changes
+### Removed
+- `RecordsProviderInteractor.contains(identifier: String)` method removed.
+- `MapboxMobileEvents` dependecy.
+
+### Added
+- `SearchError.searchRequestCancelled` in order to identify cancelled request.
+
+## Known limitations
+- Analytics reports disabled for the `beta.30` + (unit tests), it will be enabled again in `beta.31`.
+
+**MapboxCommon**: v21.3.0
+**MapboxCoreSearch**: v0.54.1
+
+
 ## [1.0.0-beta.29] - 2022-04-29
 
 ### Fixed

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearch'
-  s.version          = '1.0.0-beta.29'
+  s.version          = '1.0.0-beta.30'
   s.summary          = 'Search SDK for Mapbox Search API '
 
 # This description is used to generate tags and improve search results.

--- a/MapboxSearchUI.podspec
+++ b/MapboxSearchUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearchUI'
-  s.version          = '1.0.0-beta.29'
+  s.version          = '1.0.0-beta.30'
   s.summary          = 'Search UI for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.
@@ -23,5 +23,5 @@ Card style custom UI with full search functionality powered by Mapbox Search API
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency 'MapboxSearch', "1.0.0-beta.29"
+  s.dependency 'MapboxSearch', "1.0.0-beta.30"
 end


### PR DESCRIPTION
## Public API changes
### Removed
- `RecordsProviderInteractor.contains(identifier: String)` method removed.
- `MapboxMobileEvents` dependecy.

### Added
- `SearchError.searchRequestCancelled` in order to identify cancelled request.

## Known limitations
- Analytics reports disabled for the `beta.30` + (unit tests), will be enabled again in `beta.31`.

**MapboxCommon**: v21.3.0
**MapboxCoreSearch**: v0.54.1
