### PR TITLE
[Tech]: migrate to latest `CoreSearch` version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Breaking changes
+- [CORE] `SearchEngine.setAccessToken(_: String)` has been removed.
+
 ## [1.0.0-beta.33] - 2022-07-20
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Guide: https://keepachangelog.com/en/1.0.0/
 ### Breaking changes
 - [CORE] `SearchEngine.setAccessToken(_: String)` has been removed.
 
+
+### Fixed
+- [UI]: fixed UIViewController presentation on SDK side. [#7 ](https://github.com/mapbox/mapbox-search-ios/issues/7)
+
 ## [1.0.0-beta.33] - 2022-07-20
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ Guide: https://keepachangelog.com/en/1.0.0/
 ## [Unreleased]
 
 ### Breaking changes
-- [CORE] `SearchEngine.setAccessToken(_: String)` has been removed.
+- [CORE]: `SearchEngine.setAccessToken(_: String)` has been removed.
 
+### Added
+- [CORE]: SearchResultType provides a new value - `block` which represents the block number. Available specifically for Japan.
 
 ### Fixed
 - [UI]: fixed UIViewController presentation on SDK side. [#7 ](https://github.com/mapbox/mapbox-search-ios/issues/7)

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 0.57.0
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 22.0.0
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 0.58.0
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 23.0.0-beta.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "22.0.0"
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "0.57.0"
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "23.0.0-beta.1"
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "0.58.0"

--- a/MapboxSearch.xcodeproj/project.pbxproj
+++ b/MapboxSearch.xcodeproj/project.pbxproj
@@ -1660,7 +1660,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1250;
-				LastUpgradeCheck = 1310;
+				LastUpgradeCheck = 1340;
 				ORGANIZATIONNAME = Mapbox;
 				TargetAttributes = {
 					3A0D7E4B233522D4006D81BB = {
@@ -2489,7 +2489,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_SWIFT_FLAGS = "-D DEBUG -D DISABLE_SSL_PINNING -D FAST_LOCATION_CHANGES_TRACKING";
 				SDKROOT = iphoneos;
@@ -2549,7 +2549,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_SWIFT_FLAGS = "-D DISABLE_SSL_PINNING";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -2572,7 +2572,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/MapboxSearch/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2601,7 +2601,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/MapboxSearch/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2669,7 +2669,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				INFOPLIST_FILE = Tests/MapboxSearchUITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2693,7 +2693,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				INFOPLIST_FILE = Tests/MapboxSearchUITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2762,7 +2762,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Demo/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2787,7 +2787,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Demo/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2858,7 +2858,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/MapboxSearchUI/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2893,7 +2893,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/MapboxSearchUI/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/MapboxSearch.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
+++ b/MapboxSearch.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1340"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MapboxSearch.xcodeproj/xcshareddata/xcschemes/MapboxSearch.xcscheme
+++ b/MapboxSearch.xcodeproj/xcshareddata/xcschemes/MapboxSearch.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MapboxSearch.xcodeproj/xcshareddata/xcschemes/MapboxSearchTests.xcscheme
+++ b/MapboxSearch.xcodeproj/xcshareddata/xcschemes/MapboxSearchTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MapboxSearch.xcodeproj/xcshareddata/xcschemes/MapboxSearchUI.xcscheme
+++ b/MapboxSearch.xcodeproj/xcshareddata/xcschemes/MapboxSearchUI.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MapboxSearch.xcodeproj/xcshareddata/xcschemes/MapboxSearchUIResources.xcscheme
+++ b/MapboxSearch.xcodeproj/xcshareddata/xcschemes/MapboxSearchUIResources.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
-          "revision": "d9670cde1143ff3d3b3d840bfeb7413be2e2a9ae",
-          "version": "22.0.0"
+          "revision": "c9e536d608d9fa1b84e7abbce37d283d06c8c00f",
+          "version": "23.0.0-beta.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 import Foundation
 
 let registry = SDKRegistry()
-let (coreSearchVersion, coreSearchVersionHash) = ("0.57.0", "404cf6abaa6856705017c06cc2915774c139ac849c7e82aa43428b5ee6b4c5e4")
+let (coreSearchVersion, coreSearchVersionHash) = ("0.58.0", "bfb8313e59573cbf94767f56b8857d4305c49b9c01593ad144a9d4e934864e60")
 
 let package = Package(
     name: "MapboxSearch",
@@ -23,7 +23,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", .exact("22.0.0")),
+        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", .exact("23.0.0-beta.1")),
         .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", from: "2.0.0")
     ],
     targets: [

--- a/Sources/MapboxSearch/InternalAPI/CoreResultType+Extensions.swift
+++ b/Sources/MapboxSearch/InternalAPI/CoreResultType+Extensions.swift
@@ -16,6 +16,7 @@ extension CoreResultType {
         case .locality: return "locality"
         case .userRecord: return "userRecord"
         case .neighborhood: return "neighborhood"
+        case .block: return "block"
         case .unknown:  fallthrough
         @unknown default:
             return "unknown"
@@ -31,7 +32,8 @@ extension CoreResultType {
         .region,
         .district,
         .locality,
-        .neighborhood
+        .neighborhood,
+        .block
     ]
     
     /// Validate that all input types are specific address subtypes (like country, district or concrete address)

--- a/Sources/MapboxSearch/InternalAPI/CoreSearchEngineProtocol.swift
+++ b/Sources/MapboxSearch/InternalAPI/CoreSearchEngineProtocol.swift
@@ -3,12 +3,6 @@ import CoreLocation
 
 protocol CoreSearchEngineProtocol {
     /**
-     @brief Set Mapbox access token.
-     Call this function in case of token's changing at runtime.
-     */
-    func setAccessTokenForToken(_ token: String) throws
-
-    /**
      -------------------------------------------------------------------------------------------
      @brief Create user data layer.
      @param[in] layer     Unique layer name.

--- a/Sources/MapboxSearch/PublicAPI/Common/Models/Address/SearchAddressType.swift
+++ b/Sources/MapboxSearch/PublicAPI/Common/Models/Address/SearchAddressType.swift
@@ -36,6 +36,10 @@ public enum SearchAddressType: String, Hashable, Codable {
     /// Unlike locality features, these typically lack official status and may lack universally agreed-upon boundaries.
     case neighborhood
     
+    /// The block number. Available specifically for Japan.
+    case block
+    
+    // swiftlint:disable:next cyclomatic_complexity
     init?(_ core: CoreResultType) {
         switch core {
         case .address:
@@ -64,6 +68,9 @@ public enum SearchAddressType: String, Hashable, Codable {
 
         case .neighborhood:
             self = .neighborhood
+            
+        case .block:
+            self = .block
 
         case .unknown, .category, .userRecord, .query, .poi:
             fallthrough

--- a/Sources/MapboxSearch/PublicAPI/Engine/AbstractSearchEngine.swift
+++ b/Sources/MapboxSearch/PublicAPI/Engine/AbstractSearchEngine.swift
@@ -111,19 +111,6 @@ public class AbstractSearchEngine: FeedbackManagerDelegate {
         )
     }
     
-    /// Update existing Access Token on the fly
-    /// - Parameter token: New valid Mapbox access token
-    /// - Throws: `NSError` if operation was failed
-    public func setAccessToken(_ token: String) throws {
-        do {
-            try engine.setAccessTokenForToken(token)
-        } catch {
-            _Logger.searchSDK.error("Failed to call \(#function) due to error: \(error)")
-            eventsManager.reportError(error)
-            throw error
-        }
-    }
-    
     /// Register indexable data provider to provide custom data layer for SearchEngine
     /// - Parameters:
     ///   - dataProvider: IndexableDataProvider to register

--- a/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
+++ b/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
@@ -1,2 +1,2 @@
 /// Mapbox Search SDK version variable
-public let mapboxSearchSDKVersion = "1.0.0-beta.32"
+public let mapboxSearchSDKVersion = "1.0.0-beta.33"

--- a/Sources/MapboxSearchUI/UIApplication+Extensions.swift
+++ b/Sources/MapboxSearchUI/UIApplication+Extensions.swift
@@ -6,7 +6,7 @@ extension UIApplication {
     static var topPresentedViewController: UIViewController? {
         let keyWindow: UIWindow?
         if #available(iOS 13, *) {
-            keyWindow = UIApplication.shared.windows.filter { $0.isKeyWindow }.first
+            keyWindow = UIApplication.shared.windows.first(where: { $0.isKeyWindow })
         } else {
             keyWindow = UIApplication.shared.keyWindow
         }

--- a/Tests/MapboxSearchTests/Legacy/SearchEngineTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/SearchEngineTests.swift
@@ -412,12 +412,4 @@ class SearchEngineTests: XCTestCase {
         searchEngine.query = "random-query"
         XCTAssertEqual(searchEngine.query, "random-query")
     }
-    
-    func testAccessTokenUpdate() throws {
-        let searchEngine = SearchEngine(accessToken: "mapbox-access-token", serviceProvider: provider, locationProvider: DefaultLocationProvider())
-        XCTAssertEqual(provider.latestCoreEngine.accessToken, "mapbox-access-token")
-        
-        try searchEngine.setAccessToken("updated-token")
-        XCTAssertEqual(provider.latestCoreEngine.accessToken, "updated-token")
-    }
 }


### PR DESCRIPTION
- Exposed `AddressType.block` field. 
- Removed `SearchEngine.setAccessToken(_: String)` method
- Updated Changelog
