### PR TITLE
[SSDK-528] Prepare 2.0.0-alpha.1 release, update version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+<!-- Add changes for active work here -->
+
+## 2.0.0-alpha.1
+
+### Breaking changes
+
 - [Address Autofill] Suggestions no longer perform a `retrieve` call.
 - [Address Autofill] `Suggestion.coordinate` is now an optional. `init` requires an Underlying enum parameter.
 - [Address Autofill] Added new AddressAutofill.Suggestion.Underlying enum parameter with cases for suggestion and result inputs.

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearch'
-  s.version          = '1.0.0-rc.8'
+  s.version          = '2.0.0-alpha.1'
   s.summary          = 'Search SDK for Mapbox Search API '
 
 # This description is used to generate tags and improve search results.
@@ -20,7 +20,7 @@ Some iOS platform specifics applies.
   s.source           = { :http => "https://api.mapbox.com/downloads/v2/search-sdk/releases/ios/packages/#{s.version.to_s}/#{s.name}.zip" }
 
   s.ios.deployment_target = '12.0'
-  s.swift_versions = [5.2]
+  s.swift_versions = [5.7.1]
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 

--- a/MapboxSearchUI.podspec
+++ b/MapboxSearchUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearchUI'
-  s.version          = '1.0.0-rc.8'
+  s.version          = '2.0.0-alpha.1'
   s.summary          = 'Search UI for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.
@@ -19,9 +19,9 @@ Card style custom UI with full search functionality powered by Mapbox Search API
   s.source           = { :http => "https://api.mapbox.com/downloads/v2/search-sdk/releases/ios/packages/#{s.version.to_s}/#{s.name}.zip" }
 
   s.ios.deployment_target = '12.0'
-  s.swift_versions = [5.2]
+  s.swift_versions = [5.7.1]
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency 'MapboxSearch', "1.0.0-rc.8"
+  s.dependency 'MapboxSearch', "2.0.0-alpha.1"
 end

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The Search SDK is pre-configured for autocomplete, local search biasing, and inc
 ## Requirements
 
 - iOS 12.0 and newer
-- Xcode 14 and newer
+- Xcode 14.1 and newer
 - Swift 5.7.1 and newer
 - Objective-C is not supported
 - macOS/tvOS/watchOS platforms currently are not supported
@@ -104,13 +104,13 @@ MapboxSearchDemoApplication provides a Demo app wih MapboxSearchUI.framework pre
 ##### MapboxSearch
 To integrate latest preview version of `MapboxSearch` into your Xcode project using CocoaPods, specify it in your `Podfile`:  
 ```
-pod 'MapboxSearch', ">= 1.0.0-rc.8", "< 2.0"
+pod 'MapboxSearch', ">= 2.0.0-alpha.1", "< 3.0"
 ```
 
 ##### MapboxSearchUI
 To integrate latest preview version of `MapboxSearchUI` into your Xcode project using CocoaPods, specify it in your `Podfile`:  
 ```
-pod 'MapboxSearchUI', ">= 1.0.0-rc.8", "< 2.0"
+pod 'MapboxSearchUI', ">= 2.0.0-alpha.1", "< 3.0"
 ```
 
 ### Swift Package Manager

--- a/Search Documentation.docc/Installation.md
+++ b/Search Documentation.docc/Installation.md
@@ -59,7 +59,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearchUI', ">= 1.0.0-rc.8", "< 2.0"
+      pod 'MapboxSearchUI', ">= 2.0.0-alpha.1", "< 3.0"
     end
     ```
 
@@ -68,7 +68,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearch', ">= 1.0.0-rc.8", "< 2.0"
+      pod 'MapboxSearch', ">= 2.0.0-alpha.1", "< 3.0"
     end
     ```
 


### PR DESCRIPTION
### Description
**Fixes [SSDK-528](https://mapbox.atlassian.net/browse/SSDK-528)**

- Fine tune Swift and Xcode version numbers in docs

### Checklist
- [x] Update `CHANGELOG`
