### PR TITLE
Fix weekday conversion in OpenPeriod for Gregorian calendar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 Guide: https://keepachangelog.com/en/1.0.0/
 -->
 
+### Fixed
+- [Core]: fixed possibly incorrect data about POI opening hours. Fixed weekday conversion to the Gregorian calendar with Sunday as the first weekday.
+
 ## 1.0.0-rc.3 - 2023-04-21
 
 ### Added

--- a/Sources/MapboxSearch/PublicAPI/OpenPeriod.swift
+++ b/Sources/MapboxSearch/PublicAPI/OpenPeriod.swift
@@ -2,19 +2,22 @@ import Foundation
 
 /// Single entry of shopping hours for POI entry
 public struct OpenPeriod: Codable, Hashable {
-    /// Represents the start of the period. Components should contain weekday, hour and minute
+    /// Represents the start of the period. Components should contain weekday, hour and minute.
     public let start: DateComponents
-    /// Represents the end of the period. Components should contain weekday, hour and minute
+
+    /// Represents the end of the period. Components should contain weekday, hour and minute.
     public let end: DateComponents
     
     init(_ core: CoreOpenPeriod) {
-        start = DateComponents(calendar: Calendar(identifier: .gregorian),
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.firstWeekday = 1
+        start = DateComponents(calendar: calendar,
                                hour: Int(core.openH),
                                minute: Int(core.openM),
-                               weekday: Int((core.openD + 2) % 7)) // Convert Monday=0 style to the Sunday=1, Monday=2 iOS default style
-        end = DateComponents(calendar: Calendar(identifier: .gregorian),
+                               weekday: (Int(core.openD) + 1) % 7 + 1) // Convert Monday=0 style to the Sunday=1, Monday=2, ..., Saturday=7 iOS default style
+        end = DateComponents(calendar: calendar,
                                hour: Int(core.closedH),
                                minute: Int(core.closedM),
-                               weekday: Int((core.closedD + 2) % 7))
+                               weekday: (Int(core.closedD) + 1) % 7 + 1)
     }
 }

--- a/Tests/MapboxSearchTests/Common/Models/Metadata/OpenPeriodTests.swift
+++ b/Tests/MapboxSearchTests/Common/Models/Metadata/OpenPeriodTests.swift
@@ -51,4 +51,41 @@ class OpenPeriodTests: XCTestCase {
         let endDateString = ISO8601DateFormatter().string(from: endDate)
         XCTAssertEqual(endDateString, "2021-01-04T00:00:00Z") // Monday
     }
+
+    func testWeekdayConversionInGregorianCalenda() {
+        let sundayPeriod = CoreOpenPeriod(openD: 6, openH: 10, openM: 10, closedD: 6, closedH: 22, closedM: 00)
+        let sundayOpenPeriod = OpenPeriod(sundayPeriod)
+        XCTAssertEqual(sundayOpenPeriod.start.weekday, 1)
+        XCTAssertEqual(sundayOpenPeriod.end.weekday, 1)
+
+        let mondayPeriod = CoreOpenPeriod(openD: 0, openH: 10, openM: 10, closedD: 0, closedH: 22, closedM: 00)
+        let mondayOpenPeriod = OpenPeriod(mondayPeriod)
+        XCTAssertEqual(mondayOpenPeriod.start.weekday, 2)
+        XCTAssertEqual(mondayOpenPeriod.end.weekday, 2)
+
+        let tuesdayPeriod = CoreOpenPeriod(openD: 1, openH: 10, openM: 10, closedD: 1, closedH: 22, closedM: 00)
+        let tuesdayOpenPeriod = OpenPeriod(tuesdayPeriod)
+        XCTAssertEqual(tuesdayOpenPeriod.start.weekday, 3)
+        XCTAssertEqual(tuesdayOpenPeriod.end.weekday, 3)
+
+        let wednesdayPeriod = CoreOpenPeriod(openD: 2, openH: 10, openM: 10, closedD: 2, closedH: 22, closedM: 00)
+        let wednesdayOpenPeriod = OpenPeriod(wednesdayPeriod)
+        XCTAssertEqual(wednesdayOpenPeriod.start.weekday, 4)
+        XCTAssertEqual(wednesdayOpenPeriod.end.weekday, 4)
+
+        let thursdayPeriod = CoreOpenPeriod(openD: 3, openH: 10, openM: 10, closedD: 3, closedH: 22, closedM: 00)
+        let thursdayOpenPeriod = OpenPeriod(thursdayPeriod)
+        XCTAssertEqual(thursdayOpenPeriod.start.weekday, 5)
+        XCTAssertEqual(thursdayOpenPeriod.end.weekday, 5)
+
+        let fridayPeriod = CoreOpenPeriod(openD: 4, openH: 10, openM: 10, closedD: 4, closedH: 22, closedM: 00)
+        let fridayOpenPeriod = OpenPeriod(fridayPeriod)
+        XCTAssertEqual(fridayOpenPeriod.start.weekday, 6)
+        XCTAssertEqual(fridayOpenPeriod.end.weekday, 6)
+        
+        let saturdayPeriod = CoreOpenPeriod(openD: 5, openH: 10, openM: 10, closedD: 5, closedH: 22, closedM: 00)
+        let saturdayOpenPeriod = OpenPeriod(saturdayPeriod)
+        XCTAssertEqual(saturdayOpenPeriod.start.weekday, 7)
+        XCTAssertEqual(saturdayOpenPeriod.end.weekday, 7)
+    }
 }


### PR DESCRIPTION
### Description
Fixes weekday conversion for POI's business opening hours.
Fixes incorrect `Saturday=0` to `Saturday=7` in `DateComponents`.