### PR TITLE
[SSDK-525] Update Example/SearchExample.xcworkspace to use local package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Guide: https://keepachangelog.com/en/1.0.0/
 <!-- Add changes for active work here -->
 
 - [Core] Remove legacy `MGLMapboxAccessToken`.
+- [SearchExample] Update Examples/SearchExample.xcworkspace to use MapboxMaps v11, MapboxCommon v24, and the local package (parent directory) for MapboxSearch.
 
 ## 2.0.0-alpha.1
 

--- a/Examples/SearchExamples.xcodeproj/project.pbxproj
+++ b/Examples/SearchExamples.xcodeproj/project.pbxproj
@@ -22,8 +22,6 @@
 		FE8295832701E46D001005B4 /* MapboxBoundingBoxController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE780E3124C9B3D000C62400 /* MapboxBoundingBoxController.swift */; };
 		FE849B5626FC9E63001CBC27 /* ExamplesTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE849B5526FC9E63001CBC27 /* ExamplesTableViewController.swift */; };
 		FE849B5A26FCBCEC001CBC27 /* MapsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE849B5926FCBCEC001CBC27 /* MapsViewController.swift */; };
-		FE9DFDAA26F8D9A60021375F /* MapboxSearch in Frameworks */ = {isa = PBXBuildFile; productRef = FE9DFDA926F8D9A60021375F /* MapboxSearch */; };
-		FE9DFDAC26F8DA0F0021375F /* MapboxSearchUI in Frameworks */ = {isa = PBXBuildFile; productRef = FE9DFDAB26F8DA0F0021375F /* MapboxSearchUI */; };
 		FEF1D1BA26FDF642004AE229 /* TextViewLoggerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF1D1B926FDF642004AE229 /* TextViewLoggerViewController.swift */; };
 		FEF1D1BD26FDFB1F004AE229 /* Atlantis in Frameworks */ = {isa = PBXBuildFile; productRef = FEF1D1BC26FDFB1F004AE229 /* Atlantis */; };
 /* End PBXBuildFile section */
@@ -55,9 +53,7 @@
 				04F0A1612B4F276D0097D316 /* MapboxMaps in Frameworks */,
 				FE0720C026FC86C70065A273 /* MapboxSearchUI in Frameworks */,
 				FE0720BE26FC86C70065A273 /* MapboxSearch in Frameworks */,
-				FE9DFDAC26F8DA0F0021375F /* MapboxSearchUI in Frameworks */,
 				FEF1D1BD26FDFB1F004AE229 /* Atlantis in Frameworks */,
-				FE9DFDAA26F8D9A60021375F /* MapboxSearch in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -144,8 +140,6 @@
 			);
 			name = SearchExamples;
 			packageProductDependencies = (
-				FE9DFDA926F8D9A60021375F /* MapboxSearch */,
-				FE9DFDAB26F8DA0F0021375F /* MapboxSearchUI */,
 				FE0720BD26FC86C70065A273 /* MapboxSearch */,
 				FE0720BF26FC86C70065A273 /* MapboxSearchUI */,
 				FEF1D1BC26FDFB1F004AE229 /* Atlantis */,
@@ -477,14 +471,6 @@
 		FE0720BF26FC86C70065A273 /* MapboxSearchUI */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = FE0720BC26FC86C70065A273 /* XCRemoteSwiftPackageReference "search-ios" */;
