### PR TITLE
[Tech]: codecov updates

### DIFF
--- a/scripts/coverage/upload_codecov.sh
+++ b/scripts/coverage/upload_codecov.sh
@@ -6,6 +6,5 @@ pip3 install --user codecov
 env -i python3 -m \
 		codecov \
 		--root "$(pwd)" \
-		--token "$CODECOV_TOKEN" \
 		--file "$1" \
 		--required || echo 'Codecov failed to upload'


### PR DESCRIPTION
According to Codecov docs, tokens are no longer needed for public repos.
Removed it from the script.
