### PR TITLE
Japan search example

### DIFF
--- a/Examples/SearchExamples.xcodeproj/project.pbxproj
+++ b/Examples/SearchExamples.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		83BCC5B42891159F00CD4CB3 /* JapanSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83BCC5B32891159F00CD4CB3 /* JapanSearchViewController.swift */; };
 		FE00067F26FDCB9E00846819 /* Examples.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE00067E26FDCB9E00846819 /* Examples.swift */; };
 		FE0720BE26FC86C70065A273 /* MapboxSearch in Frameworks */ = {isa = PBXBuildFile; productRef = FE0720BD26FC86C70065A273 /* MapboxSearch */; };
 		FE0720C026FC86C70065A273 /* MapboxSearchUI in Frameworks */ = {isa = PBXBuildFile; productRef = FE0720BF26FC86C70065A273 /* MapboxSearchUI */; };
@@ -29,6 +30,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		83BCC5B32891159F00CD4CB3 /* JapanSearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JapanSearchViewController.swift; sourceTree = "<group>"; };
 		FE00067E26FDCB9E00846819 /* Examples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Examples.swift; sourceTree = "<group>"; };
 		FE114AA424C10B88001B2CE8 /* SearchExamples.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SearchExamples.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FE114AA724C10B88001B2CE8 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -92,6 +94,7 @@
 				FE114D9424C1C1E9001B2CE8 /* SimpleCategorySearchViewController.swift */,
 				FE114D8124C1A382001B2CE8 /* SimpleListSearchViewController.swift */,
 				FE5EC2F024C60F3C000DB978 /* SimpleUISearchViewController.swift */,
+				83BCC5B32891159F00CD4CB3 /* JapanSearchViewController.swift */,
 			);
 			path = SearchExamples;
 			sourceTree = "<group>";
@@ -238,6 +241,7 @@
 				FE114D8224C1A382001B2CE8 /* SimpleListSearchViewController.swift in Sources */,
 				FE849B5A26FCBCEC001CBC27 /* MapsViewController.swift in Sources */,
 				FE8295832701E46D001005B4 /* MapboxBoundingBoxController.swift in Sources */,
+				83BCC5B42891159F00CD4CB3 /* JapanSearchViewController.swift in Sources */,
 				FE114D9524C1C1E9001B2CE8 /* SimpleCategorySearchViewController.swift in Sources */,
 				FE114D9D24C1EBAD001B2CE8 /* ContinuousSearchViewController.swift in Sources */,
 				FE114D9B24C1E37D001B2CE8 /* MapboxMapsCategoryResultsViewController.swift in Sources */,

