### PR TITLE
Release: v.1.0.0 beta.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+## [1.0.0-beta.38] - 2022-10-26
+
 ### Fixed
 - Fixed the issue when `defaultSearchOptions` were ignored for the `CategorySearchEngine`.
 
@@ -14,7 +16,7 @@ Guide: https://keepachangelog.com/en/1.0.0/
 - [Autofill]: exposed query requirements constant in `AddressAutofill.Query.Requirements`.
 - [Autofill]: added example to the Demo project
 
-- [Common]: added support to initialize `Language` with the `locale` object.
+- [Common]: added support to initialize `Language` with the `Locale` object.
 - [Common]: added support to pass `Locale` object to the `SearchOptions`. Language code will be used for a search request if present.
 
 ## [1.0.0-beta.37] - 2022-10-14

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == "0.61.0"
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == "23.1.0-rc.1"
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 0.62.0
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 23.1.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "23.1.0-rc.1"
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "0.61.0"
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "23.1.0"
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "0.62.0"

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearch'
-  s.version          = '1.0.0-beta.37'
+  s.version          = '1.0.0-beta.38'
   s.summary          = 'Search SDK for Mapbox Search API '
 
 # This description is used to generate tags and improve search results.
@@ -24,6 +24,6 @@ Some iOS platform specifics applies.
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency "MapboxCommon", "23.1.0-rc.1"
+  s.dependency "MapboxCommon", "23.1.0"
 
 end

--- a/MapboxSearchUI.podspec
+++ b/MapboxSearchUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearchUI'
-  s.version          = '1.0.0-beta.37'
+  s.version          = '1.0.0-beta.38'
   s.summary          = 'Search UI for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.
@@ -23,5 +23,5 @@ Card style custom UI with full search functionality powered by Mapbox Search API
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency 'MapboxSearch', "1.0.0-beta.37"
+  s.dependency 'MapboxSearch', "1.0.0-beta.38"
 end

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
-          "revision": "c727e7bf94cd6c0e382884ab3fbea79de488a866",
-          "version": "23.1.0-rc.1"
+          "revision": "dbb2e33e29ba3bb75b9f63673504a5847c8c6e24",
+          "version": "23.1.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 import Foundation
 
 let registry = SDKRegistry()
-let (coreSearchVersion, coreSearchVersionHash) = ("0.61.0", "ae5275ba89cb9b21def1659b3243464cf34d04a54b94300e39a579861e282f0d")
+let (coreSearchVersion, coreSearchVersionHash) = ("0.62.0", "4ef5dcd4f9f8680539cccea0f410f5e04b272c6966cc99537f195b1bfafec15b")
 
 let package = Package(
     name: "MapboxSearch",
@@ -23,7 +23,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", .exact("23.1.0-rc.1")),
+        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", .exact("23.1.0")),
         .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", from: "2.0.0")
     ],
     targets: [


### PR DESCRIPTION
Updated specs and manifest files for the `beta.38` release.

