### PR TITLE
update license text and copyright year of docs builder script

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -3,13 +3,10 @@
 Mapbox Search for iOS version 1.0
 Mapbox Search iOS SDK
 
-Copyright © 2021 Mapbox
+Copyright © 2021 - 2023 Mapbox, Inc. All rights reserved.
 
-All rights reserved.
+The software and files in this repository (collectively, "Software") are licensed under the Mapbox TOS for use only with the relevant Mapbox product(s) listed at www.mapbox.com/pricing. This license allows developers with a current active Mapbox account to use and modify the authorized portions of the Software as needed for use only with the relevant Mapbox product(s) through their Mapbox account in accordance with the Mapbox TOS.  This license terminates automatically if a developer no longer has a Mapbox account in good standing or breaches the Mapbox TOS. For the license terms, please see the Mapbox TOS at https://www.mapbox.com/legal/tos/ which incorporates the Mapbox Product Terms at www.mapbox.com/legal/service-terms.  If this Software is a SDK, modifications that change or interfere with marked portions of the code related to billing, accounting, or data collection are not authorized and the SDK sends limited de-identified location and usage data which is used in accordance with the Mapbox TOS. [Updated 2023-01]
 
-Mapbox Search for iOS version 1.0 (“Mapbox Search iOS SDK”) or higher must be used according to the Mapbox Terms of Service. This license allows developers with a current active Mapbox account to use and modify the Mapbox Search iOS SDK. Developers may modify the Mapbox Search iOS SDK code so long as the modifications do not change or interfere with marked portions of the code related to billing, accounting, and anonymized data collection. The Mapbox Search iOS SDK sends anonymized location and usage data, which Mapbox uses for fixing bugs and errors, accounting, and generating aggregated anonymized statistics. This license terminates automatically if a user no longer has an active Mapbox account.
-
-For the full license terms, please see the Mapbox Terms of Service at https://www.mapbox.com/legal/tos/
 ## Acknowledgements
 This application makes use of the following third party libraries:
 

--- a/scripts/generate_docs.sh
+++ b/scripts/generate_docs.sh
@@ -3,9 +3,8 @@ set -euo pipefail
 
 AUTHOR="Mapbox"
 AUTHOR_URL="https://mapbox.com"
-COPYRIGHT_TEXT="Copyright © 2020 Mapbox, Inc. You may use this code with your Mapbox account and under the Mapbox Terms of Service (available at: https://www.mapbox.com/legal/tos). All other rights reserved."
+COPYRIGHT_TEXT="Copyright © 2020 - $(date '+%Y') Mapbox, Inc. You may use this code with your Mapbox account and under the Mapbox Terms of Service (available at: https://www.mapbox.com/legal/tos). All other rights reserved."
 JAZZY_THEME="jazzy-theme"
-
 [[ -d jazzy-theme ]] || git clone git@github.com:mapbox/jazzy-theme.git
 
 bundle exec jazzy \


### PR DESCRIPTION
- update license text to reflect current version
- update docs script to automatically include full copyright year range