### PR TITLE
Tech: release workflow updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,11 +238,7 @@ jobs:
           name: Push podspecs to CocoaPods CDN Trunk
           command: |
             pod trunk push MapboxSearch.podspec
-            md5 -s MapboxSearch
-            pod search MapboxSearchUI --no-pager
-            cat ~/.cocoapods/repos/trunk/all_pods_versions_6_6_f.txt
-            sed -i '' -E "s/(MapboxSearch.*)/\1\/${VERSION}/g" ~/.cocoapods/repos/trunk/all_pods_versions_6_6_f.txt
-            pod trunk push MapboxSearchUI.podspec
+            pod trunk push MapboxSearchUI.podspec --synchronous
       - run: brew install gh taiki-e/tap/parse-changelog
       - run: scripts/release_notes.sh
 

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -24,6 +24,5 @@ Some iOS platform specifics applies.
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency "MapboxCommon", '<= 24.0.0-rc.3'
-
+  s.dependency "MapboxCommon", '~> 24.0'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import Foundation
 
 let (coreSearchVersion, coreSearchVersionHash) = ("0.63.0", "9cc9b254d093f1b04354ee9ea706c99a41d4a822aa4f8dd8751d5740644e7427")
 
-let commonMinVersion = Version(23, 1, 0, prereleaseIdentifiers: ["1"])
+let commonMinVersion = Version("23.0.0")
 let commonMaxVersion = Version("24.0.0")
 
 let package = Package(


### PR DESCRIPTION
- use `--synchronous` when uploading Cocoapods specs to CDN;
- use stable version of `MapboxCommon` in SPM and Cocoapods.
