### PR TITLE
Remove swifter from mapbox search target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
+- [Core] Remove Swifter library dependency from MapboxSearch target (only used in Test targets)
 - [Discover] Fix charging station category canonical ID
 - [SearchUI] Rename MapboxPanelController.Configuration to .PanelConfiguration. This disambiguates PanelConfiguration from the broader Configuration struct.
 - [Core] Update SwiftLint to 0.54.0 and SwiftFormat to 0.52.11

--- a/MapboxSearch.xcodeproj/project.pbxproj
+++ b/MapboxSearch.xcodeproj/project.pbxproj
@@ -45,10 +45,9 @@
 		148DE66C285757AA0085684D /* AddressAutofill+Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 148DE66B285757AA0085684D /* AddressAutofill+Result.swift */; };
 		148DE671285777180085684D /* NSLocking+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 148DE670285777180085684D /* NSLocking+Extensions.swift */; };
 		148DE68B285A18900085684D /* AddressAutofill+AddressComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 148DE68A285A18900085684D /* AddressAutofill+AddressComponent.swift */; };
-		149948E7290A8ACE00E7E619 /* Swifter in Frameworks */ = {isa = PBXBuildFile; productRef = 149948E6290A8ACE00E7E619 /* Swifter */; };
 		149948ED290A8DCA00E7E619 /* Swifter in Frameworks */ = {isa = PBXBuildFile; productRef = 149948EC290A8DCA00E7E619 /* Swifter */; };
 		149948EF290A8DD500E7E619 /* Swifter in Frameworks */ = {isa = PBXBuildFile; productRef = 149948EE290A8DD500E7E619 /* Swifter */; };
-		149948F1290A8DF900E7E619 /* Swifter in Frameworks */ = {isa = PBXBuildFile; productRef = 149948F0290A8DF900E7E619 /* Swifter */; };
+		149948F1290A8DF900E7E619 /* Swifter in Frameworks */ = {isa = PBXBuildFile; productRef = 149948F0290A8DF900E7E619 /* Swifter */; settings = {ATTRIBUTES = (Required, ); }; };
 		14A0B83D2A5FF20B00D281F1 /* PlaceAutocomplet.Result+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A0B83B2A5FF1B300D281F1 /* PlaceAutocomplet.Result+Tests.swift */; };
 		14B92D5E298BFD19006003C1 /* DiscoverViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B92D5D298BFD19006003C1 /* DiscoverViewController.swift */; };
 		14F71865299FD4BD00D5BC2E /* PlaceAutocomplete+PlaceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F71864299FD4BD00D5BC2E /* PlaceAutocomplete+PlaceType.swift */; };
@@ -835,7 +834,6 @@
 				E648C0B626428D2B0044315F /* MapboxCoreSearch.xcframework in Frameworks */,
 				E648C0BA26428D3D0044315F /* MapboxCommon.xcframework in Frameworks */,
 				E648C0C9264297A10044315F /* libc++.1.tbd in Frameworks */,
-				149948E7290A8ACE00E7E619 /* Swifter in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1805,7 +1803,6 @@
 			);
 			name = MapboxSearch;
 			packageProductDependencies = (
-				149948E6290A8ACE00E7E619 /* Swifter */,
 			);
 			productName = MapboxSearch;
 			productReference = 3A0D7E4C233522D4006D81BB /* MapboxSearch.framework */;
@@ -3357,11 +3354,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		149948E6290A8ACE00E7E619 /* Swifter */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 149948E5290A8ACE00E7E619 /* XCRemoteSwiftPackageReference "swifter" */;
-			productName = Swifter;
-		};
 		149948EC290A8DCA00E7E619 /* Swifter */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 149948E5290A8ACE00E7E619 /* XCRemoteSwiftPackageReference "swifter" */;


### PR DESCRIPTION
### Description

- Change Swifter mock HTTP server to "included in test targets - only" and remove from MapboxSearch framework
- There's no reason to include Swiftter in MapboxSearch/MapboxSearchUI.
- This is still required by the test targets
- Tests run as-before
- Fixes an issue running the MapboxSearch framework

### Checklist
- [x] Update `CHANGELOG`

#### Screenshots

| Before | After |
| -- | -- |
| <img width="940" alt="Screenshot 2024-01-31 at 10 32 40" src="https://github.com/mapbox/mapbox-search-ios/assets/384288/83ff9051-f231-4cc9-9ca6-1197c32c0db7"> Runtime crash for linker error | <img width="940" alt="Screenshot 2024-01-31 at 10 33 19" src="https://github.com/mapbox/mapbox-search-ios/assets/384288/f6618fef-c1bb-4b32-a13a-32b9a2187d84"> Fixed MapboxSearch target settings |
