### PR TITLE
Added version range support for `MapboxCommon`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+- [Tech]: added version range support for `MapboxCommon` dependency in `SPM`/`Cocoapods`.
+
 ## [1.0.0-beta.39] - 2022-11-14
 
 - [Common]: fixed errors related to Xcode 14, updated unit tests and removed dead code.

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -24,6 +24,6 @@ Some iOS platform specifics applies.
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency "MapboxCommon", "23.2.0-beta.1"
+  s.dependency "MapboxCommon", '<= 24.0.0-rc.3'
 
 end

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
-          "revision": "3f170b36659c6e499a6b2079f661a76ce7596b08",
-          "version": "23.2.0-beta.1"
+          "revision": "9c387749d705972ffadb5ed60376cc3688f9d61b",
+          "version": "23.2.0-rc.3"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,9 @@ import PackageDescription
 import Foundation
 
 let (coreSearchVersion, coreSearchVersionHash) = ("0.63.0", "9cc9b254d093f1b04354ee9ea706c99a41d4a822aa4f8dd8751d5740644e7427")
-let commonVersion = Version("23.2.0-beta.1")
+
+let commonMinVersion = Version(23, 1, 0, prereleaseIdentifiers: ["1"])
+let commonMaxVersion = Version("24.0.0")
 
 let package = Package(
     name: "MapboxSearch",
@@ -23,7 +25,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", .exact(commonVersion)),
+        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", commonMinVersion..<commonMaxVersion),
         .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", from: "2.0.0")
     ],
     targets: [

--- a/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
+++ b/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
@@ -1,2 +1,2 @@
 /// Mapbox Search SDK version variable
-public let mapboxSearchSDKVersion = "1.0.0-beta.38"
+public let mapboxSearchSDKVersion = "1.0.0-beta.39"


### PR DESCRIPTION
- unpinned `MapboxCommon` in `SPM` and use version range instead;
- unpinned `MapboxCommon` in `Cocoapods` and use version range instead.
