### PR TITLE
[SSDK-544] Replace supportSBS binary with expandable ApiType enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
+- [Core] Change AbstractSearchEngine.init `supportSBS: Bool = false` parameter to `apiType: ApiType = .SBS`. This changes the default API engine for discover/category and other API requests to SBS. Add ApiType enum to represent non-Autofill and non-PlaceAutocomplete SearchEngine API types.
 - [SearchUI] Rename MapboxPanelController.Configuration to .PanelConfiguration. This disambiguates PanelConfiguration from the broader Configuration struct.
 - [Core] Update SwiftLint to 0.54.0 and SwiftFormat to 0.52.11
 - [Core] Fix project compliance with linter, reformat Swift files

--- a/MapboxSearch.xcodeproj/project.pbxproj
+++ b/MapboxSearch.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		043A3D4D2B30F38300DB681B /* CoreAddress+AddressComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043A3D4C2B30F38300DB681B /* CoreAddress+AddressComponents.swift */; };
 		04C0848D2B4C82F3002F9C69 /* SdkInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C0848C2B4C82F3002F9C69 /* SdkInformation.swift */; };
+		04C127552B62F6BC00884325 /* ApiType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C127542B62F6BC00884325 /* ApiType.swift */; };
+		04C127582B62FFDB00884325 /* ApiType+Core.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C127572B62FFDB00884325 /* ApiType+Core.swift */; };
 		04E5FF962B48828500DADC18 /* SearchAddressCountry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E5FF952B48828500DADC18 /* SearchAddressCountry.swift */; };
 		04E5FF992B48829200DADC18 /* SearchAddressRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E5FF982B48829200DADC18 /* SearchAddressRegion.swift */; };
 		140D1BDC286DB479001A51C2 /* SearchResultAccuracy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140D1BDB286DB479001A51C2 /* SearchResultAccuracy.swift */; };
