### PR TITLE
[Bugfix]: update retrieve suggestion response processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Fixed
+- [Core]: fixed an issue related to suggestion resolving, when the request was failed in case `searchEngine.query` is changed during resolving.
+
 ## [1.0.0-beta.36] - 2022-09-22
 
 ### Updated

--- a/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
+++ b/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
@@ -1,2 +1,2 @@
 /// Mapbox Search SDK version variable
-public let mapboxSearchSDKVersion = "1.0.0-beta.35"
+public let mapboxSearchSDKVersion = "1.0.0-beta.36"

--- a/Tests/MapboxSearchIntegrationTests/SearchEngineIntegrationTests.swift
+++ b/Tests/MapboxSearchIntegrationTests/SearchEngineIntegrationTests.swift
@@ -134,6 +134,28 @@ class SearchEngineIntegrationTests: MockServerTestCase {
         XCTAssertEqual(resolvedResult.name, selectedResult.name)
     }
     
+    func testResolvedSearchResultWhenQueryChanged() throws {
+        try server.setResponse(.suggestMinsk)
+        try server.setResponse(.retrieveMinsk)
+        
+        searchEngine.search(query: "Mapbox")
+        
+        let updateExpectation = delegate.updateExpectation
+        wait(for: [updateExpectation], timeout: 10)
+        
+        XCTAssertFalse(searchEngine.suggestions.isEmpty)
+        let selectedResult = searchEngine.suggestions.first!
+        
+        searchEngine.search(query: "Mapbo")
+        searchEngine.select(suggestion: selectedResult)
+        
+        let successExpectation = delegate.successExpectation
+        wait(for: [successExpectation], timeout: 10)
+        
+        let resolvedResult = try XCTUnwrap(delegate.resolvedResult)
+        XCTAssertEqual(resolvedResult.name, selectedResult.name)
+    }
+    
     func testResolvedSearchResultFailed() throws {
         
         try server.setResponse(.suggestMinsk)


### PR DESCRIPTION
Previously, when search response received, there was a check for current query and suggestion query.
While the check is fair for suggestions list in order to skip outdated responses, this check should not be applied to retrieve result flow.

- Updated retrieve suggestion logic and added a separate response processing flow;
- Added integration tests to cover broken scenario;