-			productName = MapboxSearchUI;
-		};
-		FE9DFDA926F8D9A60021375F /* MapboxSearch */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = MapboxSearch;
-		};
-		FE9DFDAB26F8DA0F0021375F /* MapboxSearchUI */ = {
-			isa = XCSwiftPackageProductDependency;
 			productName = MapboxSearchUI;
 		};
 		FEF1D1BC26FDFB1F004AE229 /* Atlantis */ = {

--- a/Examples/SearchExamples.xcodeproj/project.pbxproj
+++ b/Examples/SearchExamples.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		047D75962B584FDB005182A3 /* MapboxSearch in Frameworks */ = {isa = PBXBuildFile; productRef = 047D75952B584FDB005182A3 /* MapboxSearch */; };
-		047D75982B584FDB005182A3 /* MapboxSearchUI in Frameworks */ = {isa = PBXBuildFile; productRef = 047D75972B584FDB005182A3 /* MapboxSearchUI */; };
+		047D759E2B5850DB005182A3 /* MapboxSearch in Frameworks */ = {isa = PBXBuildFile; productRef = 047D759D2B5850DB005182A3 /* MapboxSearch */; };
+		047D75A02B5850DB005182A3 /* MapboxSearchUI in Frameworks */ = {isa = PBXBuildFile; productRef = 047D759F2B5850DB005182A3 /* MapboxSearchUI */; };
 		04F0A1612B4F276D0097D316 /* MapboxMaps in Frameworks */ = {isa = PBXBuildFile; productRef = 04F0A1602B4F276D0097D316 /* MapboxMaps */; };
 		FE00067F26FDCB9E00846819 /* Examples.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE00067E26FDCB9E00846819 /* Examples.swift */; };
 		FE114AA824C10B88001B2CE8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE114AA724C10B88001B2CE8 /* AppDelegate.swift */; };
@@ -27,6 +27,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		047D759C2B5850D3005182A3 /* mapbox-search-ios */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "mapbox-search-ios"; path = ..; sourceTree = "<group>"; };
 		FE00067E26FDCB9E00846819 /* Examples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Examples.swift; sourceTree = "<group>"; };
 		FE114AA424C10B88001B2CE8 /* SearchExamples.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SearchExamples.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FE114AA724C10B88001B2CE8 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -50,8 +51,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				047D75962B584FDB005182A3 /* MapboxSearch in Frameworks */,
-				047D75982B584FDB005182A3 /* MapboxSearchUI in Frameworks */,
+				047D759E2B5850DB005182A3 /* MapboxSearch in Frameworks */,
+				047D75A02B5850DB005182A3 /* MapboxSearchUI in Frameworks */,
 				04F0A1612B4F276D0097D316 /* MapboxMaps in Frameworks */,
 				FEF1D1BD26FDFB1F004AE229 /* Atlantis in Frameworks */,
 			);
