### PR TITLE
[AddressAutofill]: API updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Guide: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 - [Core]: fixed an issue related to suggestion resolving, when the request was failed in case `searchEngine.query` is changed during resolving.
 - [UI]: fixed `hospital` category icon.
+- [Autofill] `AddressAutofill` now returns up to 10 suggestions.
 
 ## [1.0.0-beta.36] - 2022-09-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ Guide: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 - [Core]: fixed an issue related to suggestion resolving, when the request was failed in case `searchEngine.query` is changed during resolving.
 - [UI]: fixed `hospital` category icon.
-- [Autofill] `AddressAutofill` now returns up to 10 suggestions.
+
+- [Autofill]: `AddressAutofill` now returns up to 10 suggestions.
+- [Autofill]: Now it is possible to provide custom implementation of `LocationProvider`.
 
 ## [1.0.0-beta.36] - 2022-09-22
 

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Address Autofill/AddressAutofill.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Address Autofill/AddressAutofill.swift
@@ -67,7 +67,6 @@ public extension AddressAutofill {
     func suggestions(for coordinate: CLLocationCoordinate2D, with options: Options? = nil, completion: @escaping (Swift.Result<[Suggestion], Error>) -> Void) {
         let searchOptions = ReverseGeocodingOptions(
             point: coordinate,
-            limit: Constants.defaultSuggestionsLimit,
             types: acceptedTypes,
             countries: options?.countries.map { $0.countryCode },
             languages: options.map { [$0.language.languageCode] }

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Address Autofill/AddressAutofill.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Address Autofill/AddressAutofill.swift
@@ -42,6 +42,7 @@ public extension AddressAutofill {
         let searchOptions = SearchOptions(
             countries: options?.countries.map { $0.countryCode },
             languages: options.map { [$0.language.languageCode] },
+            limit: 10,
             filterTypes: acceptedTypes,
             ignoreIndexableRecords: true
         ).toCore(apiType: Self.apiType)

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Address Autofill/AddressAutofill.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Address Autofill/AddressAutofill.swift
@@ -3,6 +3,12 @@
 import Foundation
 import CoreLocation
 
+private extension AddressAutofill {
+    enum Constants {
+        static let defaultSuggestionsLimit = 10
+    }
+}
+
 public final class AddressAutofill {
     private let searchEngine: CoreSearchEngineProtocol
     
@@ -13,7 +19,11 @@ public final class AddressAutofill {
     /// Basic internal initializer
     /// - Parameters:
     ///   - accessToken: Mapbox Access Token to be used. Info.plist value for key `MGLMapboxAccessToken` will be used for `nil` argument
-    public convenience init(accessToken: String? = nil) {
+    ///   - locationProvider: Provider configuration of LocationProvider that would grant location data by default
+    public convenience init(
+        accessToken: String? = nil,
+        locationProvider: LocationProvider? = DefaultLocationProvider()
+    ) {
         guard let accessToken = accessToken ?? ServiceProvider.shared.getStoredAccessToken() else {
             fatalError("No access token was found. Please, provide it in init(accessToken:) or in Info.plist at '\(accessTokenPlistKey)' key")
         }
@@ -21,7 +31,7 @@ public final class AddressAutofill {
         let searchEngine = ServiceProvider.shared.createEngine(
             apiType: Self.apiType,
             accessToken: accessToken,
-            locationProvider: WrapperLocationProvider(wrapping: DefaultLocationProvider())
+            locationProvider: WrapperLocationProvider(wrapping: locationProvider)
         )
         
         self.init(searchEngine: searchEngine)
@@ -42,7 +52,7 @@ public extension AddressAutofill {
         let searchOptions = SearchOptions(
             countries: options?.countries.map { $0.countryCode },
             languages: options.map { [$0.language.languageCode] },
-            limit: 10,
+            limit: Constants.defaultSuggestionsLimit,
             filterTypes: acceptedTypes,
             ignoreIndexableRecords: true
         ).toCore(apiType: Self.apiType)
@@ -57,6 +67,7 @@ public extension AddressAutofill {
     func suggestions(for coordinate: CLLocationCoordinate2D, with options: Options? = nil, completion: @escaping (Swift.Result<[Suggestion], Error>) -> Void) {
         let searchOptions = ReverseGeocodingOptions(
             point: coordinate,
+            limit: Constants.defaultSuggestionsLimit,
             types: acceptedTypes,
             countries: options?.countries.map { $0.countryCode },
             languages: options.map { [$0.language.languageCode] }


### PR DESCRIPTION
- increased default number of suggestions up to 10;
- added parameter to provide custom `LocationProvider` implementation during `AdressAutofill` initialization
