### PR TITLE
[Place Autocomplete]: reverse geocoding fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 ### Fixed
 - [Place Autocomplete]: request all possible `PlaceType` values in case if types were not specified in a search query options.
+- [Place Autocomplete]: fixed an issue when reverevse geocoding suggestion returns error on `select` request.
 - [Address Autofill]: fixed reverse geocoding query, removed unsupported types from query.
 
 ## 1.0.0-rc.4 - 2023-05-19

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/Models/PlaceAutocomplete+Suggestion.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/Models/PlaceAutocomplete+Suggestion.swift
@@ -126,6 +126,7 @@ extension PlaceAutocomplete.Suggestion {
         guard let type = SearchResultType(coreResultTypes: searchSuggestion.resultTypes) else {
             throw Error.invalidResultType
         }
+
         guard let coordinate = searchSuggestion.center?.coordinate,
                 CLLocationCoordinate2DIsValid(coordinate) else {
             throw Error.invalidCoordinates


### PR DESCRIPTION
Fixed an issue where reverse geocoding suggestions returns error on `select` request.
