### PR TITLE
Tech: added `locale` support for the language search options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Guide: https://keepachangelog.com/en/1.0.0/
 - [Autofill]: added example to the Demo project
 
 - [Common]: added support to initialize `Language` with the `locale` object.
+- [Common]: added support to pass `Locale` object to the `SearchOptions`. Language code will be used for a search request if present.
 
 ## [1.0.0-beta.37] - 2022-10-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Fixed
+- Fixed the issue when `defaultSearchOptions` were ignored for the `CategorySearchEngine`.
+
 ### Updated
 - [Autofill]: `name` field exposed for the `AddressAutofill.Suggestion`.
 - [Autofill]: exposed query requirements constant in `AddressAutofill.Query.Requirements`.
 - [Autofill]: added example to the Demo project
+
+- [Common]: added support to initialize `Language` with the `locale` object.
 
 ## [1.0.0-beta.37] - 2022-10-14
 

--- a/Sources/MapboxSearch/PublicAPI/Common/Models/Language/Language.swift
+++ b/Sources/MapboxSearch/PublicAPI/Common/Models/Language/Language.swift
@@ -5,10 +5,20 @@ import Foundation
 public struct Language: Equatable {
     public let languageCode: String
     
-    /// Country model initializier
+    /// Language model initializier
     /// - Parameter languageCode: Permitted values are ISO 639-1 language codes
     public init?(languageCode: String) {
         guard let isoCode = ISO639_1(rawValue: languageCode.lowercased()) else {
+            return nil
+        }
+        
+        self.languageCode = isoCode.rawValue
+    }
+    
+    /// Language model initializier
+    /// - Parameter locale: only `languageCode` component is used if exist.
+    public init?(locale: Locale) {
+        guard let isoCode = locale.languageCode.flatMap(ISO639_1.init(rawValue:)) else {
             return nil
         }
         

--- a/Sources/MapboxSearch/PublicAPI/Engine/CategorySearchEngine.swift
+++ b/Sources/MapboxSearch/PublicAPI/Engine/CategorySearchEngine.swift
@@ -11,7 +11,7 @@ public class CategorySearchEngine: AbstractSearchEngine {
     ///   - completionQueue: DispatchQueue.main is default
     ///   - completion: completion closure
     public func search(categoryName: String, options: SearchOptions? = nil, completionQueue: DispatchQueue = .main, completion: @escaping (Result<[SearchResult], SearchError>) -> Void) {
-        let options = options?.merged(defaultSearchOptions) ?? SearchOptions()
+        let options = options?.merged(defaultSearchOptions) ?? defaultSearchOptions
         engine.search(forQuery: "", categories: [categoryName], options: options.toCore(apiType: engineApi)) { [weak self, weak eventsManager] coreResponse in
             guard let self = self, let coreResponse = coreResponse else {
                 let error = SearchError.categorySearchRequestFailed(reason: SearchError.responseProcessingFailed)

--- a/Sources/MapboxSearch/PublicAPI/SearchOptions.swift
+++ b/Sources/MapboxSearch/PublicAPI/SearchOptions.swift
@@ -62,6 +62,18 @@ public struct SearchOptions {
     /// - Attention: May break engine entity functionality. Do not use without SDK developers agreement
     public var unsafeParameters: [String: String]?
     
+    /**
+     The locale in which results should be returned.
+     
+     This property affects the language of returned results; generally speaking, it does not determine which results are found.
+     Components other than the language code, such as the country and script codes, are ignored.
+     
+     If `locale` option is set, `languages` option will be ignored.
+     
+     By default, this property is set to `nil`, causing results to be in the default language.
+    */
+    public var locale: Locale?
+    
     /// Search request options constructor
     /// - Parameter countries: Limit results to one or more countries. Permitted values are ISO 3166 alpha 2 country codes (e.g. US, DE, GB)
     /// - Parameter languages: List of  language codes which used to provide localized results, order matters. Locale.preferredLanguages used as default or ["en"] if none.
@@ -186,6 +198,13 @@ public struct SearchOptions {
     }
     
     func toCore() -> CoreSearchOptions {
+        let searchLanguages: [String]
+        if let localeLanguageCode = locale?.languageCode {
+            searchLanguages = [localeLanguageCode]
+        } else {
+            searchLanguages = languages
+        }
+        
         return CoreSearchOptions(proximity: proximity.flatMap({ CLLocation(latitude: $0.latitude, longitude: $0.longitude) }),
                                  origin: origin.flatMap({ CLLocation(latitude: $0.latitude, longitude: $0.longitude) }),
                                  navProfile: navigationOptions?.profile.string,
@@ -193,7 +212,7 @@ public struct SearchOptions {
                                  bbox: boundingBox.map(CoreBoundingBox.init),
                                  countries: countries,
                                  fuzzyMatch: fuzzyMatch.map(NSNumber.init),
-                                 language: languages,
+                                 language: searchLanguages,
                                  limit: limit.map(NSNumber.init),
                                  types: filterTypes.map { $0.map { NSNumber(value: $0.coreValue.rawValue) } },
                                  ignoreUR: ignoreIndexableRecords,

--- a/Tests/MapboxSearchTests/Common/Models/Language+Tests.swift
+++ b/Tests/MapboxSearchTests/Common/Models/Language+Tests.swift
@@ -20,4 +20,19 @@ final class LanguageTests: XCTestCase {
 
         XCTAssertNil(invalidIdentifier)
     }
+    
+    func testThatLanguageCanBeInitializedFromLocale() {
+        [
+            Locale(identifier: "en-US"),
+            Locale(identifier: "en"),
+            Locale(identifier: "en-UK")
+        ].forEach { locale in
+            XCTAssertNotNil(locale)
+            
+            let language = Language(locale: locale)
+
+            XCTAssertNotNil(language)
+            XCTAssertEqual(language?.languageCode, locale.languageCode)
+        }
+    }
 }

--- a/Tests/MapboxSearchTests/Legacy/SearchOptionsTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/SearchOptionsTests.swift
@@ -147,6 +147,18 @@ class SearchOptionsTests: XCTestCase {
         XCTAssertEqual(fromCoreSearchOptions.indexableRecordsDistanceThreshold, searchOptions.indexableRecordsDistanceThreshold)
     }
     
+    func testSearchOptionsUsesLocale() {
+        var searchOptions = SearchOptions()
+        searchOptions.languages = ["en", "es"]
+        
+        var coreOptions = searchOptions.toCore()
+        XCTAssertEqual(coreOptions.language, ["en", "es"])
+        
+        searchOptions.locale = Locale(identifier: "fr-US")
+        coreOptions = searchOptions.toCore()
+        XCTAssertEqual(coreOptions.language, ["fr"])
+    }
+    
     func testSearchOptionsEmptyInit() {
         let searchOptions = SearchOptions()
         


### PR DESCRIPTION
- added support to initialize `Language` with the `locale` object.
- added support to pass `Locale` object to the `SearchOptions`. Language code will be used for a search request if present.