@@ -60,9 +61,18 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		047D759B2B5850D3005182A3 /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				047D759C2B5850D3005182A3 /* mapbox-search-ios */,
+			);
+			name = Packages;
+			sourceTree = "<group>";
+		};
 		FE114A9B24C10B88001B2CE8 = {
 			isa = PBXGroup;
 			children = (
+				047D759B2B5850D3005182A3 /* Packages */,
 				FE114AA624C10B88001B2CE8 /* SearchExamples */,
 				FE9DFDAD26F8E0430021375F /* scripts */,
 				FE114AA524C10B88001B2CE8 /* Products */,
@@ -142,8 +152,8 @@
 			packageProductDependencies = (
 				FEF1D1BC26FDFB1F004AE229 /* Atlantis */,
 				04F0A1602B4F276D0097D316 /* MapboxMaps */,
-				047D75952B584FDB005182A3 /* MapboxSearch */,
-				047D75972B584FDB005182A3 /* MapboxSearchUI */,
+				047D759D2B5850DB005182A3 /* MapboxSearch */,
+				047D759F2B5850DB005182A3 /* MapboxSearchUI */,
 			);
 			productName = SearchExamples;
 			productReference = FE114AA424C10B88001B2CE8 /* SearchExamples.app */;
@@ -176,7 +186,6 @@
 			packageReferences = (
 				FEF1D1BB26FDFB1F004AE229 /* XCRemoteSwiftPackageReference "atlantis" */,
 				04F0A15F2B4F276D0097D316 /* XCRemoteSwiftPackageReference "mapbox-maps-ios" */,
-				047D75942B584FDB005182A3 /* XCRemoteSwiftPackageReference "mapbox-search-ios" */,
 			);
 			productRefGroup = FE114AA524C10B88001B2CE8 /* Products */;
 			projectDirPath = "";
@@ -431,14 +440,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		047D75942B584FDB005182A3 /* XCRemoteSwiftPackageReference "mapbox-search-ios" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/mapbox/mapbox-search-ios/";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = "2.0.0-alpha.1";
-			};
-		};
 		04F0A15F2B4F276D0097D316 /* XCRemoteSwiftPackageReference "mapbox-maps-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mapbox/mapbox-maps-ios.git";
@@ -458,14 +459,12 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		047D75952B584FDB005182A3 /* MapboxSearch */ = {
+		047D759D2B5850DB005182A3 /* MapboxSearch */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 047D75942B584FDB005182A3 /* XCRemoteSwiftPackageReference "mapbox-search-ios" */;
 			productName = MapboxSearch;
 		};
-		047D75972B584FDB005182A3 /* MapboxSearchUI */ = {
+		047D759F2B5850DB005182A3 /* MapboxSearchUI */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 047D75942B584FDB005182A3 /* XCRemoteSwiftPackageReference "mapbox-search-ios" */;
 			productName = MapboxSearchUI;
 		};
 		04F0A1602B4F276D0097D316 /* MapboxMaps */ = {

--- a/Examples/SearchExamples.xcodeproj/project.pbxproj
+++ b/Examples/SearchExamples.xcodeproj/project.pbxproj
@@ -7,10 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		047D75962B584FDB005182A3 /* MapboxSearch in Frameworks */ = {isa = PBXBuildFile; productRef = 047D75952B584FDB005182A3 /* MapboxSearch */; };
+		047D75982B584FDB005182A3 /* MapboxSearchUI in Frameworks */ = {isa = PBXBuildFile; productRef = 047D75972B584FDB005182A3 /* MapboxSearchUI */; };
 		04F0A1612B4F276D0097D316 /* MapboxMaps in Frameworks */ = {isa = PBXBuildFile; productRef = 04F0A1602B4F276D0097D316 /* MapboxMaps */; };
 		FE00067F26FDCB9E00846819 /* Examples.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE00067E26FDCB9E00846819 /* Examples.swift */; };
-		FE0720BE26FC86C70065A273 /* MapboxSearch in Frameworks */ = {isa = PBXBuildFile; productRef = FE0720BD26FC86C70065A273 /* MapboxSearch */; };
-		FE0720C026FC86C70065A273 /* MapboxSearchUI in Frameworks */ = {isa = PBXBuildFile; productRef = FE0720BF26FC86C70065A273 /* MapboxSearchUI */; };
 		FE114AA824C10B88001B2CE8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE114AA724C10B88001B2CE8 /* AppDelegate.swift */; };
 		FE114AB124C10B8A001B2CE8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FE114AB024C10B8A001B2CE8 /* Assets.xcassets */; };
 		FE114AB424C10B8A001B2CE8 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FE114AB224C10B8A001B2CE8 /* LaunchScreen.storyboard */; };
@@ -50,9 +50,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				047D75962B584FDB005182A3 /* MapboxSearch in Frameworks */,
+				047D75982B584FDB005182A3 /* MapboxSearchUI in Frameworks */,
 				04F0A1612B4F276D0097D316 /* MapboxMaps in Frameworks */,
-				FE0720C026FC86C70065A273 /* MapboxSearchUI in Frameworks */,
-				FE0720BE26FC86C70065A273 /* MapboxSearch in Frameworks */,
 				FEF1D1BD26FDFB1F004AE229 /* Atlantis in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -140,10 +140,10 @@
 			);
 			name = SearchExamples;
 			packageProductDependencies = (
-				FE0720BD26FC86C70065A273 /* MapboxSearch */,
-				FE0720BF26FC86C70065A273 /* MapboxSearchUI */,
 				FEF1D1BC26FDFB1F004AE229 /* Atlantis */,
 				04F0A1602B4F276D0097D316 /* MapboxMaps */,
+				047D75952B584FDB005182A3 /* MapboxSearch */,
+				047D75972B584FDB005182A3 /* MapboxSearchUI */,
 			);
 			productName = SearchExamples;
 			productReference = FE114AA424C10B88001B2CE8 /* SearchExamples.app */;
