### PR TITLE
[SSDK-643] Upgrade MapboxCoreSearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
+- [Core] Add `SearchResultAccuracy.proximate` case which "is a known address point but does not intersect a known rooftop/parcel."
+
 - [UI] Add Right-to-Left language support for Categories/Favorites segment control and fix xib errors.
 - [UI] Add Preview file for CategoriesFavoritesSegmentControl to fix compiler problems.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 - [Tests] Change MockResponse into a protocol, create separate enums conforming to MockResponse for each API type (geocoding, sbs, autofill), add MockResponse as generic to each test base class and MockWebServer.
 
+**MapboxCoreSearch**: v2.0.0-alpha.14
+
 ## 2.0.0-rc.2
 
 - [Discover] Add support for country, proximity, and origin parameters in Discover.Options search parameters. This fixes an issue when using search-along-route to query category results.

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.0.0-alpha.13
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.0.0-alpha.14
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.0.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.0.0"
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.0.0-alpha.13"
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.0.0-alpha.14"

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 import Foundation
 
-let (coreSearchVersion, coreSearchVersionHash) = ("2.0.0-alpha.14", "bbd236f9aae5a06c23a0541e79d7196e569880ef3e8cfbdd7a906875dde3b884")
+let (coreSearchVersion, coreSearchVersionHash) = ("2.0.0-alpha.14", "c3e61341f2beb1b8043f3c71caccdd9bea12a23f221cb90eb452e2abe299c3e0")
 
 let commonMinVersion = Version("24.0.0")
 let commonMaxVersion = Version("25.0.0")

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 import Foundation
 
-let (coreSearchVersion, coreSearchVersionHash) = ("2.0.0-alpha.13", "bbd236f9aae5a06c23a0541e79d7196e569880ef3e8cfbdd7a906875dde3b884")
+let (coreSearchVersion, coreSearchVersionHash) = ("2.0.0-alpha.14", "bbd236f9aae5a06c23a0541e79d7196e569880ef3e8cfbdd7a906875dde3b884")
 
 let commonMinVersion = Version("24.0.0")
 let commonMaxVersion = Version("25.0.0")

--- a/Sources/MapboxSearch/PublicAPI/SearchResultAccuracy.swift
+++ b/Sources/MapboxSearch/PublicAPI/SearchResultAccuracy.swift
@@ -17,6 +17,9 @@ public enum SearchResultAccuracy: String, Codable {
     /// Result is a known address point but has no specific accuracy.
     case point
 
+    /// Result is a known address point but does not intersect a known rooftop/parcel.
+    case proximate
+
     /// Result is for a specific building/entrance.
     case rooftop
 
@@ -34,6 +37,7 @@ extension SearchResultAccuracy {
         case .point: return .point
         case .rooftop: return .rooftop
         case .street: return .street
+        case .proximate: return .proximate
 
         @unknown default:
             return nil


### PR DESCRIPTION
### Description
Fixes https://mapbox.atlassian.net/browse/SSDK-643

- Upgrade MapboxCoreSearch to v2.0.0-alpha.14, built with Xcode 15.3
- This should resolve build issues with Xcode 15.3
- Add `SearchResultAccuracy.proximate` case which "is a known address point but does not intersect a known rooftop/parcel."

### Checklist
- [x] Update `CHANGELOG`

### Screenshots

| Xcode 14 Validation | Xcode 15 Validation |
| -- | -- |
| <img width="1734" alt="Screenshot 2024-03-21 at 10 34 33" src="https://github.com/mapbox/mapbox-search-ios/assets/384288/c5613958-890a-4f19-90f1-0b80d59a4ae2"> | <img width="1734" alt="Screenshot 2024-03-21 at 10 42 15" src="https://github.com/mapbox/mapbox-search-ios/assets/384288/0c9db0c7-708d-4700-8fa9-52c2ab14c008"> |

