### PR TITLE
Support hiding the panel controller and requesting local search

### DIFF
--- a/Sources/MapboxSearchUI/MapboxSearchController.swift
+++ b/Sources/MapboxSearchUI/MapboxSearchController.swift
@@ -16,12 +16,20 @@ public protocol SearchControllerDelegate: AnyObject {
     
     /// Control auto-collapse behavior of the panel after result selection.
     func shouldCollapseForSelection(_ searchResult: SearchResult) -> Bool
+  
+    /// Control auto-hide behavior of the panel after result selection.
+    func shouldHideForSelection(_ searchResult: SearchResult) -> Bool
 }
 
 public extension SearchControllerDelegate {
     /// Control auto-collapse behavior of the panel after result selection. Default `true`.
     func shouldCollapseForSelection(_ searchResult: SearchResult) -> Bool {
         return true
+    }
+  
+    /// Control auto-collapse behavior of the panel after result selection. Default `true`.
+    func shouldHideForSelection(_ searchResult: SearchResult) -> Bool {
+        return false
     }
 }
 
@@ -307,6 +315,10 @@ public class MapboxSearchController: UIViewController {
             view.endEditing(true)
             panel?.setState(.collapsed, animated: true)
         }
+        if delegate?.shouldHideForSelection(searchResult) == true {
+            view.endEditing(true)
+            panel?.setState(.hidden, animated: true)
+        }
     }
     
     func handleCreateFavoriteSearchResult(_ searchResult: SearchResult) {
@@ -418,14 +430,19 @@ public extension MapboxSearchController {
     ///   - animated: Should changes be animated
     ///   - collapse: Change the collapsing status. Pass `nil` to not apply status changes.
     ///               Default: `.collapsed`
-    func resetSearchUI(animated: Bool, collapse: MapboxPanelController.State? = .collapsed) {
+    func resetSearchUI(animated: Bool, to panelState: MapboxPanelController.State? = .collapsed) {
         resetSearch(animated: animated)
         categoriesRootView?.resetUI(animated: animated)
         
-        if let collapse = collapse {
-            mapboxPanelController?.setState(collapse, animated: animated)
+        if let newState = panelState {
+            mapboxPanelController?.setState(newState, animated: animated)
         }
     }
+    
+  func requestSearchStateUI(){
+    resetSearch(animated: true)
+    updateSearchState(.localSearch)
+  }
 }
 
 // MARK: - Search Engine Delegate


### PR DESCRIPTION
- Implemented shouldHideForSelection. Similar code to shouldCollapseF…orSelection to allow users to hide panel instead of collapsing.
- Modified the resetSearchUI function to change argument name and make code more readable
- Added a requestSearchStateUI function. Takes in no parameters and requests a local search (opens panel by default in search state)

### Description
This allows users to hide the panel controller on selection via the delegate and mirrors existing code. (May need cleanup)
RequestSearchStateUI to reset and request a new search. Could be useful for requesting additional waypoints in app through a different affordance/button

### Checklist
- [ ] Update `CHANGELOG`
