### PR TITLE
[Core]: changed mechanism to check `authorizationStatus` of location services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Fixed
+- [Core] Fixed warning related to `CLLocationManager` permissions check.
+
 ## [1.0.0-beta.32] - 2022-07-04
 
 ### Added

--- a/Sources/MapboxSearch/PublicAPI/DefaultLocationProvider.swift
+++ b/Sources/MapboxSearch/PublicAPI/DefaultLocationProvider.swift
@@ -50,9 +50,17 @@ public class DefaultLocationProvider {
     }
 
     // MARK: Private functions
+    
+    private var locationServicesDisabled: Bool {
+        if #available(iOS 14.0, *) {
+            return locationManager.authorizationStatus == .denied
+        } else {
+            return CLLocationManager.authorizationStatus() == .denied
+        }
+    }
 
     private func initializeLocation() {
-        guard CLLocationManager.locationServicesEnabled() else {
+        guard !locationServicesDisabled else {
             _Logger.searchSDK.info("CLLocationManager.locationServicesEnabled == false", category: .default)
             return
         }


### PR DESCRIPTION
This MR fixes a warning introduced by `CLLocationManager. locationServicesEnabled` usage, now `authorizationStatus` is used to determine actual state of location services.