@@ -174,9 +174,9 @@
 			);
 			mainGroup = FE114A9B24C10B88001B2CE8;
 			packageReferences = (
-				FE0720BC26FC86C70065A273 /* XCRemoteSwiftPackageReference "search-ios" */,
 				FEF1D1BB26FDFB1F004AE229 /* XCRemoteSwiftPackageReference "atlantis" */,
 				04F0A15F2B4F276D0097D316 /* XCRemoteSwiftPackageReference "mapbox-maps-ios" */,
+				047D75942B584FDB005182A3 /* XCRemoteSwiftPackageReference "mapbox-search-ios" */,
 			);
 			productRefGroup = FE114AA524C10B88001B2CE8 /* Products */;
 			projectDirPath = "";
@@ -431,20 +431,20 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		047D75942B584FDB005182A3 /* XCRemoteSwiftPackageReference "mapbox-search-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/mapbox/mapbox-search-ios/";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = "2.0.0-alpha.1";
+			};
+		};
 		04F0A15F2B4F276D0097D316 /* XCRemoteSwiftPackageReference "mapbox-maps-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mapbox/mapbox-maps-ios.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 10.0.0;
-			};
-		};
-		FE0720BC26FC86C70065A273 /* XCRemoteSwiftPackageReference "search-ios" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/mapbox/search-ios";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = "1.0.0-rc.8";
+				minimumVersion = 11.0.0;
 			};
 		};
 		FEF1D1BB26FDFB1F004AE229 /* XCRemoteSwiftPackageReference "atlantis" */ = {
@@ -458,20 +458,20 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		047D75952B584FDB005182A3 /* MapboxSearch */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 047D75942B584FDB005182A3 /* XCRemoteSwiftPackageReference "mapbox-search-ios" */;
+			productName = MapboxSearch;
+		};
+		047D75972B584FDB005182A3 /* MapboxSearchUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 047D75942B584FDB005182A3 /* XCRemoteSwiftPackageReference "mapbox-search-ios" */;
+			productName = MapboxSearchUI;
+		};
 		04F0A1602B4F276D0097D316 /* MapboxMaps */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 04F0A15F2B4F276D0097D316 /* XCRemoteSwiftPackageReference "mapbox-maps-ios" */;
 			productName = MapboxMaps;
