### PR TITLE
[CI] Check for exact version matches during pre-release check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,8 @@ jobs:
       - parse-release-version
       - run:
           name: Check existing public release
-          command: curl -L https://api.mapbox.com/downloads/v2/carthage/search-sdk/MapboxSearch.json | grep -v "$VERSION"
+          # Escape the quotes to check for exact versions
+          command: curl -L https://api.mapbox.com/downloads/v2/carthage/search-sdk/MapboxSearch.json | grep -v \"$VERSION\"
 
   build:
     macos:


### PR DESCRIPTION
### Description

- Fix release-pre-check CircleCI step to check for exact version matches (inside double-quotes) during pre-release check
- The current behavior is failing for the 2.0.0 release because 2.0.0-alpha.1 is matching
- This fix will correct the behavior by searching for `"2.0.0"` which will not match against `"2.0.0-alpha.1"`

### Checklist
- [N/A] Update `CHANGELOG`