--- a/Examples/SearchExamples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/SearchExamples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,70 +1,68 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "Atlantis",
-        "repositoryURL": "https://github.com/ProxymanApp/atlantis",
-        "state": {
-          "branch": null,
-          "revision": "2ee37f1da01b438d67012cc1405617e158f358a1",
-          "version": "1.11.2"
-        }
-      },
-      {
-        "package": "MapboxCommon",
-        "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
-        "state": {
-          "branch": null,
-          "revision": "3dabe41278e9b88e3eb2851dd3967493d21f08af",
-          "version": "21.0.1"
-        }
-      },
-      {
-        "package": "MapboxCoreMaps",
-        "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
-        "state": {
-          "branch": null,
-          "revision": "a9955a309b7d17ce743bb9ea2eaf259540a2f64a",
-          "version": "10.2.0"
-        }
-      },
-      {
-        "package": "MapboxMobileEvents",
-        "repositoryURL": "https://github.com/mapbox/mapbox-events-ios.git",
-        "state": {
-          "branch": null,
-          "revision": "e29f48d9ed02b31ef51f9774a9c45f1d7c2c2b78",
-          "version": "1.0.6"
-        }
-      },
-      {
-        "package": "MapboxMaps",
-        "repositoryURL": "git@github.com:mapbox/mapbox-maps-ios.git",
-        "state": {
-          "branch": null,
-          "revision": "f8f4bb51777d2062b171018ac738c87d1ec94c7a",
-          "version": "10.2.0"
-        }
-      },
-      {
-        "package": "MapboxSearch",
-        "repositoryURL": "https://github.com/mapbox/search-ios",
-        "state": {
-          "branch": null,
-          "revision": "f909acc21a5fc17367a9bddd43056afff5fc5157",
-          "version": "1.0.0-beta.21"
-        }
-      },
-      {
-        "package": "Turf",
-        "repositoryURL": "https://github.com/mapbox/turf-swift.git",
-        "state": {
-          "branch": null,
-          "revision": "132aaf7f90fb3e334acd685ae7040a2b70b80d26",
-          "version": "2.1.0"
-        }
+  "pins" : [
+    {
+      "identity" : "atlantis",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ProxymanApp/atlantis",
+      "state" : {
+        "revision" : "2ee37f1da01b438d67012cc1405617e158f358a1",
+        "version" : "1.11.2"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "mapbox-common-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mapbox/mapbox-common-ios.git",
+      "state" : {
+        "revision" : "d9670cde1143ff3d3b3d840bfeb7413be2e2a9ae",
+        "version" : "22.0.0"
+      }
+    },
+    {
+      "identity" : "mapbox-core-maps-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mapbox/mapbox-core-maps-ios.git",
+      "state" : {
+        "revision" : "c03601b41843b6e035fd6bcbc3fa61cc45cf196c",
+        "version" : "10.6.1"
+      }
+    },
+    {
+      "identity" : "mapbox-events-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mapbox/mapbox-events-ios.git",
+      "state" : {
+        "revision" : "5e130fba637f5bbb0bb8bca0dec8d38a06ce07bf",
+        "version" : "1.0.8"
+      }
+    },
+    {
+      "identity" : "mapbox-maps-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "git@github.com:mapbox/mapbox-maps-ios.git",
+      "state" : {
+        "revision" : "afbd99975dca95dd762e62c725749840279bf927",
+        "version" : "10.6.1"
+      }
+    },
+    {
+      "identity" : "search-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mapbox/search-ios",
+      "state" : {
+        "revision" : "40bb1ffd8ada9d862f62f2e3dcdabea2fbb0c16e",
+        "version" : "1.0.0-beta.33"
+      }
+    },
+    {
+      "identity" : "turf-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mapbox/turf-swift.git",
+      "state" : {
+        "revision" : "569e0f0e96fda86e1a1dcefaefa68cfa9491ffc1",
+        "version" : "2.4.0"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Examples/SearchExamples/ExamplesTableViewController.swift
+++ b/Examples/SearchExamples/ExamplesTableViewController.swift
@@ -9,7 +9,8 @@ class ExamplesTableViewController: UITableViewController {
             Example(title: "Get query results", screenType: SimpleListSearchViewController.self),
             Example(title: "Search for category", screenType: SimpleCategorySearchViewController.self),
             Example(title: "Integrate SearchUI module", screenType: SimpleUISearchViewController.self),
-            Example(title: "Continuous Search", screenType: ContinuousSearchViewController.self)
+            Example(title: "Continuous Search", screenType: ContinuousSearchViewController.self),
+            Example(title: "Japanese Search", screenType: JapanSearchViewController.self)
         ]),
         ExampleSection(title: "Results on the Map", examples: [
             Example(title: "Category Results on MapboxMaps", screenType: MapboxMapsCategoryResultsViewController.self),

--- a/Examples/SearchExamples/JapanSearchViewController.swift
+++ b/Examples/SearchExamples/JapanSearchViewController.swift
@@ -1,0 +1,44 @@
+import UIKit
+import MapboxMaps
+import MapboxSearchUI
+
+class JapanSearchViewController: MapsViewController {
+    
+    lazy var searchController: MapboxSearchController = {
+        let locationProvider = PointLocationProvider(coordinate: .tokyo)
+        var configuration = Configuration(locationProvider: locationProvider)
+        let controller = MapboxSearchController(configuration: configuration)
+        
+        controller.searchEngine = SearchEngine(locationProvider:locationProvider, defaultSearchOptions:SearchOptions(countries:["jp"], languages: ["ja"]), supportSBS: true)
+        
+        return controller
+    }()
+    
+    lazy var panelController = MapboxPanelController(rootViewController: searchController)
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        mapView.mapboxMap.loadStyleURI(StyleURI(rawValue: "mapbox://styles/mapbox-search-web/cl5l944i6000k14o4ing22srv") ?? StyleURI.streets, completion: {_ in
+            let cameraOptions = CameraOptions(center: .tokyo, zoom: 15)
+            self.mapView.camera.fly(to: cameraOptions, duration: 1, completion: nil)
+        })
+        
+        searchController.delegate = self
+        addChild(panelController)
+    }
+}
+
+extension JapanSearchViewController: SearchControllerDelegate {
+    func categorySearchResultsReceived(category: SearchCategory, results: [SearchResult]) {
+        showAnnotations(results: results)
+    }
+    
+    func searchResultSelected(_ searchResult: SearchResult) {
+        showAnnotation(searchResult)
+    }
+    
+    func userFavoriteSelected(_ userFavorite: FavoriteRecord) {
+        showAnnotation(userFavorite)
+    }
+}

--- a/Examples/SearchExamples/MapsViewController.swift
+++ b/Examples/SearchExamples/MapsViewController.swift
@@ -70,4 +70,6 @@ extension PointAnnotation {
 
 extension CLLocationCoordinate2D {
     static let sanFrancisco = CLLocationCoordinate2D(latitude: 37.7911551, longitude: -122.3966103)
+    
+    static let tokyo = CLLocationCoordinate2D(latitude: 35.7101, longitude: 139.8107)
 }


### PR DESCRIPTION
### Description
Now that SBS can be enabled at runtime when creating a searchEngine, it's easy to add an extra example showing how to use the new Japan search API. I'm not very familiar with this repo (or Mapbox Swift style), but I took a stab at creating a basic example that's similar to the SimpleUISearch example, with the following differences:

- Uses SBS
- Language set to "ja" and country set to "jp"
- Set location to Tokyo and use a Japanese-language map style

Note that Japanese search supports "romaji" (latinized Japanese) input, so that even if the person using the example doesn't have a Japanese keyboard installed, just typing thing like "Tokyo" or "Osaka" should give reasonable results.

![Japan Search Example](https://user-images.githubusercontent.com/375121/181194625-bb690614-878a-4952-b6ac-52f2de86de50.gif)


### Checklist
- [ ] Update `CHANGELOG`

cc @kalbaxa @ehaubert 
