### PR TITLE
[Tech]: support new API and result types from Native.

### DIFF
--- a/Sources/MapboxSearch/InternalAPI/CoreResultType+Extensions.swift
+++ b/Sources/MapboxSearch/InternalAPI/CoreResultType+Extensions.swift
@@ -17,6 +17,7 @@ extension CoreResultType {
         case .userRecord: return "userRecord"
         case .neighborhood: return "neighborhood"
         case .block: return "block"
+        case .brand: return "brand"
         case .unknown:  fallthrough
         @unknown default:
             return "unknown"

--- a/Sources/MapboxSearch/InternalAPI/DefaultStringInterpolation+Extensions.swift
+++ b/Sources/MapboxSearch/InternalAPI/DefaultStringInterpolation+Extensions.swift
@@ -8,6 +8,9 @@ extension DefaultStringInterpolation {
         case .SBS:
             versionName = "SBS"
             
+        case .searchBox:
+            versionName = "searchBox"
+            
         case .autofill:
             versionName = "autofill"
 

--- a/Sources/MapboxSearch/PublicAPI/Common/Models/Result Types/SearchAddressType.swift
+++ b/Sources/MapboxSearch/PublicAPI/Common/Models/Result Types/SearchAddressType.swift
@@ -72,7 +72,7 @@ public enum SearchAddressType: String, Hashable, Codable {
         case .block:
             self = .block
 
-        case .unknown, .category, .userRecord, .query, .poi:
+        case .unknown, .category, .userRecord, .query, .poi, .brand:
             fallthrough
 
         @unknown default:

--- a/Sources/MapboxSearch/PublicAPI/SearchOptions.swift
+++ b/Sources/MapboxSearch/PublicAPI/SearchOptions.swift
@@ -273,6 +273,9 @@ public struct SearchOptions {
                 info("Autofill API doesn't support following filter types: \(unsupportedFilterTypes)")
             }
             
+        case .searchBox:
+            _Logger.searchSDK.warning("SearchBox API is not supported yet.")
+            
         @unknown default:
             _Logger.searchSDK.warning("Unexpected engine API Type: \(apiType)")
         }

--- a/Sources/MapboxSearch/PublicAPI/SearchQueryType.swift
+++ b/Sources/MapboxSearch/PublicAPI/SearchQueryType.swift
@@ -95,6 +95,11 @@ public enum SearchQueryType {
             return .street
         case .category:
             return category
+        case .brand:
+            /*
+             Brand type query is not supported.
+            */
+            return .poi
         @unknown default:
             return nil
         }


### PR DESCRIPTION
This MR adds initial support for new API and result types from native. When the final migration in native part will be done, we will expose additional fields, result and API types in publish SDK interface.
