### PR TITLE
[SSDK-536] Add support for .mapboxId field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Guide: https://keepachangelog.com/en/1.0.0/
 <!-- Add changes for active work here -->
 
 - [Core] Remove legacy `MGLMapboxAccessToken`.
+- [Address Autofill] Add support for `mapboxId` field.
+- [Discover] (aka Category) Add support for `mapboxId` field.
+- [Place Autocomplete] Add support for `mapboxId` field.
 - [Core] Update MapboxCoreSearch to alpha 8
 
 **MapboxCoreSearch**: v2.0.0-alpha.8

--- a/Sources/MapboxSearch/InternalAPI/CoreSearchResultProtocol.swift
+++ b/Sources/MapboxSearch/InternalAPI/CoreSearchResultProtocol.swift
@@ -4,6 +4,8 @@ import CoreLocation
 protocol CoreSearchResultProtocol {
     var id: String { get }
 
+    var mapboxId: String? { get }
+
     var resultTypes: [CoreResultType] { get }
 
     /**

--- a/Sources/MapboxSearch/PublicAPI/Search Results/ExternalRecordPlaceholder.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/ExternalRecordPlaceholder.swift
@@ -2,6 +2,8 @@ import Foundation
 import CoreLocation
 
 class ExternalRecordPlaceholder: SearchResultSuggestion, CoreResponseProvider {
+    var mapboxId: String?
+
     var originalResponse: CoreSearchResultResponse
     
     var dataLayerIdentifier: String
@@ -30,6 +32,7 @@ class ExternalRecordPlaceholder: SearchResultSuggestion, CoreResponseProvider {
         guard let layerIdentifier = coreResult.layer, coreResult.resultTypes == [.userRecord] else { return nil }
         
         self.id = coreResult.userRecordID ?? coreResult.id
+        self.mapboxId = coreResult.mapboxId
         self.name = coreResult.names[0]
         self.address = coreResult.addresses?.first.map(Address.init)
         self.dataLayerIdentifier = layerIdentifier

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchCategorySuggestionImpl.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchCategorySuggestionImpl.swift
@@ -2,6 +2,8 @@ import Foundation
 import CoreLocation
 
 class SearchCategorySuggestionImpl: SearchCategorySuggestion, CoreResponseProvider {
+    var mapboxId: String?
+
     var originalResponse: CoreSearchResultResponse
     
     var id: String
@@ -30,6 +32,7 @@ class SearchCategorySuggestionImpl: SearchCategorySuggestion, CoreResponseProvid
         guard coreResult.resultTypes == [.category] else { return nil }
         
         self.id = coreResult.id
+        self.mapboxId = coreResult.mapboxId
         self.suggestionType = .category
         self.name = coreResult.names[0]
         self.address = coreResult.addresses?.first.map(Address.init)

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchQuerySuggestionImpl.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchQuerySuggestionImpl.swift
@@ -6,6 +6,8 @@ class SearchQuerySuggestionImpl: SearchQuerySuggestion, CoreResponseProvider {
     var originalResponse: CoreSearchResultResponse
     
     var id: String
+
+    var mapboxId: String?
     
     var name: String
     
@@ -31,6 +33,7 @@ class SearchQuerySuggestionImpl: SearchQuerySuggestion, CoreResponseProvider {
         guard coreResult.resultTypes == [.query] else { return nil }
         
         self.id = coreResult.id
+        self.mapboxId = coreResult.mapboxId
         self.suggestionType = .query
         self.name = coreResult.names[0]
         self.address = coreResult.addresses?.first.map(Address.init)

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchResultSuggestionImpl.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchResultSuggestionImpl.swift
@@ -2,6 +2,8 @@ import Foundation
 import CoreLocation
 
 class SearchResultSuggestionImpl: SearchResultSuggestion, CoreResponseProvider {
+    var mapboxId: String?
+
     var originalResponse: CoreSearchResultResponse
     
     let dataLayerIdentifier = SearchEngine.providerIdentifier
@@ -42,6 +44,7 @@ class SearchResultSuggestionImpl: SearchResultSuggestion, CoreResponseProvider {
         }
         
         self.id = coreResult.id
+        self.mapboxId = coreResult.mapboxId
         self.name = coreResult.names[0]
         self.address = coreResult.addresses?.first.map(Address.init)
         self.iconName = coreResult.icon

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchSuggestion.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchSuggestion.swift
@@ -10,7 +10,9 @@ public protocol SearchSuggestion {
     ///
     /// - Attention: Mapbox backend may change the identifier of the object in the future.
     var id: String { get }
-    
+
+    var mapboxId: String? { get }
+
     /// Suggestion name.
     var name: String { get }
     

--- a/Sources/MapboxSearch/PublicAPI/Search Results/ServerSearchResult.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/ServerSearchResult.swift
@@ -2,6 +2,8 @@ import Foundation
 import CoreLocation
 
 class ServerSearchResult: SearchResult, SearchResultSuggestion, CoreResponseProvider {
+    var mapboxId: String?
+
     var distance: CLLocationDistance?
     
     var originalResponse: CoreSearchResultResponse
@@ -61,6 +63,7 @@ class ServerSearchResult: SearchResult, SearchResultSuggestion, CoreResponseProv
         self.type = type
 
         self.id = coreResult.id
+        self.mapboxId = coreResult.mapboxId
         self.name = coreResult.names[0]
         self.matchingName = coreResult.matchingName
         self.iconName = coreResult.icon

--- a/Tests/MapboxSearchTests/Common/Data Samples/CoreSearchResultStub+Samples.swift
+++ b/Tests/MapboxSearchTests/Common/Data Samples/CoreSearchResultStub+Samples.swift
@@ -5,16 +5,19 @@ import CoreLocation
 extension CoreSearchResultStub {
     static let sample1 = CoreSearchResultStub(
         id: "sample-1",
+        mapboxId: "sample-1",
         type: .poi,
         distance: 4200,
         estimatedTime: Measurement(value: 10.5, unit: .minutes)
     )
     static let sample2 = CoreSearchResultStub(
         id: "sample-2",
+        mapboxId: "sample-3",
         type: .category
     )
     
     static let externalRecordSample = CoreSearchResultStub(id: "sample-3",
+                                                           mapboxId: "sample-3",
                                                            type: .userRecord,
                                                            centerLocation: .sample1,
                                                            layer: FavoritesProvider.providerIdentifier,
@@ -32,6 +35,7 @@ extension CoreSearchResultStub {
     static func makeSuggestion(metadata: CoreResultMetadata? = nil) -> CoreSearchResultStub {
         let result = CoreSearchResultStub(
             id: UUID().uuidString,
+            mapboxId: "",
             type: .place,
             names: ["Some Place Name"],
             languages: ["en"],
@@ -62,12 +66,13 @@ extension CoreSearchResultStub {
     }
     
     static func makeSuggestionTypeQuery() -> CoreSearchResultStub {
-        CoreSearchResultStub(id: "recursion", type: .query, centerLocation: nil)
+        CoreSearchResultStub(id: "recursion", mapboxId: "", type: .query, centerLocation: nil)
     }
     
     static func makeCategory() -> CoreSearchResultStub {
         CoreSearchResultStub(
             id: UUID().uuidString,
+            mapboxId: "",
             type: .category,
             names: ["Bar"],
             languages: ["en"],
@@ -80,6 +85,7 @@ extension CoreSearchResultStub {
         let center = CLLocation(latitude: 12.0000, longitude: 10.0000)
         let result = CoreSearchResultStub(
             id: UUID().uuidString,
+            mapboxId: "",
             type: .place,
             names: ["Some Place Name"],
             languages: ["en"],
@@ -94,6 +100,7 @@ extension CoreSearchResultStub {
     static func makeAddress() -> CoreSearchResultStub {
         let result = CoreSearchResultStub(
             id: UUID().uuidString,
+            mapboxId: "",
             type: .address,
             names: ["Some Place Name"],
             languages: ["en"],
@@ -123,6 +130,7 @@ extension CoreSearchResultStub {
         )
         let result = CoreSearchResultStub(
             id: UUID().uuidString,
+            mapboxId: "",
             type: .place,
             names: ["Some Place Name"],
             languages: ["en"],
@@ -153,6 +161,7 @@ extension CoreSearchResultStub {
         )
         let result = CoreSearchResultStub(
             id: UUID().uuidString,
+            mapboxId: "",
             type: .place,
             names: ["Some Place Name"],
             languages: ["en"],
@@ -183,6 +192,7 @@ extension CoreSearchResultStub {
         )
         let result = CoreSearchResultStub(
             id: UUID().uuidString,
+            mapboxId: "",
             type: .place,
             names: ["Some Place Name"],
             languages: ["en"],

--- a/Tests/MapboxSearchTests/Common/Data Samples/SearchCategorySuggestion+Samples.swift
+++ b/Tests/MapboxSearchTests/Common/Data Samples/SearchCategorySuggestion+Samples.swift
@@ -3,6 +3,7 @@ import XCTest
 
 extension SearchCategorySuggestionImpl {
     static let sample1 = SearchCategorySuggestionImpl(coreResult: CoreSearchResultStub(id: "sample-2",
+                                                                                       mapboxId: "sample-2",
                                                                                        type: .category,
                                                                                        centerLocation: nil),
                                                       response: CoreSearchResponseStub(id: 42,

--- a/Tests/MapboxSearchTests/Common/Data Samples/SearchQuerySuggestionImpl+Samples.swift
+++ b/Tests/MapboxSearchTests/Common/Data Samples/SearchQuerySuggestionImpl+Samples.swift
@@ -3,6 +3,7 @@ import XCTest
 
 extension SearchQuerySuggestionImpl {
     static let sample1 = SearchQuerySuggestionImpl(coreResult: CoreSearchResultStub(id: "sample-43",
+                                                                                    mapboxId: "sample-43",
                                                                                     type: .query,
                                                                                     centerLocation: nil),
                                                    response: CoreSearchResponseStub(id: 42,

--- a/Tests/MapboxSearchTests/Common/Models/Search Result/SearchResultSuggestionImplTests.swift
+++ b/Tests/MapboxSearchTests/Common/Models/Search Result/SearchResultSuggestionImplTests.swift
@@ -6,26 +6,29 @@ import CwlPreconditionTesting
 class SearchResultSuggestionImplTests: XCTestCase {
     func testSuccessfulInitForAddressType() throws {
         let suggestionImpl = try XCTUnwrap(SearchResultSuggestionImpl(coreResult: CoreSearchResultStub(id: "sample-2",
-                                                                                                         type: .address,
-                                                                                                         centerLocation: nil),
-                                                                        response: CoreSearchResponseStub(id: 42,
-                                                                                                         options: .sample1,
-                                                                                                         result: .success([]))))
+                                                                                                       mapboxId: "sample-2",
+                                                                                                       type: .address,
+                                                                                                       centerLocation: nil),
+                                                                      response: CoreSearchResponseStub(id: 42,
+                                                                                                       options: .sample1,
+                                                                                                       result: .success([]))))
         XCTAssertEqual(suggestionImpl.suggestionType, .address(subtypes: [.address]))
     }
     
     func testSuccessfulInitForPOIType() throws {
         let suggestionImpl = try XCTUnwrap(SearchResultSuggestionImpl(coreResult: CoreSearchResultStub(id: "sample-2",
-                                                                                                         type: .poi,
-                                                                                                         centerLocation: nil),
-                                                                        response: CoreSearchResponseStub(id: 42,
-                                                                                                         options: .sample1,
-                                                                                                         result: .success([]))))
+                                                                                                       mapboxId: "sample-2",
+                                                                                                       type: .poi,
+                                                                                                       centerLocation: nil),
+                                                                      response: CoreSearchResponseStub(id: 42,
+                                                                                                       options: .sample1,
+                                                                                                       result: .success([]))))
         XCTAssertEqual(suggestionImpl.suggestionType, .POI)
     }
     
     func testFailedInit() throws {
         XCTAssertNil(SearchResultSuggestionImpl(coreResult: CoreSearchResultStub(id: "sample-2",
+                                                                                 mapboxId: "sample-2",
                                                                                  type: .category,
                                                                                  centerLocation: nil),
                                                 response: CoreSearchResponseStub(id: 42,
@@ -40,6 +43,7 @@ class SearchResultSuggestionImplTests: XCTestCase {
 
         let exception = catchBadInstruction {
             _ = SearchResultSuggestionImpl(coreResult: CoreSearchResultStub(id: "sample-2",
+                                                                            mapboxId: "sample-2",
                                                                             type: .category,
                                                                             centerLocation: .sample1),
                                            response: CoreSearchResponseStub(id: 42,

--- a/Tests/MapboxSearchTests/Common/Models/Search Result/ServerSearchResultTests.swift
+++ b/Tests/MapboxSearchTests/Common/Models/Search Result/ServerSearchResultTests.swift
@@ -3,35 +3,35 @@ import XCTest
 
 class ServerSearchResultTests: XCTestCase {
     func testServerSearchResultNilForUnknownType() {
-        let result = ServerSearchResult(coreResult: CoreSearchResultStub(id: UUID().uuidString, type: .unknown),
+        let result = ServerSearchResult(coreResult: CoreSearchResultStub(id: UUID().uuidString, mapboxId: "", type: .unknown),
                                         response: CoreSearchResponseStub.failureSample)
         
         XCTAssertNil(result)
     }
     
     func testServerSearchResultNilForCategoryType() {
-        let result = ServerSearchResult(coreResult: CoreSearchResultStub(id: UUID().uuidString, type: .category),
+        let result = ServerSearchResult(coreResult: CoreSearchResultStub(id: UUID().uuidString, mapboxId: "", type: .category),
                                         response: CoreSearchResponseStub.failureSample)
         
         XCTAssertNil(result)
     }
     
     func testServerSearchResultNilForUserRecordType() {
-        let result = ServerSearchResult(coreResult: CoreSearchResultStub(id: UUID().uuidString, type: .userRecord),
+        let result = ServerSearchResult(coreResult: CoreSearchResultStub(id: UUID().uuidString, mapboxId: "", type: .userRecord),
                                         response: CoreSearchResponseStub.failureSample)
         
         XCTAssertNil(result)
     }
     
     func testServerSearchResultNilForMissingCoordinates() {
-        let result = ServerSearchResult(coreResult: CoreSearchResultStub(id: UUID().uuidString, type: .userRecord, centerLocation: nil),
+        let result = ServerSearchResult(coreResult: CoreSearchResultStub(id: UUID().uuidString, mapboxId: "", type: .userRecord, centerLocation: nil),
                                         response: CoreSearchResponseStub.failureSample)
         
         XCTAssertNil(result)
     }
     
     func testServerSearchResultPOIFields() throws {
-        let coreResult = CoreSearchResultStub(id: UUID().uuidString, type: .poi)
+        let coreResult = CoreSearchResultStub(id: UUID().uuidString, mapboxId: "", type: .poi)
         let result = try XCTUnwrap(ServerSearchResult(coreResult: coreResult,
                                                       response: CoreSearchResponseStub.failureSample))
         XCTAssertEqual(result.suggestionType, .POI)
@@ -45,7 +45,7 @@ class ServerSearchResultTests: XCTestCase {
     }
     
     func testServerSearchResultAddressType() throws {
-        let coreResult = CoreSearchResultStub(id: UUID().uuidString, type: .address)
+        let coreResult = CoreSearchResultStub(id: UUID().uuidString, mapboxId: "", type: .address)
         let result = try XCTUnwrap(ServerSearchResult(coreResult: coreResult,
                                                       response: CoreSearchResponseStub.failureSample))
         XCTAssertEqual(result.suggestionType, .address(subtypes: [.address]))

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/CoreSearchResultStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/CoreSearchResultStub.swift
@@ -4,6 +4,7 @@ import CoreLocation
 class CoreSearchResultStub: CoreSearchResultProtocol {
     init(
         id: String,
+        mapboxId: String?,
         resultAccuracy: CoreAccuracy? = nil,
         type: CoreResultType,
         names: [String] = ["sample-name1", "sample-name2"],
@@ -24,6 +25,7 @@ class CoreSearchResultStub: CoreSearchResultProtocol {
         estimatedTime: Measurement<UnitDuration>? = nil
     ) {
         self.id = id
+        self.mapboxId = mapboxId
         self.resultAccuracy = resultAccuracy
         self.resultTypes = [type]
         self.names = names
@@ -46,6 +48,7 @@ class CoreSearchResultStub: CoreSearchResultProtocol {
     convenience init(dataProviderRecord: TestDataProviderRecord) {
         self.init(
             id: dataProviderRecord.id,
+            mapboxId: dataProviderRecord.mapboxId,
             type: dataProviderRecord.type.coreType,
             names: [dataProviderRecord.name],
             languages: ["en"]
@@ -53,6 +56,7 @@ class CoreSearchResultStub: CoreSearchResultProtocol {
     }
     
     var id: String
+    var mapboxId: String?
     var resultAccuracy: CoreAccuracy?
     var resultTypes: [CoreResultType]
     var type: CoreResultType { resultTypes.first ?? .unknown }
@@ -98,6 +102,7 @@ class CoreSearchResultStub: CoreSearchResultProtocol {
 extension CoreSearchResultStub: Equatable {
     static func == (lhs: CoreSearchResultStub, rhs: CoreSearchResultStub) -> Bool {
         return lhs.id == rhs.id
+        && lhs.mapboxId == rhs.mapboxId
         && lhs.type == rhs.type
         && lhs.names == rhs.names
         && lhs.languages == rhs.languages
@@ -116,7 +121,7 @@ extension CoreSearchResultStub: Equatable {
 extension CoreSearchResultProtocol {
     var asCoreSearchResult: CoreSearchResult {
         CoreSearchResult(id: id,
-                         mapboxId: nil,
+                         mapboxId: mapboxId,
                          types: resultTypes.map({ NSNumber(value: $0.rawValue) }),
                          names: names,
                          languages: languages,

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/SearchResultSuggestionStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/SearchResultSuggestionStub.swift
@@ -8,7 +8,9 @@ struct SearchResultSuggestionStub: SearchResultSuggestion {
     var dataLayerIdentifier: String = "tests-dataLayerIdentifier"
     
     var id: String = UUID().uuidString
-    
+
+    var mapboxId: String? = ""
+
     var name: String = "Name for UnitTests"
     
     var address: Address?

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/SearchSuggestionStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/SearchSuggestionStub.swift
@@ -3,6 +3,7 @@ import CoreLocation
 
 struct SearchSuggestionStub: SearchSuggestion {
     var id: String = UUID().uuidString
+    var mapboxId: String? = ""
     var name: String = "Test Name"
     var categories: [String]?
     var descriptionText: String? = "Test Description"

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/TestDataProviderRecord.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/TestDataProviderRecord.swift
@@ -4,6 +4,7 @@ import CoreLocation
 struct TestDataProviderRecord: IndexableRecord, SearchResult {
     var type: SearchResultType
     var id: String = UUID().uuidString
+    var mapboxId: String = UUID().uuidString // TODO: Revisit
     var accuracy: SearchResultAccuracy?
     var name: String
     var matchingName: String?

--- a/Tests/MapboxSearchTests/Legacy/SearchCategorySuggestionImplTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/SearchCategorySuggestionImplTests.swift
@@ -5,6 +5,7 @@ import CoreLocation
 class SearchCategorySuggestionImplTests: XCTestCase {
     func testSuccessfulInit() throws {
         let suggestionImpl = try XCTUnwrap(SearchCategorySuggestionImpl(coreResult: CoreSearchResultStub(id: "sample-2",
+                                                                                                         mapboxId: "sample-2",
                                                                                                          type: .category,
                                                                                                          centerLocation: nil),
                                                                         response: CoreSearchResponseStub(id: 42,
@@ -14,7 +15,7 @@ class SearchCategorySuggestionImplTests: XCTestCase {
     }
     
     func testFailedInitForPOI() throws {
-        XCTAssertNil(SearchCategorySuggestionImpl(coreResult: CoreSearchResultStub(id: "sample-1", type: .poi, centerLocation: nil),
+        XCTAssertNil(SearchCategorySuggestionImpl(coreResult: CoreSearchResultStub(id: "sample-1", mapboxId: "", type: .poi, centerLocation: nil),
                                                   response: CoreSearchResponseStub(id: 42,
                                                                                    options: .sample1,
                                                                                    result: .success([]))))

--- a/Tests/MapboxSearchTests/Use Cases/Place Autocomplete/PlaceAutocomplet.Result+Tests.swift
+++ b/Tests/MapboxSearchTests/Use Cases/Place Autocomplete/PlaceAutocomplet.Result+Tests.swift
@@ -7,6 +7,7 @@ final class PlaceAutocompleteResultTests: XCTestCase {
     func testResultContainsISOCountryCodes() {
         let coreResult = CoreSearchResultStub(
             id: UUID().uuidString,
+            mapboxId: "",
             type: .address
         )
         coreResult.metadata = .make(data: [


### PR DESCRIPTION
### Description
**Ticket**: [SSDK-536](https://mapbox.atlassian.net/browse/SSDK-536)

- Add support for `mapboxId` field in SearchCategorySuggestion, SearchQuerySuggestion, SearchResultSuggestion, SearchSuggestion and other classes to propagate mapbox_id value when available in API responses

### Checklist
- [x] Update `CHANGELOG`


[SSDK-536]: https://mapbox.atlassian.net/browse/SSDK-536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