### PR TITLE
[UI]: don't show distance for `userRecords` suggestions if `navProfile` is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Fixed
+- [UI]: fixed the issue with incorrect distance for the suggestions from `History/Favorites`.
+
 ## [1.0.0-beta.38] - 2022-10-26
 
 ### Fixed

--- a/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
+++ b/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
@@ -1,2 +1,2 @@
 /// Mapbox Search SDK version variable
-public let mapboxSearchSDKVersion = "1.0.0-beta.37"
+public let mapboxSearchSDKVersion = "1.0.0-beta.38"

--- a/Sources/MapboxSearch/PublicAPI/Search Results/ExternalRecordPlaceholder.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/ExternalRecordPlaceholder.swift
@@ -33,10 +33,18 @@ class ExternalRecordPlaceholder: SearchResultSuggestion, CoreResponseProvider {
         self.name = coreResult.names[0]
         self.address = coreResult.addresses?.first.map(Address.init)
         self.dataLayerIdentifier = layerIdentifier
-        self.distance = coreResult.distanceToProximity
         self.originalResponse = CoreSearchResultResponse(coreResult: coreResult, response: response)
         self.categories = coreResult.categories
         self.serverIndex = coreResult.serverIndex?.intValue
+        
+        /*
+            It is not possible to calculate distance correctly for userRecords suggestions in case if navProfile is specified.
+        */
+        if response.request.options.navProfile != nil {
+            self.distance = nil
+        } else {
+            self.distance = coreResult.distanceToProximity
+        }
         
         self.descriptionText = coreResult.addresses?.first.map(Address.init)?.formattedAddress(style: .medium)
         self.batchResolveSupported = coreResult.action?.isMultiRetrievable ?? false


### PR DESCRIPTION
Search SDK won't return distance field for the suggestions from `userRecords` in case if `navProfile` is set in `searchOptions`.