### PR TITLE
[PlaceAutocomplete]: improvements and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,17 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
-## 1.0.0-rc.5 - 2023-06-29
-
 ### Added
 - [PlaceAutocomplete]: added `formattedAddress` function to perform default address formatting.
 - [PlaceAutocomplete]: added `countryISO1` and `countryISO2` properties in the resul's address.
 
+### Fixed
+- [Core]: Fixed street name capitalization for names with numbers.
+
 ### Breaking changes
 - [PlaceAutocomplete]: replaced `Address` type of the `Result` to the `AddressComponents`.
+
+## 1.0.0-rc.5 - 2023-06-29
 
 ### Fixed
 - [Core]: removed assertion for unsupported search result types.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 ## 1.0.0-rc.5 - 2023-06-29
 
+### Added
+- [PlaceAutocomplete]: added `formattedAddress` function to perform default address formatting.
+- [PlaceAutocomplete]: added `countryISO1` and `countryISO2` properties in the resul's address.
+
+### Breaking changes
+- [PlaceAutocomplete]: replaced `Address` type of the `Result` to the `AddressComponents`.
+
 ### Fixed
 - [Core]: removed assertion for unsupported search result types.
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 0.68.0
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 23.3.1
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 0.71.0
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 23.6.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "23.3.1"
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "0.68.0"
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "23.6.0"
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "0.71.0"

--- a/MapboxSearch.xcodeproj/project.pbxproj
+++ b/MapboxSearch.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		149948ED290A8DCA00E7E619 /* Swifter in Frameworks */ = {isa = PBXBuildFile; productRef = 149948EC290A8DCA00E7E619 /* Swifter */; };
 		149948EF290A8DD500E7E619 /* Swifter in Frameworks */ = {isa = PBXBuildFile; productRef = 149948EE290A8DD500E7E619 /* Swifter */; };
 		149948F1290A8DF900E7E619 /* Swifter in Frameworks */ = {isa = PBXBuildFile; productRef = 149948F0290A8DF900E7E619 /* Swifter */; };
+		14A0B83D2A5FF20B00D281F1 /* PlaceAutocomplet.Result+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A0B83B2A5FF1B300D281F1 /* PlaceAutocomplet.Result+Tests.swift */; };
 		14B92D5E298BFD19006003C1 /* DiscoverViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B92D5D298BFD19006003C1 /* DiscoverViewController.swift */; };
 		14F71865299FD4BD00D5BC2E /* PlaceAutocomplete+PlaceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F71864299FD4BD00D5BC2E /* PlaceAutocomplete+PlaceType.swift */; };
 		14F7186B29A1361700D5BC2E /* PlaceAutocompleteMainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F7186929A1341A00D5BC2E /* PlaceAutocompleteMainViewController.swift */; };
@@ -506,6 +507,7 @@
 		148DE66B285757AA0085684D /* AddressAutofill+Result.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddressAutofill+Result.swift"; sourceTree = "<group>"; };
 		148DE670285777180085684D /* NSLocking+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSLocking+Extensions.swift"; sourceTree = "<group>"; };
 		148DE68A285A18900085684D /* AddressAutofill+AddressComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddressAutofill+AddressComponent.swift"; sourceTree = "<group>"; };
+		14A0B83B2A5FF1B300D281F1 /* PlaceAutocomplet.Result+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaceAutocomplet.Result+Tests.swift"; sourceTree = "<group>"; };
 		14B92D5D298BFD19006003C1 /* DiscoverViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverViewController.swift; sourceTree = "<group>"; };
 		14F71864299FD4BD00D5BC2E /* PlaceAutocomplete+PlaceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaceAutocomplete+PlaceType.swift"; sourceTree = "<group>"; };
 		14F7186929A1341A00D5BC2E /* PlaceAutocompleteMainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceAutocompleteMainViewController.swift; sourceTree = "<group>"; };
@@ -1224,6 +1226,7 @@
 			children = (
 				14FA65832953618800056E5B /* PlaceAutocomplete.Options+Tests.swift */,
 				2CA1E22029F09CD200A533CF /* PlaceAutocomplete.Suggestion+Tests.swift */,
+				14A0B83B2A5FF1B300D281F1 /* PlaceAutocomplet.Result+Tests.swift */,
 				2CA1E22229F0A47600A533CF /* PlaceAutocompleteTests.swift */,
 			);
 			path = "Place Autocomplete";
@@ -2467,6 +2470,7 @@
 				FE7C73B3256687310047CA20 /* IndexableRecordStub.swift in Sources */,
 				FEEDD3A42508E24900DC0A98 /* SearchErrorTests.swift in Sources */,
 				FE8F821C256D509600A100D4 /* RoutablePointTests.swift in Sources */,
