### PR TITLE
[SSDK-133] Disambiguate MapboxPanelController.PanelConfiguration struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
+- [SearchUI] Rename MapboxPanelController.Configuration to .PanelConfiguration. This disambiguates PanelConfiguration from the broader Configuration struct.
 - [Core] Update SwiftLint to 0.54.0 and SwiftFormat to 0.52.11
 - [Core] Fix project compliance with linter, reformat Swift files
 - [Core] Add Brewfile for project

--- a/Sources/MapboxSearchUI/MapboxPanelController.swift
+++ b/Sources/MapboxSearchUI/MapboxPanelController.swift
@@ -16,7 +16,7 @@ public class MapboxPanelController: UIViewController {
     }
 
     /// Configuration for `MapboxPanelController` class. Use `.default` for default cases
-    public struct Configuration {
+    public struct PanelConfiguration {
         var topOffset: CGFloat = 40
 
         lazy var topDraggingWall = topOffset
@@ -29,7 +29,7 @@ public class MapboxPanelController: UIViewController {
         public var initialState: State
 
         /// Configuration with set of default values.
-        public static let `default` = Configuration()
+        public static let `default` = PanelConfiguration()
 
         /// Make new `Configuration` instance for `MapboxPanelController`
         /// - Parameter state: Initial state of `MapboxPanelController`
@@ -42,7 +42,7 @@ public class MapboxPanelController: UIViewController {
         }
     }
 
-    var configuration: Configuration
+    var configuration: PanelConfiguration
 
     /// Damping ration animation parameter
     public var dampingRatio: CGFloat = 0.7
@@ -103,11 +103,11 @@ public class MapboxPanelController: UIViewController {
         return searchController?.configuration
     }
 
-    /// Make new `MapboxPanelController` with custom `Configuration`
+    /// Make new `MapboxPanelController` with custom `PanelConfiguration`
     /// - Parameters:
     ///   - rootViewController: Root controller to be embedded into MapboxPanelController
-    ///   - configuration: Configuration for MapboxPanelController. Defaults to `.default`
-    public init(rootViewController: UIViewController, configuration: Configuration = .default) {
+    ///   - configuration: PanelConfiguration for MapboxPanelController. Defaults to `.default`
+    public init(rootViewController: UIViewController, configuration: PanelConfiguration = .default) {
         self.panelNavigationController = UINavigationController(rootViewController: rootViewController)
         panelNavigationController.isNavigationBarHidden = true
         self.configuration = configuration


### PR DESCRIPTION
### Description
Fixes [SSDK-133](https://mapbox.atlassian.net/browse/SSDK-133)

- Documentation pages for [MapboxPanelController.Configuration](https://docs.mapbox.com/ios/search/api/ui/2.0.0-alpha.1/Classes/MapboxPanelController/Configuration.html) (old name, old link) would highlight navigation to Configuration.swift which was incorrect and confusing
- Separating MapboxPanelController.PanelConfiguration from the more broadly used [Configuration](https://docs.mapbox.com/ios/search/api/ui/2.0.0-alpha.1/Structs/Configuration.html) (heavily used by MapboxSearchController) resolves this ambiguity and makes the documentation pages clear with correct link navigation.

### Checklist
- [x] Update `CHANGELOG`

### Screenshots

Corrected behavior

| MapboxPanelController.PanelConfiguration | Configuration |
| -- | -- |
| <img width="100%" alt="Screenshot 2024-01-22 at 17 04 28" src="https://github.com/mapbox/mapbox-search-ios/assets/384288/7963c954-73fb-468b-89c0-db70af9265a5"> | <img width="100%" alt="Screenshot 2024-01-22 at 17 04 31" src="https://github.com/mapbox/mapbox-search-ios/assets/384288/44dc0c13-d78c-40b0-867e-7d726c302fad"> |

[SSDK-133]: https://mapbox.atlassian.net/browse/SSDK-133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