-		};
-		FE0720BD26FC86C70065A273 /* MapboxSearch */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = FE0720BC26FC86C70065A273 /* XCRemoteSwiftPackageReference "search-ios" */;
-			productName = MapboxSearch;
-		};
-		FE0720BF26FC86C70065A273 /* MapboxSearchUI */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = FE0720BC26FC86C70065A273 /* XCRemoteSwiftPackageReference "search-ios" */;
-			productName = MapboxSearchUI;
 		};
 		FEF1D1BC26FDFB1F004AE229 /* Atlantis */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Examples/SearchExamples.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/SearchExamples.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mapbox/mapbox-common-ios.git",
       "state" : {
-        "revision" : "065cb97a83b8bf8d8584ab56cb6ebed898cc0c97",
-        "version" : "23.8.6"
+        "revision" : "6ed3e33b51d3e3162843885f6914d7fb175609c6",
+        "version" : "24.1.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mapbox/mapbox-core-maps-ios.git",
       "state" : {
-        "revision" : "798644dafccc37c3be17127e39638f39d6cd57e3",
-        "version" : "10.16.4"
+        "revision" : "d9cdf51cf4b897811a5c5d5135d3c772830e2b7c",
+        "version" : "11.1.0"
       }
     },
     {
@@ -32,17 +32,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mapbox/mapbox-maps-ios.git",
       "state" : {
-        "revision" : "05a275f685ac95982716d87ccb677ebad417c252",
-        "version" : "10.16.4"
+        "revision" : "3fa9b6660abca863f0a2eccfe3a4001904b2120b",
+        "version" : "11.1.0"
       }
     },
     {
-      "identity" : "search-ios",
+      "identity" : "mapbox-search-ios",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mapbox/search-ios",
+      "location" : "https://github.com/mapbox/mapbox-search-ios/",
       "state" : {
-        "revision" : "ecd3aa0f782aa0a27267c7118dd6ebd391ea7f82",
-        "version" : "1.0.0-rc.8"
+        "revision" : "1141870c3fcb9e801114ea82f2eb6161c21cd2e9",
+        "version" : "2.0.0-alpha.1"
       }
     },
     {

--- a/Examples/SearchExamples.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/SearchExamples.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,59 +1,70 @@
 {
-  "pins" : [
-    {
-      "identity" : "atlantis",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ProxymanApp/atlantis",
-      "state" : {
-        "revision" : "131d757cf8e6e368ad338728379174f7cfff9326",
-        "version" : "1.23.0"
+  "object": {
+    "pins": [
+      {
+        "package": "Atlantis",
+        "repositoryURL": "https://github.com/ProxymanApp/atlantis",
+        "state": {
+          "branch": null,
+          "revision": "131d757cf8e6e368ad338728379174f7cfff9326",
+          "version": "1.23.0"
+        }
+      },
+      {
+        "package": "CwlCatchException",
+        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
+        "state": {
+          "branch": null,
+          "revision": "3b123999de19bf04905bc1dfdb76f817b0f2cc00",
+          "version": "2.1.2"
+        }
+      },
+      {
+        "package": "CwlPreconditionTesting",
+        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+        "state": {
+          "branch": null,
+          "revision": "dc9af4781f2afdd1e68e90f80b8603be73ea7abc",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "package": "MapboxCommon",
+        "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
+        "state": {
+          "branch": null,
+          "revision": "6ed3e33b51d3e3162843885f6914d7fb175609c6",
+          "version": "24.1.0"
+        }
+      },
+      {
+        "package": "MapboxCoreMaps",
+        "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
+        "state": {
+          "branch": null,
+          "revision": "d9cdf51cf4b897811a5c5d5135d3c772830e2b7c",
+          "version": "11.1.0"
+        }
+      },
+      {
+        "package": "MapboxMaps",
+        "repositoryURL": "https://github.com/mapbox/mapbox-maps-ios.git",
+        "state": {
+          "branch": null,
+          "revision": "3fa9b6660abca863f0a2eccfe3a4001904b2120b",
+          "version": "11.1.0"
+        }
+      },
+      {
+        "package": "Turf",
+        "repositoryURL": "https://github.com/mapbox/turf-swift.git",
+        "state": {
+          "branch": null,
+          "revision": "f0afe204b4266337066a436becab62fdd2b32378",
+          "version": "2.7.0"
+        }
       }
-    },
-    {
-      "identity" : "mapbox-common-ios",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mapbox/mapbox-common-ios.git",
-      "state" : {
-        "revision" : "6ed3e33b51d3e3162843885f6914d7fb175609c6",
-        "version" : "24.1.0"
-      }
-    },
-    {
-      "identity" : "mapbox-core-maps-ios",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mapbox/mapbox-core-maps-ios.git",
-      "state" : {
-        "revision" : "d9cdf51cf4b897811a5c5d5135d3c772830e2b7c",
-        "version" : "11.1.0"
-      }
-    },
-    {
-      "identity" : "mapbox-maps-ios",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mapbox/mapbox-maps-ios.git",
-      "state" : {
-        "revision" : "3fa9b6660abca863f0a2eccfe3a4001904b2120b",
-        "version" : "11.1.0"
-      }
-    },
-    {
-      "identity" : "mapbox-search-ios",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mapbox/mapbox-search-ios/",
-      "state" : {
-        "revision" : "1141870c3fcb9e801114ea82f2eb6161c21cd2e9",
-        "version" : "2.0.0-alpha.1"
-      }
-    },
-    {
-      "identity" : "turf-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mapbox/turf-swift.git",
-      "state" : {
-        "revision" : "f0afe204b4266337066a436becab62fdd2b32378",
-        "version" : "2.7.0"
-      }
-    }
-  ],
-  "version" : 2
+    ]
+  },
+  "version": 1
 }


### PR DESCRIPTION
### Description

Fixes [SSDK-525](https://mapbox.atlassian.net/browse/SSDK-525)

- Update Examples/SearchExample.xcworkspace to use MapboxMaps v11, MapboxCommon v24, and the local package (parent directory) for MapboxSearch.
- Built with Xcode 14.1
- This allows testing the latest local changes directly without relying on releases or branches published to GitHub

### Checklist
- [x] Update `CHANGELOG`
