### PR TITLE
[Core]: added option to initialize `SearchEngine` with SBS-support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ workflows:
 jobs:
   pre-check:
     macos:
-      xcode: 12.5.0
+      xcode: 13.4.0
     steps:
       - checkout
       - ios-install-carthage-dependencies
@@ -92,7 +92,7 @@ jobs:
 
   release-pre-check:
     macos:
-      xcode: 12.5.0
+      xcode: 13.4.0
     steps:
       - parse-release-version
       - run:
@@ -101,7 +101,7 @@ jobs:
 
   build:
     macos:
-      xcode: 12.5.0 # Specify the Xcode version to use
+      xcode: 13.4.0 # Specify the Xcode version to use
     environment:
       FL_OUTPUT_DIR: ../output
     steps:
@@ -139,7 +139,7 @@ jobs:
 
   release-documentation:
     macos:
-      xcode: 12.5.0
+      xcode: 13.4.0
     steps:
       - checkout
       - parse-release-version
@@ -160,7 +160,7 @@ jobs:
 
   documentation-pr:
     macos:
-      xcode: 12.5.0
+      xcode: 13.4.0
     steps:
       - checkout
       - parse-release-version
@@ -183,7 +183,7 @@ jobs:
 
   build-for-release:
     macos:
-      xcode: 12.5.0
+      xcode: 13.4.0
     steps:
       - checkout
       - setup-authentication
@@ -202,7 +202,7 @@ jobs:
 
   release-ios:
     macos:
-      xcode: 12.5.0
+      xcode: 13.4.0
     steps:
       - checkout
       - setup-authentication
@@ -226,7 +226,7 @@ jobs:
 
   post-SDK_Registry-release:
     macos:
-      xcode: 12.5.0
+      xcode: 13.4.0
     steps:
       - checkout
       - parse-release-version
@@ -247,7 +247,7 @@ jobs:
 
   spm-build:
     macos:
-      xcode: 12.5.0
+      xcode: 13.4.0
     steps:
       - checkout
       - setup-authentication

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Breaking changes
+- [CORE] Undocumented system property used to enable SBS API Type is deprecated. `com.mapbox.mapboxsearch.enableSBS`
+
 ### Added
 - [Core] `SearchResult.searchRequest` field exposed. Identifies original search request for a result.
