### PR TITLE
Fix ev charging station canonical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
+- [Discover] Fix charging station category canonical ID
 - [SearchUI] Rename MapboxPanelController.Configuration to .PanelConfiguration. This disambiguates PanelConfiguration from the broader Configuration struct.
 - [Core] Update SwiftLint to 0.54.0 and SwiftFormat to 0.52.11
 - [Core] Fix project compliance with linter, reformat Swift files

--- a/Sources/MapboxSearchUI/SearchCategory.swift
+++ b/Sources/MapboxSearchUI/SearchCategory.swift
@@ -142,7 +142,7 @@ extension SearchCategory {
     /// EV Charging station category.
     public static let chargingStation =
         SearchCategory(
-            canonicalId: "ev_charging_station",
+            canonicalId: "charging_station",
             name: Strings.Categories.chargingStation,
             legacyName: "charging station",
             iconName: Maki.chargingStation.xcassetName


### PR DESCRIPTION
### Description

- Correct EV Charging Station category SBS and search-box canonical ID
- Compare against category list from `search/searchbox/v1/list/category`
    - docs: https://docs.mapbox.com/api/search/search-box/#list-categories

#### Steps to reproduce

1. Change the CategorySearchEngine initializer in MapboxSearchController to use SBS
2. Build and run 
3. In the SearchUI tab tap the "Charging Station" category
- Result before this change: No results
- Actual result / fixed result: EV Charging Station Results are shown

```diff
diff --git a/Sources/MapboxSearchUI/MapboxSearchController.swift b/Sources/MapboxSearchUI/MapboxSearchController.swift
index e133df99..39ec0b60 100644
--- a/Sources/MapboxSearchUI/MapboxSearchController.swift
+++ b/Sources/MapboxSearchUI/MapboxSearchController.swift
@@ -154,7 +154,8 @@ public class MapboxSearchController: UIViewController {
     public required init(accessToken: String, configuration: Configuration = Configuration()) {
         self.categorySearchEngine = CategorySearchEngine(
             accessToken: accessToken,
-            locationProvider: configuration.locationProvider
+            locationProvider: configuration.locationProvider,
+            supportSBS: true
         )
         self.searchEngine = SearchEngine(accessToken: accessToken, locationProvider: configuration.locationProvider)
         self.configuration = configuration
@@ -171,7 +172,7 @@ public class MapboxSearchController: UIViewController {
     /// - Parameters:
     ///   - configuration: configuration for search and categorySearch engines.
     public required init(configuration: Configuration = Configuration()) {
-        self.categorySearchEngine = CategorySearchEngine(locationProvider: configuration.locationProvider)
+        self.categorySearchEngine = CategorySearchEngine(locationProvider: configuration.locationProvider, supportSBS: true)
         self.searchEngine = SearchEngine(locationProvider: configuration.locationProvider)
         self.configuration = configuration
 
```

### Checklist
- [x] Update `CHANGELOG`
