### PR TITLE
Prepare v2.0.0-rc.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,11 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
+## 2.0.0-rc.2
+
 - [Discover] Add support for country, proximity, and origin parameters in Discover.Options search parameters. This fixes an issue when using search-along-route to query category results.
-
 - [SearchUI] Add `distanceFormatter` field to Configuration to support changing the search suggestions distance format. Nil values will use the default behavior.
-
 - [Core] Add xcprivacy for MapboxSearch and MapboxSearchUI
-
 - [SearchUI] Update Maki icons to all SVG, latest versions from https://github.com/mapbox/maki
 - [SearchUI] Remove all custom Maki icons
 - [Unit Tests] Update and correct tests for iOS 17 using all mocked data.

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearch'
-  s.version          = '2.0.0'
+  s.version          = '2.0.0-rc.2'
   s.summary          = 'Search SDK for Mapbox Search API '
 
 # This description is used to generate tags and improve search results.

--- a/MapboxSearchUI.podspec
+++ b/MapboxSearchUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearchUI'
-  s.version          = '2.0.0'
+  s.version          = '2.0.0-rc.2'
   s.summary          = 'Search UI for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ Once you've installed the prerequisites, no additional steps are needed: Open th
 
 You can find the following documentation pages helpful:
 - [Search SDK for iOS guide](https://docs.mapbox.com/ios/search/guides/)
-- [MapboxSearch reference](https://docs.mapbox.com/ios/search/api/core/2.0.0/)
-- [MapboxSearchUI reference](https://docs.mapbox.com/ios/search/api/ui/2.0.0/)
+- [MapboxSearch reference](https://docs.mapbox.com/ios/search/api/core/2.0.0-rc.2/)
+- [MapboxSearchUI reference](https://docs.mapbox.com/ios/search/api/ui/2.0.0-rc.2/)
 
 ## Project structure overview
 
@@ -108,13 +108,13 @@ MapboxSearchDemoApplication provides a Demo app wih MapboxSearchUI.framework pre
 ##### MapboxSearch
 To integrate latest preview version of `MapboxSearch` into your Xcode project using CocoaPods, specify it in your `Podfile`:  
 ```
-pod 'MapboxSearch', ">= 2.0.0", "< 3.0"
+pod 'MapboxSearch', ">= 2.0.0-rc.2", "< 3.0"
 ```
 
 ##### MapboxSearchUI
 To integrate latest preview version of `MapboxSearchUI` into your Xcode project using CocoaPods, specify it in your `Podfile`:  
 ```
-pod 'MapboxSearchUI', ">= 2.0.0", "< 3.0"
+pod 'MapboxSearchUI', ">= 2.0.0-rc.2", "< 3.0"
 ```
 
 ### Swift Package Manager

--- a/Search Documentation.docc/Installation.md
+++ b/Search Documentation.docc/Installation.md
@@ -59,7 +59,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearchUI', ">= 2.0.0", "< 3.0"
+      pod 'MapboxSearchUI', ">= 2.0.0-rc.2", "< 3.0"
     end
     ```
 
@@ -68,7 +68,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearch', ">= 2.0.0", "< 3.0"
+      pod 'MapboxSearch', ">= 2.0.0-rc.2", "< 3.0"
     end
     ```
 

--- a/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
+++ b/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
@@ -1,2 +1,2 @@
 /// Mapbox Search SDK version variable
-public let mapboxSearchSDKVersion = "2.0.0"
+public let mapboxSearchSDKVersion = "2.0.0-rc.2"


### PR DESCRIPTION
### Description

- Prepare 2.0.0-rc.2 release
- Update version number in documentation and SDK

### Checklist
- [x] Update `CHANGELOG`

### Changes

#### 2.0.0-rc.2

- [Discover] Add support for country, proximity, and origin parameters in Discover.Options search parameters. This fixes an issue when using search-along-route to query category results.
- [SearchUI] Add `distanceFormatter` field to Configuration to support changing the search suggestions distance format. Nil values will use the default behavior.
- [Core] Add xcprivacy for MapboxSearch and MapboxSearchUI
- [SearchUI] Update Maki icons to all SVG, latest versions from https://github.com/mapbox/maki
- [SearchUI] Remove all custom Maki icons
- [Unit Tests] Update and correct tests for iOS 17 using all mocked data.
- [UI Tests] Update and correct tests for iOS 17 using all mocked data.
- [Search] Rename `SearchEngine.reverseGeocoding` function to `SearchEngine.reverse`.
- [Core] Stop reading "MapboxAPIBaseURL" from UserDefaults in `ServiceProvider.createEngine`. (Providing a value in Info.plist is still supported).
- [Core] Remove Swifter library dependency from MapboxSearch target (only used in Test targets)
- [Core] Change AbstractSearchEngine.init `supportSBS: Bool = false` parameter to `apiType: ApiType = .SBS`. This changes the default API engine for discover/category and other API requests to SBS. Add ApiType enum to represent non-Autofill and non-PlaceAutocomplete SearchEngine API types.

**MapboxCoreSearch**: v2.0.0-alpha.13