### PR TITLE
[Core]: expose original search request in `SearchResult`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Added
+- [Core] `SearchResult.searchRequest` field exposed. Identifies original search request for a result.
+
 ### Fixed
 - [Core] Fixed warning related to `CLLocationManager` permissions check.
 

--- a/Sources/MapboxSearch/PublicAPI/FavoriteRecord.swift
+++ b/Sources/MapboxSearch/PublicAPI/FavoriteRecord.swift
@@ -61,6 +61,9 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
     /// FavoriteRecord Always has estimatedTime as nil.
     public var estimatedTime: Measurement<UnitDuration>?
     
+    /// Original search request.
+    public let searchRequest: SearchRequestOptions
+    
     /// Associated metadata
     public var metadata: SearchResultMetadata?
     
@@ -72,6 +75,7 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
     ///   - address: Favorite address
     ///   - makiIcon:Favorite  icon name
     ///   - categories: Favorite categories list
+    ///   - searchRequest: original search request
     ///   - resultType: Favorite result type
     public init(
         id: String? = nil,
@@ -85,6 +89,7 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
         categories: [String]?,
         routablePoints: [RoutablePoint]? = nil,
         resultType: SearchResultType,
+        searchRequest: SearchRequestOptions,
         metadata: SearchResultMetadata? = nil
     ) {
         self.id = id ?? UUID().uuidString
@@ -98,6 +103,7 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
         self.categories = categories
         self.type = resultType
         self.metadata = metadata
+        self.searchRequest = searchRequest
     }
     
     /// Build Favorite record from SearchResult
@@ -121,6 +127,7 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
                   categories: searchResult.categories,
                   routablePoints: searchResult.routablePoints,
                   resultType: searchResult.type,
+                  searchRequest: searchResult.searchRequest,
                   metadata: searchResult.metadata)
     }
 } 

--- a/Sources/MapboxSearch/PublicAPI/HistoryRecord.swift
+++ b/Sources/MapboxSearch/PublicAPI/HistoryRecord.swift
@@ -79,6 +79,9 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
     /// Categories associated with original result
     public var categories: [String]?
     
+    /// Original search request.
+    public let searchRequest: SearchRequestOptions
+    
     /// Coordinates of building entries
     public var routablePoints: [RoutablePoint]?
     
@@ -107,6 +110,7 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
         address: Address?,
         metadata: SearchResultMetadata? = nil,
         categories: [String]? = nil,
+        searchRequest: SearchRequestOptions,
         routablePoints: [RoutablePoint]? = nil
     ) {
         self.id = id
@@ -121,6 +125,7 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
         self.address = address
         self.metadata = metadata
         self.categories = categories
+        self.searchRequest = searchRequest
         self.routablePoints = routablePoints
     }
     
@@ -146,6 +151,7 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
         self.address = searchResult.address
         self.metadata = searchResult.metadata
         self.categories = searchResult.categories
