### PR TITLE
SearchCore: exposed `categories` field of POI in `SearchSuggestion` model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+## Public API changes
+### Added
+- `SearchSuggestion.categories` identifies categories of POI, optional.
+
+**MapboxCommon**: v21.3.0
+**MapboxCoreSearch**: v0.54.1
+
 ## [1.0.0-beta.30] - 2022-05-03
 
 ## Public API changes

--- a/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
+++ b/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
@@ -1,2 +1,2 @@
 /// Mapbox Search SDK version variable
-public let mapboxSearchSDKVersion = "1.0.0-beta.29"
+public let mapboxSearchSDKVersion = "1.0.0-beta.30"

--- a/Sources/MapboxSearch/PublicAPI/Search Results/ExternalRecordPlaceholder.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/ExternalRecordPlaceholder.swift
@@ -16,6 +16,8 @@ class ExternalRecordPlaceholder: SearchResultSuggestion, CoreResponseProvider {
     
     var iconName: String?
     
+    var categories: [String]?
+    
     var suggestionType: SearchSuggestType = .POI
     
     var distance: CLLocationDistance?
@@ -31,6 +33,7 @@ class ExternalRecordPlaceholder: SearchResultSuggestion, CoreResponseProvider {
         self.dataLayerIdentifier = layerIdentifier
         self.distance = coreResult.distanceToProximity
         self.originalResponse = CoreSearchResultResponse(coreResult: coreResult, response: response)
+        self.categories = coreResult.categories
         
         self.descriptionText = coreResult.addresses?.first.map(Address.init)?.formattedAddress(style: .medium)
         self.batchResolveSupported = coreResult.action?.isMultiRetrievable ?? false

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchCategorySuggestionImpl.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchCategorySuggestionImpl.swift
@@ -16,6 +16,8 @@ class SearchCategorySuggestionImpl: SearchCategorySuggestion, CoreResponseProvid
     
     var suggestionType: SearchSuggestType
     
+    var categories: [String]?
+    
     var distance: CLLocationDistance?
     
     let batchResolveSupported: Bool
@@ -33,6 +35,7 @@ class SearchCategorySuggestionImpl: SearchCategorySuggestion, CoreResponseProvid
         self.originalResponse = CoreSearchResultResponse(coreResult: coreResult, response: response)
         self.distance = coreResult.distanceToProximity
         self.batchResolveSupported = coreResult.action?.isMultiRetrievable ?? false
+        self.categories = coreResult.categories
         
         self.descriptionText = coreResult.addressDescription
     }

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchQuerySuggestionImpl.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchQuerySuggestionImpl.swift
@@ -15,6 +15,8 @@ class SearchQuerySuggestionImpl: SearchQuerySuggestion, CoreResponseProvider {
     
     var iconName: String?
     
+    var categories: [String]?
+    
     var suggestionType: SearchSuggestType
     
     var distance: CLLocationDistance?
@@ -34,6 +36,7 @@ class SearchQuerySuggestionImpl: SearchQuerySuggestion, CoreResponseProvider {
         self.originalResponse = CoreSearchResultResponse(coreResult: coreResult, response: response)
         self.distance = coreResult.distanceToProximity
         self.batchResolveSupported = coreResult.action?.isMultiRetrievable ?? false
+        self.categories = coreResult.categories
         
         self.descriptionText = coreResult.addressDescription
     }

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchResultSuggestionImpl.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchResultSuggestionImpl.swift
@@ -14,6 +14,8 @@ class SearchResultSuggestionImpl: SearchResultSuggestion, CoreResponseProvider {
     
     var iconName: String?
     
+    var categories: [String]?
+    
     var suggestionType: SearchSuggestType
     
     var descriptionText: String?
@@ -44,6 +46,7 @@ class SearchResultSuggestionImpl: SearchResultSuggestion, CoreResponseProvider {
         self.originalResponse = CoreSearchResultResponse(coreResult: coreResult, response: response)
         self.distance = coreResult.distanceToProximity
         self.batchResolveSupported = coreResult.action?.isMultiRetrievable ?? false
+        self.categories = coreResult.categories
         
         self.descriptionText = coreResult.addressDescription
     }

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchSuggestion.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchSuggestion.swift
@@ -18,6 +18,9 @@ public protocol SearchSuggestion {
     /// Usually contains pre-formatted address.
     var descriptionText: String? { get }
     
+    /// Result categories types.
+    var categories: [String]? { get }
+    
     /// Result address.
     var address: Address? { get }
     

--- a/Tests/MapboxSearchTests/Stubs&Models/SearchResultSuggestionStub.swift
+++ b/Tests/MapboxSearchTests/Stubs&Models/SearchResultSuggestionStub.swift
@@ -13,6 +13,8 @@ struct SearchResultSuggestionStub: SearchResultSuggestion {
     
     var address: Address?
     
+    var categories: [String]?
+    
     var descriptionText: String? = "Test description text"
     
     var iconName: String? = Maki.bar.name

--- a/Tests/MapboxSearchTests/Stubs&Models/SearchSuggestionStub.swift
+++ b/Tests/MapboxSearchTests/Stubs&Models/SearchSuggestionStub.swift
@@ -4,6 +4,7 @@ import CoreLocation
 struct SearchSuggestionStub: SearchSuggestion {
     var id: String = UUID().uuidString
     var name: String = "Test Name"
+    var categories: [String]?
     var descriptionText: String? = "Test Description"
     var address: Address?
     var iconName: String?


### PR DESCRIPTION
Public API changes:
added `categories` field to the `SearchSuggestion` model in order to identify categories of POI.