+- [Core] `SearchEngine.init(supportSBS: Bool) added flag to initialize `SearchEngine` with SBS support.
 
 ### Fixed
 - [Core] Fixed warning related to `CLLocationManager` permissions check.

--- a/Sources/Demo/AppDelegate.swift
+++ b/Sources/Demo/AppDelegate.swift
@@ -12,9 +12,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             ServiceProvider.shared.localHistoryProvider.deleteAll()
             UserDefaults.resetStandardUserDefaults()
         }
-        
-        UserDefaults.standard.setValue(true, forKey: "com.mapbox.mapboxsearch.enableSBS")
-        
+
         if let customEndpoint = ProcessInfo.processInfo.environment["search_endpoint"] {
             UserDefaults.standard.setValue(customEndpoint, forKey: "MGLMapboxAPIBaseURL")
         } else {

--- a/Sources/MapboxSearch/PublicAPI/Engine/AbstractSearchEngine.swift
+++ b/Sources/MapboxSearch/PublicAPI/Engine/AbstractSearchEngine.swift
@@ -21,7 +21,7 @@ public class AbstractSearchEngine: FeedbackManagerDelegate {
     var locationProviderWrapper: WrapperLocationProvider?
     
     /// SearchEngine supports the latest Single-Box Search APIs
-    public internal(set) var supportSBS = UserDefaults.standard.bool(forKey: "com.mapbox.mapboxsearch.enableSBS")
+    public let supportSBS: Bool
     
     /// Location provider for search results `proximity` argument
     public let locationProvider: LocationProvider?
@@ -52,12 +52,15 @@ public class AbstractSearchEngine: FeedbackManagerDelegate {
     init(accessToken: String? = nil,
          serviceProvider: ServiceProviderProtocol & EngineProviderProtocol,
          locationProvider: LocationProvider? = DefaultLocationProvider(),
-         defaultSearchOptions: SearchOptions = SearchOptions()) {
+         defaultSearchOptions: SearchOptions = SearchOptions(),
+         supportSBS: Bool = false
+    ) {
         
         guard let accessToken = accessToken ?? serviceProvider.getStoredAccessToken() else {
             fatalError("No access token was found. Please, provide it in init(accessToken:) or in Info.plist at '\(accessTokenPlistKey)' key")
         }
         
+        self.supportSBS = supportSBS
         self.locationProvider = locationProvider
         self.locationProviderWrapper = WrapperLocationProvider(wrapping: locationProvider)
         self.eventsManager = serviceProvider.eventsManager

--- a/Sources/MapboxSearch/PublicAPI/Engine/AbstractSearchEngine.swift
+++ b/Sources/MapboxSearch/PublicAPI/Engine/AbstractSearchEngine.swift
@@ -49,6 +49,7 @@ public class AbstractSearchEngine: FeedbackManagerDelegate {
     ///   - accessToken: Mapbox Access Token to be used. Info.plist value for key `MGLMapboxAccessToken` will be used for `nil` argument
     ///   - locationProvider: Provider configuration of LocationProvider that would grant location data by default
     ///   - serviceProvider: Internal `ServiceProvider` for sharing common dependencies like favoritesService or eventsManager
+    ///   - supportSBS: enable support the latest Single-Box Search APIs
     init(accessToken: String? = nil,
          serviceProvider: ServiceProviderProtocol & EngineProviderProtocol,
          locationProvider: LocationProvider? = DefaultLocationProvider(),
@@ -94,10 +95,20 @@ public class AbstractSearchEngine: FeedbackManagerDelegate {
     ///   - accessToken: Mapbox Access Token to be used. Info.plist value for key `MGLMapboxAccessToken` will be used for `nil` argument
     ///   - locationProvider: Provider configuration of LocationProvider that would grant location data by default
     ///   - defaultSearchOptions: Default options to use when `nil` was passed to the `search(…: options:)` call
-    public convenience init(accessToken: String? = nil,
-                            locationProvider: LocationProvider? = DefaultLocationProvider(),
-                            defaultSearchOptions: SearchOptions = SearchOptions()) {
-        self.init(accessToken: accessToken, serviceProvider: ServiceProvider.shared, locationProvider: locationProvider, defaultSearchOptions: defaultSearchOptions)
+    ///   - supportSBS: enable support the latest Single-Box Search APIs
+    public convenience init(
+        accessToken: String? = nil,
+        locationProvider: LocationProvider? = DefaultLocationProvider(),
+        defaultSearchOptions: SearchOptions = SearchOptions(),
+        supportSBS: Bool = false
+    ) {
+        self.init(
+            accessToken: accessToken,
+            serviceProvider: ServiceProvider.shared,
+            locationProvider: locationProvider,
+            defaultSearchOptions: defaultSearchOptions,
+            supportSBS: supportSBS
+        )
     }
     
     /// Update existing Access Token on the fly

--- a/Tests/CI-dev.xctestplan
+++ b/Tests/CI-dev.xctestplan
@@ -19,9 +19,7 @@
       ]
     },
     "commandLineArgumentEntries" : [
-      {
-        "argument" : "-com.mapbox.mapboxsearch.enableSBS YES"
-      }
+
     ],
     "language" : "en",
     "region" : "US",

--- a/Tests/Demo.xctestplan
+++ b/Tests/Demo.xctestplan
@@ -22,9 +22,7 @@
       ]
     },
     "commandLineArgumentEntries" : [
-      {
-        "argument" : "-com.mapbox.mapboxsearch.enableSBS YES"
-      }
+
     ],
     "language" : "en",
     "region" : "US",
@@ -41,7 +39,7 @@
       ],
       "target" : {
         "containerPath" : "container:MapboxSearch.xcodeproj",
-        "identifier" : "F9C557272670C88E00BE8B94",
+        "identifier" : "F9C557382670CB0400BE8B94",
         "name" : "MapboxSearchIntegrationTests"
       }
     },

--- a/Tests/MapboxSearchIntegrationTests/CategorySearchEngineIntegrationTests.swift
+++ b/Tests/MapboxSearchIntegrationTests/CategorySearchEngineIntegrationTests.swift
@@ -4,7 +4,11 @@ import CoreLocation
 
 class CategorySearchEngineIntegrationTests: MockServerTestCase {
     
-    lazy var searchEngine = CategorySearchEngine(accessToken: "access-token", locationProvider: DefaultLocationProvider())
+    lazy var searchEngine = CategorySearchEngine(
+        accessToken: "access-token",
+        locationProvider: DefaultLocationProvider(),
+        supportSBS: true
+    )
     
     func testCategorySearch() throws {
         

--- a/Tests/MapboxSearchIntegrationTests/SearchEngineIntegrationTests.swift
+++ b/Tests/MapboxSearchIntegrationTests/SearchEngineIntegrationTests.swift
@@ -5,7 +5,11 @@ import CoreLocation
 class SearchEngineIntegrationTests: MockServerTestCase {
     
     let delegate = SearchEngineDelegateStub()
-    lazy var searchEngine = SearchEngine(accessToken: "access-token", locationProvider: DefaultLocationProvider())
+    lazy var searchEngine = SearchEngine(
+        accessToken: "access-token",
+        locationProvider: DefaultLocationProvider(),
+        supportSBS: true
+    )
     
     override func setUpWithError() throws {
         try super.setUpWithError()


### PR DESCRIPTION
- added option to initialize `SearchEngine` with SBS-support
- Updated Changelog
- Removed undocumented flag to enable SBS support