### PR TITLE
[NAVIOS-1250]: removed `acceptedTypes` from the `AddressAutofill` query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 Guide: https://keepachangelog.com/en/1.0.0/
 -->
 
+## Unreleased
+
+### Fixed
+- [Place Autocomplete]: request all possible `PlaceType` values in case if types were not specified in a search query options.
+- [Address Autofill]: fixed reverse geocoding query, removed unsupported types from query.
+
 ## 1.0.0-rc.4 - 2023-05-19
 
 ### Added

--- a/Sources/Demo/AddressAutofillResultViewController.swift
+++ b/Sources/Demo/AddressAutofillResultViewController.swift
@@ -184,15 +184,14 @@ private extension AddressAutofillResultViewController {
                 if let first = suggestions.first {
                     self.addressAutofill.select(suggestion: first) { [weak self] result in
                         guard let self = self else { return }
-
-                        if case .success = result {
+                        
+                        if case let .success(suggestionResult) = result {
+                            self.result = suggestionResult
                             self.updateViewState(to: .result)
                         } else {
                             self.updateViewState(to: .empty)
                         }
                     }
-                    
-                    self.updateViewState(to: .result)
                 } else {
                     self.updateViewState(to: .empty)
                 }

--- a/Sources/MapboxSearch/PublicAPI/Common/Models/Administrative Unit/AdministrativeUnits.swift
+++ b/Sources/MapboxSearch/PublicAPI/Common/Models/Administrative Unit/AdministrativeUnits.swift
@@ -51,4 +51,8 @@ public struct AdministrativeUnit: Equatable {
     /// Japanese administrative unit analogous to `neighborhood`.
     /// - Note: Not available for reverse geocoding requests.
     public static let chome: AdministrativeUnit = .init(rawValue: .neighborhood)
+    
+    public static var all: [AdministrativeUnit] {
+        [.country, .region, .postcode, .district, .place, .locality, .neighborhood, .street, .address, .city, prefecture, .oaza, chome]
+    }
 }

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Address Autofill/AddressAutofill.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Address Autofill/AddressAutofill.swift
@@ -65,7 +65,6 @@ public extension AddressAutofill {
             countries: options?.countries.map { $0.countryCode },
             languages: options.map { [$0.language.languageCode] },
             limit: Constants.defaultSuggestionsLimit,
-            filterTypes: acceptedTypes,
             ignoreIndexableRecords: true
         ).toCore(apiType: Self.apiType)
         
@@ -81,7 +80,6 @@ public extension AddressAutofill {
         
         let searchOptions = ReverseGeocodingOptions(
             point: coordinate,
-            types: acceptedTypes,
             countries: options?.countries.map { $0.countryCode },
             languages: options.map { [$0.language.languageCode] }
         ).toCore()
@@ -151,10 +149,6 @@ private extension AddressAutofill {
 
 // MARK: - Text query
 private extension AddressAutofill {
-    var acceptedTypes: [SearchQueryType] {
-        [.country, .region, .postcode, .district, .place, .locality, .neighborhood, .address, .street, .poi]
-    }
-
     func fetchSuggestions(for query: String, with options: CoreSearchOptions, completion: @escaping (Swift.Result<[Suggestion], Error>) -> Void) {
         searchEngine.search(
             forQuery: query,

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/Models/PlaceAutocomplete+Options.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/Models/PlaceAutocomplete+Options.swift
@@ -25,7 +25,7 @@ public extension PlaceAutocomplete {
         public init(
             countries: [Country] = [],
             language: Language? = nil,
-            types: [PlaceType] = [.POI],
+            types: [PlaceType] = [],
             navigationProfile: SearchNavigationProfile? = nil
         ) {
             self.countries = countries

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/Models/PlaceAutocomplete+Options.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/Models/PlaceAutocomplete+Options.swift
@@ -25,7 +25,7 @@ public extension PlaceAutocomplete {
         public init(
             countries: [Country] = [],
             language: Language? = nil,
-            types: [PlaceType] = [],
+            types: [PlaceType] = [.POI],
             navigationProfile: SearchNavigationProfile? = nil
         ) {
             self.countries = countries

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/Models/PlaceAutocomplete+PlaceType.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/Models/PlaceAutocomplete+PlaceType.swift
@@ -9,6 +9,10 @@ public extension PlaceAutocomplete {
         case POI
         case administrativeUnit(AdministrativeUnit)
         
+        public static var allTypes: [PlaceType] {
+            [.POI] + AdministrativeUnit.all.map(PlaceType.administrativeUnit)
+        }
+        
         var coreType: SearchQueryType {
             switch self {
             case .POI: return .poi

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/PlaceAutocomplete.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/PlaceAutocomplete.swift
@@ -75,6 +75,13 @@ public extension PlaceAutocomplete {
         if let navigationProfiler = options.navigationProfile {
             navigationOptions = .init(profile: navigationProfiler, etaType: .navigation)
         }
+        
+        // We should not leave core types list empty or null in order to avoid unsupported types being requested
+        var filterTypes = options.types
+        if filterTypes.isEmpty {
+            filterTypes = PlaceType.allTypes
+        }
+        
         let searchOptions = SearchOptions(
             countries: options.countries.map { $0.countryCode },
             languages: [options.language.languageCode],
@@ -83,7 +90,7 @@ public extension PlaceAutocomplete {
             boundingBox: region,
             origin: proximity,
             navigationOptions: navigationOptions,
-            filterTypes: options.types.isEmpty ? nil : options.types.map { $0.coreType },
+            filterTypes: filterTypes.map { $0.coreType },
             ignoreIndexableRecords: true
         ).toCore(apiType: Self.apiType)
         
@@ -102,9 +109,15 @@ public extension PlaceAutocomplete {
     ) {
         userActivityReporter.reportActivity(forComponent: "place-autocomplete-reverse-geocoding")
         
+        // We should not leave core types list empty or null in order to avoid unsupported types being requested
+        var filterTypes = options.types
+        if filterTypes.isEmpty {
+            filterTypes = PlaceType.allTypes
+        }
+        
         let searchOptions = ReverseGeocodingOptions(
             point: query,
-            types: options.types.map { $0.coreType },
+            types: filterTypes.map { $0.coreType },
             countries: options.countries.map { $0.countryCode },
             languages: [options.language.languageCode]
         ).toCore()

--- a/Tests/MapboxSearchIntegrationTests/OfflineIntegrationTests.swift
+++ b/Tests/MapboxSearchIntegrationTests/OfflineIntegrationTests.swift
@@ -85,7 +85,6 @@ class OfflineIntegrationTests: MockServerTestCase {
         wait(for: [errorExpectation], timeout: 10)
         
         XCTAssertTrue(searchEngine.suggestions.isEmpty)
-        
     }
     
     func testCancelDownload() {

--- a/Tests/MapboxSearchTests/Use Cases/Address Autofill/AddressAutofill+Tests.swift
+++ b/Tests/MapboxSearchTests/Use Cases/Address Autofill/AddressAutofill+Tests.swift
@@ -30,10 +30,8 @@ final class AddressAutofillTests: XCTestCase {
     
     func testThatCorrectAcceptedTypesAreUsedForSuggestionsByQuery() {
         addressAutofill.suggestions(for: .init(value: "query")!) { _ in }
-        
-        let acceptedTypes: [SearchQueryType] = [.country, .region, .postcode, .district, .place, .locality, .neighborhood, .address, .street, .poi]
-        
-        XCTAssertEqual(searchEngine.searchOptions?.types, acceptedTypes.map { NSNumber(value: $0.coreValue.rawValue) })
+
+        XCTAssertNil(searchEngine.searchOptions!.types)
     }
     
     func testThatDefaultOptionsArePassedForSuggestionsByQuery() {
@@ -63,9 +61,7 @@ final class AddressAutofillTests: XCTestCase {
     func testThatCorrectAcceptedTypesAreUsedForSuggestionsByCoordinate() {
         addressAutofill.suggestions(for: kCLLocationCoordinate2DInvalid) { _ in }
         
-        let acceptedTypes: [SearchQueryType] = [.country, .region, .postcode, .district, .place, .locality, .neighborhood, .address, .street, .poi]
-        
-        XCTAssertEqual(searchEngine.reverseGeocodingOptions?.types, acceptedTypes.map { NSNumber(value: $0.coreValue.rawValue) })
+        XCTAssertNil(searchEngine.reverseGeocodingOptions!.types)
     }
     
     func testThatDefaultOptionsArePassedForSuggestionsByCoordinate() {

--- a/Tests/MapboxSearchTests/Use Cases/Place Autocomplete/PlaceAutocomplete.Options+Tests.swift
+++ b/Tests/MapboxSearchTests/Use Cases/Place Autocomplete/PlaceAutocomplete.Options+Tests.swift
@@ -8,8 +8,9 @@ final class PlaceAutocompleteOptionsTests: XCTestCase {
         let options = PlaceAutocomplete.Options()
         
         XCTAssertTrue(options.countries.isEmpty)
+        XCTAssertTrue(options.types.isEmpty)
+
         XCTAssertEqual(options.language, .default)
-        XCTAssertEqual(options.types, [.POI])
     }
     
     func testThatOptionsInitializedWithCountries() {

--- a/Tests/MapboxSearchTests/Use Cases/Place Autocomplete/PlaceAutocomplete.Options+Tests.swift
+++ b/Tests/MapboxSearchTests/Use Cases/Place Autocomplete/PlaceAutocomplete.Options+Tests.swift
@@ -9,7 +9,7 @@ final class PlaceAutocompleteOptionsTests: XCTestCase {
         
         XCTAssertTrue(options.countries.isEmpty)
         XCTAssertEqual(options.language, .default)
-        XCTAssertTrue(options.types.isEmpty)
+        XCTAssertEqual(options.types, [.POI])
     }
     
     func testThatOptionsInitializedWithCountries() {

--- a/Tests/MapboxSearchTests/Use Cases/Place Autocomplete/PlaceAutocompleteTests.swift
+++ b/Tests/MapboxSearchTests/Use Cases/Place Autocomplete/PlaceAutocompleteTests.swift
@@ -44,6 +44,20 @@ final class PlaceAutocompleteTests: XCTestCase {
         XCTAssertNil(searchEngine.searchOptions?.navProfile)
         XCTAssertNil(searchEngine.searchOptions?.etaType)
     }
+    
+    func testReverseGeocodingRequestUsesAllPlaceTypesIfTheyWereNotSpecifiedInOptions() {
+        placeAutocomplete.suggestions(for: .sample1) { _ in }
+        
+        XCTAssertFalse(searchEngine.reverseGeocodingOptions!.types!.isEmpty)
+        XCTAssertEqual(searchEngine.reverseGeocodingOptions!.types!.count, PlaceAutocomplete.PlaceType.allTypes.count)
+    }
+    
+    func testSuggestionsRequestUsesAllPlaceTypesIfTheyWereNotSpecifiedInOptions() {
+        placeAutocomplete.suggestions(for: "query") { _ in }
+        
+        XCTAssertFalse(searchEngine.searchOptions!.types!.isEmpty)
+        XCTAssertEqual(searchEngine.searchOptions!.types!.count, PlaceAutocomplete.PlaceType.allTypes.count)
+    }
 
     func testSuggestionsFilteredBy() {
         let types: [PlaceAutocomplete.PlaceType] = [.POI, .administrativeUnit(.city)]
@@ -127,7 +141,7 @@ final class PlaceAutocompleteTests: XCTestCase {
         XCTAssertFalse(searchEngine.nextSearchCalled)
     }
 
-    func testSelectSuggestionIfNeedToRetrive() {
+    func testSelectSuggestionIfNeedToRetrieve() {
         let coreSuggestion = CoreSearchResultStub.makeSuggestion()
         coreSuggestion.resultTypes = [.poi]
         coreSuggestion.center = CLLocation(latitude: 10.0, longitude: 20.0)
@@ -146,7 +160,7 @@ final class PlaceAutocompleteTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
-    func testSelectSuggestionIfDoNotNeedToRetrive() {
+    func testSelectSuggestionIfDoNotNeedToRetrieve() {
         let suggestion = PlaceAutocomplete.Suggestion.makeMock()
 
         let expectation = XCTestExpectation(description: "Call callback")


### PR DESCRIPTION
According to the API requirements, there is not types should be specified for an `autofill` query. 