@@ -481,6 +483,8 @@
 /* Begin PBXFileReference section */
 		043A3D4C2B30F38300DB681B /* CoreAddress+AddressComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CoreAddress+AddressComponents.swift"; sourceTree = "<group>"; };
 		04C0848C2B4C82F3002F9C69 /* SdkInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdkInformation.swift; sourceTree = "<group>"; };
+		04C127542B62F6BC00884325 /* ApiType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiType.swift; sourceTree = "<group>"; };
+		04C127572B62FFDB00884325 /* ApiType+Core.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ApiType+Core.swift"; sourceTree = "<group>"; };
 		04E5FF952B48828500DADC18 /* SearchAddressCountry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchAddressCountry.swift; sourceTree = "<group>"; };
 		04E5FF982B48829200DADC18 /* SearchAddressRegion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchAddressRegion.swift; sourceTree = "<group>"; };
 		140D1BDB286DB479001A51C2 /* SearchResultAccuracy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultAccuracy.swift; sourceTree = "<group>"; };
@@ -897,6 +901,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		04C127562B62FFD000884325 /* Engine */ = {
+			isa = PBXGroup;
+			children = (
+				04C127572B62FFDB00884325 /* ApiType+Core.swift */,
+			);
+			path = Engine;
+			sourceTree = "<group>";
+		};
 		04E5FF972B48829200DADC18 /* Region */ = {
 			isa = PBXGroup;
 			children = (
@@ -1364,6 +1376,7 @@
 			isa = PBXGroup;
 			children = (
 				FEEDD2E32508DFE400DC0A98 /* AbstractSearchEngine.swift */,
+				04C127542B62F6BC00884325 /* ApiType.swift */,
 				FEEDD2D82508DFE400DC0A98 /* SearchEngine.swift */,
 				FEEDD2EB2508DFE400DC0A98 /* CategorySearchEngine.swift */,
 				04C0848C2B4C82F3002F9C69 /* SdkInformation.swift */,
@@ -1546,6 +1559,7 @@
 		FEEDD2C12508DFE400DC0A98 /* InternalAPI */ = {
 			isa = PBXGroup;
 			children = (
+				04C127562B62FFD000884325 /* Engine */,
 				148DE66E285777050085684D /* Common */,
 				F98BECBB2577B9150081D3BC /* Telemetry */,
 				FEEDD2C32508DFE400DC0A98 /* Array+Extensions.swift */,
@@ -2350,6 +2364,7 @@
 				F93DA6FF274E4B86005595B5 /* CoreSearchEngineStatics.swift in Sources */,
 				14F71865299FD4BD00D5BC2E /* PlaceAutocomplete+PlaceType.swift in Sources */,
 				F9F6378A25DD6A4E00C99904 /* FeedbackManager.swift in Sources */,
+				04C127582B62FFDB00884325 /* ApiType+Core.swift in Sources */,
 				148DE65D28574E6E0085684D /* AddressAutofill.swift in Sources */,
 				140E47A7298BCBDF00677E30 /* Discover+Query.swift in Sources */,
 				FEEDD3092508DFE400DC0A98 /* CodablePersistentService.swift in Sources */,
@@ -2443,6 +2458,7 @@
 				FEEDD3152508DFE400DC0A98 /* ServerSearchResult.swift in Sources */,
 				140E47A2298BC90E00677E30 /* Discover.swift in Sources */,
 				14FA65872953644400056E5B /* PlaceAutocomplete+Suggestion.swift in Sources */,
+				04C127552B62F6BC00884325 /* ApiType.swift in Sources */,
 				FE059C5A251A0AE6001F7701 /* SearchCategorySuggestionImpl.swift in Sources */,
 				FEEDD2F62508DFE400DC0A98 /* CoreSearchResultResponse.swift in Sources */,
 				FE260A6725C063880037B725 /* ReverseGeocodingOptions.swift in Sources */,

--- a/Sources/MapboxSearch/InternalAPI/Engine/ApiType+Core.swift
+++ b/Sources/MapboxSearch/InternalAPI/Engine/ApiType+Core.swift
@@ -1,0 +1,14 @@
+// Copyright © 2024 Mapbox. All rights reserved.
+
+import Foundation
+
+extension ApiType {
+    func toCore() -> CoreSearchEngine.ApiType {
+        switch self {
+        case .geocoding:
+            return .geocoding
+        case .SBS:
+            return .SBS
+        }
+    }
+}

--- a/Sources/MapboxSearch/PublicAPI/Engine/AbstractSearchEngine.swift
+++ b/Sources/MapboxSearch/PublicAPI/Engine/AbstractSearchEngine.swift
@@ -68,12 +68,12 @@ public class AbstractSearchEngine: FeedbackManagerDelegate {
             )
         }
 
-        self.apiType = apiType
         self.locationProvider = locationProvider
         self.locationProviderWrapper = WrapperLocationProvider(wrapping: locationProvider)
         self.eventsManager = serviceProvider.eventsManager
         self.feedbackManager = serviceProvider.feedbackManager
         self.defaultSearchOptions = defaultSearchOptions
+        self.apiType = apiType
         self.engineApi = apiType.toCore()
 
         self.userActivityReporter = .getOrCreate(

--- a/Sources/MapboxSearch/PublicAPI/Engine/AbstractSearchEngine.swift
+++ b/Sources/MapboxSearch/PublicAPI/Engine/AbstractSearchEngine.swift
@@ -20,8 +20,8 @@ public class AbstractSearchEngine: FeedbackManagerDelegate {
 
     var locationProviderWrapper: WrapperLocationProvider?
 
-    /// SearchEngine supports the latest Single-Box Search APIs
-    public let supportSBS: Bool
+    /// Provide a specific API type
+    public let apiType: ApiType
 
     /// Location provider for search results `proximity` argument
     public let locationProvider: LocationProvider?
@@ -54,13 +54,13 @@ public class AbstractSearchEngine: FeedbackManagerDelegate {
     ///   - locationProvider: Provider configuration of LocationProvider that would grant location data by default
     ///   - serviceProvider: Internal `ServiceProvider` for sharing common dependencies like favoritesService or
     /// eventsManager
-    ///   - supportSBS: enable support the latest Single-Box Search APIs
+    ///   - apiType: choose which API provider to use through this search engine
     init(
         accessToken: String? = nil,
         serviceProvider: ServiceProviderProtocol & EngineProviderProtocol,
         locationProvider: LocationProvider? = DefaultLocationProvider(),
         defaultSearchOptions: SearchOptions = SearchOptions(),
-        supportSBS: Bool = false
+        apiType: ApiType = .SBS
     ) {
         guard let accessToken = accessToken ?? serviceProvider.getStoredAccessToken() else {
             fatalError(
@@ -68,13 +68,13 @@ public class AbstractSearchEngine: FeedbackManagerDelegate {
             )
         }
 
-        self.supportSBS = supportSBS
+        self.apiType = apiType
         self.locationProvider = locationProvider
         self.locationProviderWrapper = WrapperLocationProvider(wrapping: locationProvider)
         self.eventsManager = serviceProvider.eventsManager
         self.feedbackManager = serviceProvider.feedbackManager
         self.defaultSearchOptions = defaultSearchOptions
-        self.engineApi = supportSBS ? .SBS : .geocoding
+        self.engineApi = apiType.toCore()
 
         self.userActivityReporter = .getOrCreate(
             for: .init(
@@ -110,19 +110,19 @@ public class AbstractSearchEngine: FeedbackManagerDelegate {
     /// for `nil` argument
     ///   - locationProvider: Provider configuration of LocationProvider that would grant location data by default
     ///   - defaultSearchOptions: Default options to use when `nil` was passed to the `search(…: options:)` call
-    ///   - supportSBS: enable support the latest Single-Box Search APIs
+    ///   - apiType: choose which API provider to use through this search engine
     public convenience init(
         accessToken: String? = nil,
         locationProvider: LocationProvider? = DefaultLocationProvider(),
         defaultSearchOptions: SearchOptions = SearchOptions(),
-        supportSBS: Bool = false
+        apiType: ApiType = .SBS
     ) {
         self.init(
             accessToken: accessToken,
             serviceProvider: ServiceProvider.shared,
             locationProvider: locationProvider,
             defaultSearchOptions: defaultSearchOptions,
-            supportSBS: supportSBS
+            apiType: apiType
         )
     }
 

--- a/Sources/MapboxSearch/PublicAPI/Engine/ApiType.swift
+++ b/Sources/MapboxSearch/PublicAPI/Engine/ApiType.swift
@@ -1,0 +1,12 @@
+// Copyright © 2024 Mapbox. All rights reserved.
+
+import Foundation
+
+/// Determine which Mapbox API to use for a SearchEngine instance
+public enum ApiType {
+    /// The Mapbox Geocoding (a.k.a V5) API - https://docs.mapbox.com/api/search/geocoding/
+    case geocoding
+
+    /// The Mapbox Single Box Search (a.k.a Federation API) - https://docs.mapbox.com/api/search/search/
+    case SBS
+}

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Discover API/Discover.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Discover API/Discover.swift
@@ -23,7 +23,7 @@ public final class Discover {
         let searchEngine = CategorySearchEngine(
             accessToken: accessToken,
             locationProvider: locationProvider,
-            supportSBS: true
+            apiType: .SBS
         )
 
         let userActivityReporter = CoreUserActivityReporter.getOrCreate(

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/PlaceAutocomplete.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/PlaceAutocomplete.swift
@@ -13,7 +13,7 @@ public final class PlaceAutocomplete {
     private let userActivityReporter: CoreUserActivityReporterProtocol
 
     private static var apiType: CoreSearchEngine.ApiType {
-        return .SBS
+        return .searchBox
     }
 
     /// Basic internal initializer

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/PlaceAutocomplete.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/PlaceAutocomplete.swift
@@ -13,7 +13,7 @@ public final class PlaceAutocomplete {
     private let userActivityReporter: CoreUserActivityReporterProtocol
 
     private static var apiType: CoreSearchEngine.ApiType {
-        return .searchBox
+        return .SBS
     }
 
     /// Basic internal initializer

--- a/Sources/MapboxSearchUI/MapboxSearchController.swift
+++ b/Sources/MapboxSearchUI/MapboxSearchController.swift
@@ -636,7 +636,7 @@ extension MapboxSearchController: SearchCategoriesRootViewDelegate {
     }
 
     func userSelectedCategory(_ category: SearchCategory) {
-        let categoryName = categorySearchEngine.supportSBS ? category.canonicalId : category.legacyName
+        let categoryName = categorySearchEngine.apiType == .geocoding ? category.legacyName : category.canonicalId
 
         categorySearchEngine.search(categoryName: categoryName, options: categorySearchOptions) { results in
             switch results {

--- a/Tests/MapboxSearchIntegrationTests/CategorySearchEngineIntegrationTests.swift
+++ b/Tests/MapboxSearchIntegrationTests/CategorySearchEngineIntegrationTests.swift
@@ -6,7 +6,7 @@ class CategorySearchEngineIntegrationTests: MockServerTestCase {
     lazy var searchEngine = CategorySearchEngine(
         accessToken: "access-token",
         locationProvider: DefaultLocationProvider(),
-        supportSBS: true
+        apiType: .SBS
     )
 
     func testCategorySearch() throws {

--- a/Tests/MapboxSearchIntegrationTests/PlaceAutocompleteIntegrationTests.swift
+++ b/Tests/MapboxSearchIntegrationTests/PlaceAutocompleteIntegrationTests.swift
@@ -38,7 +38,8 @@ final class PlaceAutocompleteIntegrationTests: MockServerTestCase {
         wait(for: [expectation], timeout: 5)
 
         let selectionExpectation = XCTestExpectation(description: "Expecting selection result")
-        placeAutocomplete.select(suggestion: suggestion!) { result in
+        let unwrappedSuggestion = try XCTUnwrap(suggestion)
+        placeAutocomplete.select(suggestion: unwrappedSuggestion) { result in
             switch result {
             case .success(let resolvedSuggestion):
                 XCTAssertEqual(resolvedSuggestion.name, "San Francisco")
@@ -92,7 +93,8 @@ final class PlaceAutocompleteIntegrationTests: MockServerTestCase {
 
         try server.setResponse(.retrieveMinsk)
         let selectionExpectation = XCTestExpectation(description: "Expecting selection result")
-        placeAutocomplete.select(suggestion: suggestion!) { result in
+        let unwrappedSuggestion = try XCTUnwrap(suggestion)
+        placeAutocomplete.select(suggestion: unwrappedSuggestion) { result in
             switch result {
             case .success(let resolvedSuggestion):
                 XCTAssertEqual(resolvedSuggestion.name, "Minsk")
@@ -225,7 +227,8 @@ final class PlaceAutocompleteIntegrationTests: MockServerTestCase {
 
         try server.setResponse(.retrievePoi)
         let selectionExpectation = XCTestExpectation(description: "Expecting selection result")
-        placeAutocomplete.select(suggestion: suggestion!) { result in
+        let unwrappedSuggestion = try XCTUnwrap(suggestion)
+        placeAutocomplete.select(suggestion: unwrappedSuggestion) { result in
             switch result {
             case .success(let resolvedSuggestion):
                 XCTAssertEqual(resolvedSuggestion.name, "Starbucks")

--- a/Tests/MapboxSearchIntegrationTests/SearchEngineIntegrationTests.swift
+++ b/Tests/MapboxSearchIntegrationTests/SearchEngineIntegrationTests.swift
@@ -7,7 +7,7 @@ class SearchEngineIntegrationTests: MockServerTestCase {
     lazy var searchEngine = SearchEngine(
         accessToken: "access-token",
         locationProvider: DefaultLocationProvider(),
-        supportSBS: true
+        apiType: .SBS
     )
 
     override func setUpWithError() throws {


### PR DESCRIPTION
### Description

Fixes [SSDK-544](https://mapbox.atlassian.net/browse/SSDK-544)

- Change AbstractSearchEngine.init `supportSBS: Bool = false` parameter to `apiType: ApiType = .SBS`. 
- This changes the default API engine for discover/category and other API requests to SBS. 
- Add ApiType enum to represent non-Autofill and non-PlaceAutocomplete SearchEngine API types.
- This will be expanded to include the new [search-box](https://docs.mapbox.com/api/search/search-box/) API type

### Checklist
- [x] Update `CHANGELOG`


[SSDK-544]: https://mapbox.atlassian.net/browse/SSDK-544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