+				14A0B83D2A5FF20B00D281F1 /* PlaceAutocomplet.Result+Tests.swift in Sources */,
 				14FA658229535ABC00056E5B /* AdministrativeUnits+Tests.swift in Sources */,
 				FEB0AA8325CAC3EF002F0D1F /* CoreResultTypeTests.swift in Sources */,
 				FE4655A12566B619007ECC6A /* SearchResultSuggestionImplTests.swift in Sources */,

--- a/Sources/MapboxSearch/PublicAPI/Common/Models/Address/Address.swift
+++ b/Sources/MapboxSearch/PublicAPI/Common/Models/Address/Address.swift
@@ -50,7 +50,7 @@ public struct Address: Codable, Hashable {
         address.country = country ?? ""
         address.state = region ?? ""
         address.city = place ?? ""
-        
+
         return address
     }
     

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/Models/PlaceAutocomplete+Result.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/Models/PlaceAutocomplete+Result.swift
@@ -31,8 +31,8 @@ public extension PlaceAutocomplete {
         /// Poi categories. Always empty for non-POI suggestions.
         public let categories: [String]
         
-        /// Textual representation of the address.
-        public let address: Address?
+        /// Type representing address components.
+        public let address: AddressComponents?
         
         /// Business phone number
         public let phone: String?

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/Models/PlaceAutocomplete+Suggestion.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/Models/PlaceAutocomplete+Suggestion.swift
@@ -77,7 +77,7 @@ extension PlaceAutocomplete.Suggestion {
             estimatedTime: estimatedTime,
             routablePoints: underlyingResult.routablePoints ?? [],
             categories: underlyingResult.categories ?? [],
-            address: underlyingResult.address,
+            address: AddressComponents(searchResult: underlyingResult),
             phone: underlyingResult.metadata?.phone,
             website: underlyingResult.metadata?.website,
             reviewCount: underlyingResult.metadata?.reviewCount,

--- a/Tests/MapboxSearchTests/Common/Data Samples/CoreSearchResultStub+Samples.swift
+++ b/Tests/MapboxSearchTests/Common/Data Samples/CoreSearchResultStub+Samples.swift
@@ -29,7 +29,7 @@ extension CoreSearchResultStub {
         return results
     }
     
-    static func makeSuggestion() -> CoreSearchResultStub {
+    static func makeSuggestion(metadata: CoreResultMetadata? = nil) -> CoreSearchResultStub {
         let result = CoreSearchResultStub(
             id: UUID().uuidString,
             type: .place,
@@ -37,7 +37,8 @@ extension CoreSearchResultStub {
             languages: ["en"],
             center: nil,
             categories: ["cafe"],
-            icon: Maki.alcoholShop.name
+            icon: Maki.alcoholShop.name,
+            metadata: metadata
         )
         return result
     }

--- a/Tests/MapboxSearchTests/Common/Data Samples/SearchResultMetadata+Samples.swift
+++ b/Tests/MapboxSearchTests/Common/Data Samples/SearchResultMetadata+Samples.swift
@@ -21,3 +21,21 @@ extension SearchResultMetadata {
         website: "https://www.pizzahut.com")
     )
 }
+
+extension CoreResultMetadata {
+    static func make(data: [String: String] = [:]) -> CoreResultMetadata {
+        .init(
+            reviewCount: nil,
+            phone: nil,
+            website: nil,
+            avRating: nil,
+            description: nil,
+            openHours: nil,
+            primaryPhoto: nil,
+            otherPhoto: nil,
+            cpsJson: nil,
+            parking: nil,
+            data: data
+        )
+    }
+}

--- a/Tests/MapboxSearchTests/Use Cases/Place Autocomplete/PlaceAutocomplet.Result+Tests.swift
+++ b/Tests/MapboxSearchTests/Use Cases/Place Autocomplete/PlaceAutocomplet.Result+Tests.swift
@@ -1,0 +1,27 @@
+// Copyright © 2023 Mapbox. All rights reserved.
+
+import XCTest
+@testable import MapboxSearch
+
+final class PlaceAutocompleteResultTests: XCTestCase {
+    func testResultContainsISOCountryCodes() {
+        let coreResult = CoreSearchResultStub(
+            id: UUID().uuidString,
+            type: .address
+        )
+        coreResult.metadata = .make(data: [
+            "iso_3166_1": "US",
+            "iso_3166_2": "US-NY"
+        ])
+        
+        let searchResult = ServerSearchResult(
+            coreResult: coreResult,
+            response: CoreSearchResponseStub.successSample(results: [coreResult])
+        )!
+        
+        let result = try! PlaceAutocomplete.Suggestion.from(searchResult).result(for: searchResult)
+        
+        XCTAssertEqual(result.address?.countryISO1, "US")
+        XCTAssertEqual(result.address?.countryISO2, "US-NY")
+    }
+}


### PR DESCRIPTION
- added `formattedAddress` function to perform default address formatting.
- added `countryISO1` and `countryISO2` properties in the resul's address.
- Fixed street name capitalization for names with numbers.
- replaced `Address` type of the `Result` to the `AddressComponents`.