### PR TITLE
Up version to v.1.0.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+## 1.0.0-rc.2 - 2023-03-17
+
+### Fixed
+- [Core]: partially fixed a bug when indexable records couldn't be matched with corresponding search results which caused duplicated search results.
+
 ## [1.0.0-rc.1] - 2023-02-19
 
 ## [1.0.0-beta.42] - 2023-02-06

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 0.67.1
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 0.67.2
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 23.3.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "23.3.1"
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "0.67.1"
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "0.67.2"

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearch'
-  s.version          = '1.0.0-rc.1'
+  s.version          = '1.0.0-rc.2'
   s.summary          = 'Search SDK for Mapbox Search API '
 
 # This description is used to generate tags and improve search results.

--- a/MapboxSearchUI.podspec
+++ b/MapboxSearchUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearchUI'
-  s.version          = '1.0.0-rc.1'
+  s.version          = '1.0.0-rc.2'
   s.summary          = 'Search UI for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.
@@ -23,5 +23,5 @@ Card style custom UI with full search functionality powered by Mapbox Search API
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency 'MapboxSearch', "1.0.0-rc.1"
+  s.dependency 'MapboxSearch', "1.0.0-rc.2"
 end

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 import Foundation
 
-let (coreSearchVersion, coreSearchVersionHash) = ("0.67.1", "0ae7e081ac8e80b5996fb48c8eec1eb0d1cd3a2130ed371e29aa97214aeacb9e")
+let (coreSearchVersion, coreSearchVersionHash) = ("0.67.2", "2ef9f07e3b5f255633516bc5b5651a705a0372d7cd4df0c7887b93c7f6d7c16e")
 
 let commonMinVersion = Version("23.3.1")
 let commonMaxVersion = Version("24.0.0")

--- a/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
+++ b/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
@@ -1,2 +1,2 @@
 /// Mapbox Search SDK version variable
-public let mapboxSearchSDKVersion = "1.0.0-beta.42"
+public let mapboxSearchSDKVersion = "1.0.0-rc.2"


### PR DESCRIPTION
### Description
- SDK version bump to `v.1.0.0-rc.2`;
- MapboxCoreSearch version bump to `v0.67.2`;
- Changelog update;
- Sync with Android mapbox/mapbox-search-android#142

### Checklist
- [x] Update `CHANGELOG`