+        self.searchRequest = searchResult.searchRequest
         self.routablePoints = searchResult.routablePoints
     }
 }

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchResult.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchResult.swift
@@ -40,6 +40,9 @@ public protocol SearchResult {
     /// Coordinates of building entries
     var routablePoints: [RoutablePoint]? { get }
     
+    /// Original search request.
+    var searchRequest: SearchRequestOptions { get }
+    
     /// MapKit placemark
     var placemark: MKPlacemark { get }
     

--- a/Sources/MapboxSearch/PublicAPI/SearchRequestOptions.swift
+++ b/Sources/MapboxSearch/PublicAPI/SearchRequestOptions.swift
@@ -1,7 +1,7 @@
 import CoreLocation
 
 /// Possible options for search request
-public struct SearchRequestOptions: Codable {
+public struct SearchRequestOptions: Equatable, Hashable, Codable {
     /// Search query
     public let query: String
     

--- a/Tests/MapboxSearchTests/CodablePersistentServiceTests.swift
+++ b/Tests/MapboxSearchTests/CodablePersistentServiceTests.swift
@@ -38,7 +38,9 @@ class CodablePersistentServiceTests: XCTestCase {
                                     serverIndex: nil,
                                     accuracy: nil,
                                     categories: [],
-                                    resultType: .address(subtypes: [.address]))
+                                    resultType: .address(subtypes: [.address]),
+                                    searchRequest: .init(query: "Sample", proximity: nil)
+        )
         XCTAssertTrue(service.saveData(record), "Unable to save record")
         if let loadedRecord = service.loadData() {
             XCTAssertEqual(record, loadedRecord)
@@ -61,7 +63,9 @@ class CodablePersistentServiceTests: XCTestCase {
                                    timestamp: Date(),
                                    historyType: .category,
                                    type: .address(subtypes: [.address]),
-                                   address: nil)
+                                   address: nil,
+                                   searchRequest: .init(query: "Sample", proximity: nil)
+        )
         XCTAssertTrue(service.saveData(record), "Unable to save record")
         if let loadedRecord = service.loadData() {
             XCTAssertEqual(record, loadedRecord)

--- a/Tests/MapboxSearchTests/HistoryRecordTests.swift
+++ b/Tests/MapboxSearchTests/HistoryRecordTests.swift
@@ -12,7 +12,9 @@ class HistoryRecordTests: XCTestCase {
                                    timestamp: Date(),
                                    historyType: .category,
                                    type: .address(subtypes: [.address]),
-                                   address: nil)
+                                   address: nil,
+                                   searchRequest: .init(query: "Sample", proximity: nil)
+        )
         XCTAssertNil(record.categories)
     }
     
@@ -26,7 +28,9 @@ class HistoryRecordTests: XCTestCase {
                                    timestamp: Date(),
                                    historyType: .category,
                                    type: .address(subtypes: [.address]),
-                                   address: nil)
+                                   address: nil,
+                                   searchRequest: .init(query: "Sample", proximity: nil)
+        )
         
         XCTAssertEqual(record.coordinate, .sample1)
         
@@ -44,7 +48,9 @@ class HistoryRecordTests: XCTestCase {
                                    timestamp: Date(),
                                    historyType: .category,
                                    type: .address(subtypes: [.address]),
-                                   address: .mapboxDCOffice)
+                                   address: .mapboxDCOffice,
+                                   searchRequest: .init(query: "Sample", proximity: nil)
+        )
         
         XCTAssertEqual(record.descriptionText, "740 15th St NW, Washington")
     }

--- a/Tests/MapboxSearchTests/Stubs&Models/SearchResultStub.swift
+++ b/Tests/MapboxSearchTests/Stubs&Models/SearchResultStub.swift
@@ -16,6 +16,7 @@ class SearchResultStub: SearchResult {
         coordinate: CLLocationCoordinate2DCodable,
         address: Address? = nil,
         metadata: SearchResultMetadata?,
+        searchRequest: SearchRequestOptions = .init(query: "Sample", proximity: nil),
         dataLayerIdentifier: String = "unit-test-stub"
     ) {
         self.id = id
@@ -31,6 +32,7 @@ class SearchResultStub: SearchResult {
         self.address = address
         self.metadata = metadata
         self.dataLayerIdentifier = dataLayerIdentifier
+        self.searchRequest = searchRequest
     }
     
     var dataLayerIdentifier: String
@@ -58,4 +60,5 @@ class SearchResultStub: SearchResult {
     var coordinateCodable: CLLocationCoordinate2DCodable
     var address: Address?
     var descriptionText: String?
+    var searchRequest: SearchRequestOptions
 }

--- a/Tests/MapboxSearchTests/Stubs&Models/TestDataProviderRecord.swift
+++ b/Tests/MapboxSearchTests/Stubs&Models/TestDataProviderRecord.swift
@@ -17,6 +17,7 @@ struct TestDataProviderRecord: IndexableRecord, SearchResult {
     var estimatedTime: Measurement<UnitDuration>?
     var metadata: SearchResultMetadata?
     var descriptionText: String?
+    var searchRequest: SearchRequestOptions = .init(query: "Sample", proximity: nil)
 
     static func testData(count: Int) -> [TestDataProviderRecord] {
         var results = [TestDataProviderRecord]()


### PR DESCRIPTION
Added `searchRequest` field to the `SearchResult` model in order to identify original search request.