### PR TITLE
[Core/UI]: added separate `SearchEngineDelegate` callback for results received in offline mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Added
+- [Core] `SearchEngineDelegate.suggestionsUpdated(results:suggestions:searchEngine)` - added a separate method for search results received in offline mode.
+
+### Fixed
+- [UI] Fixed an issue in `MapboxSearchController` when search suggestions didn't update in offline mode
+
 ## [1.0.0-beta.31] - 2022-06-20
 
 ### Added

--- a/Sources/MapboxSearch/PublicAPI/Engine/SearchEngine.swift
+++ b/Sources/MapboxSearch/PublicAPI/Engine/SearchEngine.swift
@@ -9,6 +9,12 @@ public protocol SearchEngineDelegate: AnyObject {
     /// - Parameter searchEngine: calling engine
     func suggestionsUpdated(suggestions: [SearchSuggestion], searchEngine: SearchEngine)
     
+    /// Search Engine calls this method for every offline search update
+    /// - Parameter results: resolved search results
+    /// - Parameter suggestions: suggestions for search results
+    /// - Parameter searchEngine: calling engine
+    func offlineResultsUpdated(_ results: [SearchResult], suggestions: [SearchSuggestion], searchEngine: SearchEngine)
+    
     /// Search Engine did resolve SearchSuggestion.
     /// To receive resolved Search result you have to call "select(suggestion: SearchSuggestion)" method
     /// - Parameter result: resolved search result
@@ -33,6 +39,12 @@ public extension SearchEngineDelegate {
     ///   - results: resolved search result
     ///   - searchEngine: calling engine
     func resultsResolved(results: [SearchResult], searchEngine: SearchEngine) { }
+    
+    /// Default implementation does nothing
+    /// - Parameter results: resolved search results
+    /// - Parameter suggestions: suggestions for search results
+    /// - Parameter searchEngine: calling engine
+    func offlineResultsUpdated(_ results: [SearchResult], suggestions: [SearchSuggestion], searchEngine: SearchEngine) { }
 }
 
 /**
@@ -276,9 +288,11 @@ public class SearchEngine: AbstractSearchEngine {
             suggestions = responseResult.suggestions
             
             if offlineMode == .enabled {
-                let results = responseResult.results
-                
-                delegate?.resultsResolved(results: results, searchEngine: self)
+                delegate?.offlineResultsUpdated(
+                    responseResult.results,
+                    suggestions: responseResult.suggestions,
+                    searchEngine: self
+                )
             } else {
                 delegate?.suggestionsUpdated(suggestions: suggestions, searchEngine: self)
             }

--- a/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
+++ b/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
@@ -1,2 +1,2 @@
 /// Mapbox Search SDK version variable
-public let mapboxSearchSDKVersion = "1.0.0-beta.30"
+public let mapboxSearchSDKVersion = "1.0.0-beta.31"

--- a/Sources/MapboxSearchUI/MapboxSearchController.swift
+++ b/Sources/MapboxSearchUI/MapboxSearchController.swift
@@ -444,7 +444,21 @@ extension MapboxSearchController: SearchEngineDelegate {
         }
         searchSuggestionsSource.suggestions = suggestions
         
-        noSuggestionsView.suggestionLabelVisible = searchSuggestionsSource.suggestions.isEmpty
+        noSuggestionsView.suggestionLabelVisible = suggestions.isEmpty
+        tableController.tableView.tableFooterView = noSuggestionsView
+        tableController.tableView.reloadData()
+    }
+    
+    public func offlineResultsUpdated(_ results: [SearchResult], suggestions: [SearchSuggestion], searchEngine: SearchEngine) {
+        assert(Thread.isMainThread)
+        assert(results.count == suggestions.count)
+        
+        let responseQuery = Query(string: searchEngine.query)
+        guard responseQuery == query || responseQuery == .none else { return }
+        
+        searchSuggestionsSource.suggestions = suggestions
+        
+        noSuggestionsView.suggestionLabelVisible = suggestions.isEmpty
         tableController.tableView.tableFooterView = noSuggestionsView
         tableController.tableView.reloadData()
     }


### PR DESCRIPTION
### Added
- [Core] `SearchEngineDelegate.suggestionsUpdated(results:suggestions:searchEngine)` - added a separate method for search results received in offline mode.

### Fixed
- [UI] Fixed an issue in `MapboxSearchController` when search suggestions didn't update in offline mode
