### PR TITLE
Expose TileRegionLoadOptions ExtraOptions struct to provide extraOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
+- [Offline] Add `TileRegionLoadOptions.ExtraOptions` struct to provide strongly-typed accepted input into extra options parameter.
+
 ## 2.0.0-rc.3
 
 - [Core] Add `SearchResultAccuracy.proximate` case which "is a known address point but does not intersect a known rooftop/parcel."

--- a/Sources/Demo/MapRootController.swift
+++ b/Sources/Demo/MapRootController.swift
@@ -32,10 +32,13 @@ class MapRootController: UIViewController {
         engine.setOfflineMode(.enabled) {
             let descriptor = SearchOfflineManager.createDefaultTilesetDescriptor()
             let dcLocation = NSValue(cgPoint: CGPoint(x: 38.89992081005698, y: -77.03399849939174))
-            guard let options = MapboxCommon.TileRegionLoadOptions.build(
+            let extraOptions = TileRegionLoadOptions.ExtraOptions(forceRefresh: false)
+
+            guard let options = TileRegionLoadOptions.build(
                 geometry: Geometry(point: dcLocation),
                 descriptors: [descriptor],
-                acceptExpired: true
+                acceptExpired: true,
+                extraOptions: extraOptions
             ) else {
                 assertionFailure()
                 return

--- a/Sources/MapboxSearch/PublicAPI/Offline/TileRegionLoadOptions+Search.swift
+++ b/Sources/MapboxSearch/PublicAPI/Offline/TileRegionLoadOptions+Search.swift
@@ -13,6 +13,9 @@ extension TileRegionLoadOptions {
     ///         specified network types. If none of the specified network types
     ///         is available, the load request fails with an error.
     ///   - averageBytesPerSecond: Limits the download speed of the tile region.
+    ///   - extraOptions: Provide extra options, such as forceRefresh (will use `false` by default) in a container
+    /// struct. Nil input will use default behavior.
+    ///
     ///
     /// `averageBytesPerSecond` is not a strict bandwidth limit, but only
     /// limits the average download speed. tile regions may be temporarily
@@ -27,7 +30,8 @@ extension TileRegionLoadOptions {
         metadata: Any? = nil,
         acceptExpired: Bool = false,
         networkRestriction: NetworkRestriction = .none,
-        averageBytesPerSecond: Int? = nil
+        averageBytesPerSecond: Int? = nil,
+        extraOptions: ExtraOptions? = nil
     ) -> TileRegionLoadOptions? {
         if let metadata {
             guard JSONSerialization.isValidJSONObject(metadata) else {
@@ -43,7 +47,27 @@ extension TileRegionLoadOptions {
             networkRestriction: networkRestriction,
             startLocation: nil,
             averageBytesPerSecond: averageBytesPerSecond.map(NSNumber.init(value:)),
-            extraOptions: nil
+            extraOptions: extraOptions?.toCore()
         )
+    }
+}
+
+extension TileRegionLoadOptions {
+    /// Wraps extra options with Core-compatible inputs for building a `TileRegionLoadOptions`. Providing nil instead
+    public struct ExtraOptions {
+        /// If set to a true boolean value, all tiles in the group will be loaded instead of loading only missing or
+        /// expired tiles. Default value is false.
+        public var forceRefresh: Bool
+
+        public init(forceRefresh: Bool = false) {
+            self.forceRefresh = forceRefresh
+        }
+
+        /// Provide a Core-compatible object
+        func toCore() -> [String: Any] {
+            [
+                "force_refresh": forceRefresh,
+            ]
+        }
     }
 }


### PR DESCRIPTION
### Description

- Add `TileRegionLoadOptions.ExtraOptions` struct to provide strongly-typed accepted input into extra options parameter.

### Checklist
- [x] Update `CHANGELOG`
