### PR TITLE
[SSDK-622] Add language parameter to offline tileset descriptor creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Guide: https://keepachangelog.com/en/1.0.0/
 <!-- Add changes for active work here -->
 
 - [Offline] Add optional `language` parameter to SearchOfflineManager.createTilesetDescriptor and SearchOfflineManager.createPlacesTilesetDescriptor functions.
+- [Tests] Add Spanish language offline search test.
 
 - [Offline] Added OfflineIndexObserver which accepts two blocks for indexChanged or error events. This can be assigned to the offline search engine to receive state updates.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
+- [Offline] Add optional `language` parameter to SearchOfflineManager.createTilesetDescriptor and SearchOfflineManager.createPlacesTilesetDescriptor functions.
+
 ## 2.0.0-rc.3
 
 - [Core] Add `SearchResultAccuracy.proximate` case which "is a known address point but does not intersect a known rooftop/parcel."

--- a/Sources/MapboxSearch/InternalAPI/CoreSearchEngineStatics.swift
+++ b/Sources/MapboxSearch/InternalAPI/CoreSearchEngineStatics.swift
@@ -8,7 +8,7 @@ enum CoreSearchEngineStatics {
     static func createTilesetDescriptor(dataset: String, version: String, language: String? = nil) -> MapboxCommon
     .TilesetDescriptor {
         let identifier: String
-        if let language {
+        if let language, ISOLanguages.contains(language: language) {
             identifier = dataset + Constants.delimiter + language
         } else {
             identifier = dataset
@@ -19,7 +19,7 @@ enum CoreSearchEngineStatics {
     static func createPlacesTilesetDescriptor(dataset: String, version: String, language: String? = nil) -> MapboxCommon
     .TilesetDescriptor {
         let identifier: String
-        if let language {
+        if let language, ISOLanguages.contains(language: language) {
             identifier = dataset + Constants.delimiter + language
         } else {
             identifier = dataset
@@ -28,8 +28,8 @@ enum CoreSearchEngineStatics {
     }
 }
 
-enum DatasetLanguages {
-    static func filter(language: String) -> String? {
+enum ISOLanguages {
+    static func contains(language: String) -> Bool {
         var validLanguage: Bool
         if #available(iOS 16, *) {
             validLanguage = Locale.LanguageCode.isoLanguageCodes
@@ -39,6 +39,6 @@ enum DatasetLanguages {
             validLanguage = Locale.isoLanguageCodes
                 .contains(language)
         }
-        return validLanguage ? language : nil
+        return validLanguage
     }
 }

--- a/Sources/MapboxSearch/InternalAPI/CoreSearchEngineStatics.swift
+++ b/Sources/MapboxSearch/InternalAPI/CoreSearchEngineStatics.swift
@@ -1,11 +1,15 @@
 import Foundation
 
 enum CoreSearchEngineStatics {
+    enum Constants {
+        static let delimiter = "_"
+    }
+
     static func createTilesetDescriptor(dataset: String, version: String, language: String? = nil) -> MapboxCommon
     .TilesetDescriptor {
         let identifier: String
         if let language {
-            identifier = dataset + "|" + language
+            identifier = dataset + Constants.delimiter + language
         } else {
             identifier = dataset
         }
@@ -16,10 +20,25 @@ enum CoreSearchEngineStatics {
     .TilesetDescriptor {
         let identifier: String
         if let language {
-            identifier = dataset + "|" + language
+            identifier = dataset + Constants.delimiter + language
         } else {
             identifier = dataset
         }
         return CoreSearchEngine.createPlacesTilesetDescriptor(forDataset: identifier, version: version)
+    }
+}
+
+enum DatasetLanguages {
+    static func filter(language: String) -> String? {
+        var validLanguage: Bool
+        if #available(iOS 16, *) {
+            validLanguage = Locale.LanguageCode.isoLanguageCodes
+                .map(\.identifier)
+                .contains(language)
+        } else {
+            validLanguage = Locale.isoLanguageCodes
+                .contains(language)
+        }
+        return validLanguage ? language : nil
     }
 }

--- a/Sources/MapboxSearch/InternalAPI/CoreSearchEngineStatics.swift
+++ b/Sources/MapboxSearch/InternalAPI/CoreSearchEngineStatics.swift
@@ -1,11 +1,25 @@
 import Foundation
 
 enum CoreSearchEngineStatics {
-    static func createTilesetDescriptor(dataset: String, version: String) -> MapboxCommon.TilesetDescriptor {
-        CoreSearchEngine.createTilesetDescriptor(forDataset: dataset, version: version)
+    static func createTilesetDescriptor(dataset: String, version: String, language: String? = nil) -> MapboxCommon
+    .TilesetDescriptor {
+        let identifier: String
+        if let language {
+            identifier = dataset + "|" + language
+        } else {
+            identifier = dataset
+        }
+        return CoreSearchEngine.createTilesetDescriptor(forDataset: identifier, version: version)
     }
 
-    static func createPlacesTilesetDescriptor(dataset: String, version: String) -> MapboxCommon.TilesetDescriptor {
-        CoreSearchEngine.createPlacesTilesetDescriptor(forDataset: dataset, version: version)
+    static func createPlacesTilesetDescriptor(dataset: String, version: String, language: String? = nil) -> MapboxCommon
+    .TilesetDescriptor {
+        let identifier: String
+        if let language {
+            identifier = dataset + "|" + language
+        } else {
+            identifier = dataset
+        }
+        return CoreSearchEngine.createPlacesTilesetDescriptor(forDataset: identifier, version: version)
     }
 }

--- a/Sources/MapboxSearch/InternalAPI/CoreSearchEngineStatics.swift
+++ b/Sources/MapboxSearch/InternalAPI/CoreSearchEngineStatics.swift
@@ -8,8 +8,16 @@ enum CoreSearchEngineStatics {
     static func createTilesetDescriptor(dataset: String, version: String, language: String? = nil) -> MapboxCommon
     .TilesetDescriptor {
         let identifier: String
-        if let language, ISOLanguages.contains(language: language) {
-            identifier = dataset + Constants.delimiter + language
+        if let language {
+            if ISOLanguages.contains(language: language) {
+                identifier = dataset + Constants.delimiter + language
+            } else {
+                _Logger.searchSDK
+                    .warning(
+                        "Provided language code '\(language)' for tileset is non-ISO. Dataset '\(dataset)' without language will be used."
+                    )
+                identifier = dataset
+            }
         } else {
             identifier = dataset
         }
@@ -19,8 +27,16 @@ enum CoreSearchEngineStatics {
     static func createPlacesTilesetDescriptor(dataset: String, version: String, language: String? = nil) -> MapboxCommon
     .TilesetDescriptor {
         let identifier: String
-        if let language, ISOLanguages.contains(language: language) {
-            identifier = dataset + Constants.delimiter + language
+        if let language {
+            if ISOLanguages.contains(language: language) {
+                identifier = dataset + Constants.delimiter + language
+            } else {
+                _Logger.searchSDK
+                    .warning(
+                        "Provided language code '\(language)' for places tileset is non-ISO. Dataset '\(dataset)' without language will be used."
+                    )
+                identifier = dataset
+            }
         } else {
             identifier = dataset
         }

--- a/Sources/MapboxSearch/PublicAPI/Offline/SearchOfflineManager.swift
+++ b/Sources/MapboxSearch/PublicAPI/Offline/SearchOfflineManager.swift
@@ -41,25 +41,52 @@ public class SearchOfflineManager {
         engine.setTileStore(searchTileStore.commonTileStore, completion: completion)
     }
 
-    /// Creates TilesetDescriptor for offline search index data with provided dataset name and version.
+    // MARK: - Tileset with name, version, and language parameters
+
+    /// Creates TilesetDescriptor for offline search index data with provided dataset name, version, and language.
+    /// Providing nil or excluding the language parameter will use the dataset name as-is.
+    /// Providing a language will append it to the name.
     /// - Parameters:
     ///   - dataset: dataset name
     ///   - version: dataset version
+    ///   - language: Provide a ISO 639-1 Code language from NSLocale. Values will be appended to the place dataset
+    /// name.
     /// - Returns: TilesetDescriptor for TileStore
-    public static func createTilesetDescriptor(dataset: String, version: String? = nil) -> MapboxCommon
+    public static func createTilesetDescriptor(
+        dataset: String,
+        version: String? = nil,
+        language: String? = nil
+    ) -> MapboxCommon
     .TilesetDescriptor {
-        CoreSearchEngineStatics.createTilesetDescriptor(dataset: dataset, version: version ?? "")
+        CoreSearchEngineStatics.createTilesetDescriptor(
+            dataset: dataset,
+            version: version ?? "",
+            language: language
+        )
     }
 
     /// Creates TilesetDescriptor for offline search boundaries with provided dataset name and version.
+    /// Providing nil or excluding the language parameter will use the places dataset name as-is.
+    /// Providing a language will append it to the name.
     /// - Parameters:
     ///   - dataset: dataset name
     ///   - version: dataset version
+    ///   - language: Provide a ISO 639-1 Code language from NSLocale. Values will be appended to the dataset name.
     /// - Returns: TilesetDescriptor for TileStore
-    public static func createPlacesTilesetDescriptor(dataset: String, version: String? = nil) -> MapboxCommon
+    public static func createPlacesTilesetDescriptor(
+        dataset: String,
+        version: String? = nil,
+        language: String? = nil
+    ) -> MapboxCommon
     .TilesetDescriptor {
-        CoreSearchEngineStatics.createPlacesTilesetDescriptor(dataset: dataset, version: version ?? "")
+        CoreSearchEngineStatics.createPlacesTilesetDescriptor(
+            dataset: dataset,
+            version: version ?? "",
+            language: language
+        )
     }
+
+    // MARK: - Default tileset
 
     /// Creates TilesetDescriptor for offline search index data using default dataset name.
     /// - Returns: TilesetDescriptor for TileStore

--- a/Tests/MapboxSearchIntegrationTests/OfflineIntegrationTests.swift
+++ b/Tests/MapboxSearchIntegrationTests/OfflineIntegrationTests.swift
@@ -36,10 +36,19 @@ class OfflineIntegrationTests: MockServerIntegrationTestCase<SBSMockResponse> {
         wait(for: [setTileStoreExpectation], timeout: 10)
     }
 
-    func loadData(completion: @escaping (Result<MapboxCommon.TileRegion, MapboxSearch.TileRegionError>) -> Void)
+    func loadData(
+        tilesetDescriptor: TilesetDescriptor? = nil,
+        completion: @escaping (Result<MapboxCommon.TileRegion, MapboxSearch.TileRegionError>) -> Void
+    )
     -> SearchCancelable {
-        /// This will use the default dataset defined at ``SearchOfflineManager.defaultDatasetName``
-        let descriptor = SearchOfflineManager.createDefaultTilesetDescriptor()
+        let descriptor: TilesetDescriptor
+        if let tilesetDescriptor {
+            descriptor = tilesetDescriptor
+        } else {
+            /// This will use the default dataset defined at ``SearchOfflineManager.defaultDatasetName``
+            descriptor = SearchOfflineManager.createDefaultTilesetDescriptor()
+        }
+
         let dcLocationValue = NSValue(mkCoordinate: dcLocation)
         let options = MapboxCommon.TileRegionLoadOptions.build(
             geometry: Geometry(point: dcLocationValue),
@@ -95,6 +104,54 @@ class OfflineIntegrationTests: MockServerIntegrationTestCase<SBSMockResponse> {
 
         let offlineUpdateExpectation = delegate.offlineUpdateExpectation
         searchEngine.search(query: "coffee")
+        wait(for: [offlineUpdateExpectation], timeout: 10)
+
+        XCTAssertNil(delegate.error)
+        XCTAssertNil(delegate.error?.localizedDescription)
+        XCTAssertNotNil(searchEngine.responseInfo)
+        XCTAssertFalse(delegate.resolvedResults.isEmpty)
+        XCTAssertFalse(searchEngine.suggestions.isEmpty)
+    }
+
+    func testSpanishLanguageSupport() throws {
+        clearData()
+
+        // Set up index observer before the fetch starts to validate changes after it completes
+        let indexChangedExpectation = expectation(description: "Received offline index changed event")
+        let offlineIndexObserver = OfflineIndexObserver(onIndexChangedBlock: { changeEvent in
+            _Logger.searchSDK.info("Index changed: \(changeEvent)")
+            indexChangedExpectation.fulfill()
+        }, onErrorBlock: { error in
+            _Logger.searchSDK.error("Encountered error in OfflineIndexObserver \(error)")
+            XCTFail(error.debugDescription)
+        })
+        searchEngine.offlineManager.engine.addOfflineIndexObserver(for: offlineIndexObserver)
+
+        // Perform the offline fetch
+        let spanishTileset = SearchOfflineManager.createTilesetDescriptor(
+            dataset: "mbx-main",
+            language: "es"
+        )
+        let loadDataExpectation = expectation(description: "Load Data")
+        _ = loadData(tilesetDescriptor: spanishTileset) { result in
+            switch result {
+            case .success(let region):
+                XCTAssert(region.id == self.regionId)
+                XCTAssert(region.completedResourceCount > 0)
+                XCTAssertEqual(region.requiredResourceCount, region.completedResourceCount)
+            case .failure(let error):
+                XCTFail("Unable to load Region, \(error.localizedDescription)")
+            }
+            loadDataExpectation.fulfill()
+        }
+        wait(
+            for: [loadDataExpectation, indexChangedExpectation],
+            timeout: 200,
+            enforceOrder: true
+        )
+
+        let offlineUpdateExpectation = delegate.offlineUpdateExpectation
+        searchEngine.search(query: "café")
         wait(for: [offlineUpdateExpectation], timeout: 10)
 
         XCTAssertNil(delegate.error)

--- a/Tests/MapboxSearchIntegrationTests/OfflineIntegrationTests.swift
+++ b/Tests/MapboxSearchIntegrationTests/OfflineIntegrationTests.swift
@@ -41,13 +41,9 @@ class OfflineIntegrationTests: MockServerIntegrationTestCase<SBSMockResponse> {
         completion: @escaping (Result<MapboxCommon.TileRegion, MapboxSearch.TileRegionError>) -> Void
     )
     -> SearchCancelable {
-        let descriptor: TilesetDescriptor
-        if let tilesetDescriptor {
-            descriptor = tilesetDescriptor
-        } else {
-            /// This will use the default dataset defined at ``SearchOfflineManager.defaultDatasetName``
-            descriptor = SearchOfflineManager.createDefaultTilesetDescriptor()
-        }
+        /// A nil tilesetDescriptor parameter will fallback to the default dataset defined at
+        /// ``SearchOfflineManager.defaultDatasetName``
+        let descriptor = tilesetDescriptor ?? SearchOfflineManager.createDefaultTilesetDescriptor()
 
         let dcLocationValue = NSValue(mkCoordinate: dcLocation)
         let options = MapboxCommon.TileRegionLoadOptions.build(


### PR DESCRIPTION
### Description
Fixes [SSDK-622](https://mapbox.atlassian.net/browse/SSDK-622)

Add optional `language` parameter that has two modes:
1. Absent language parameter / `nil` value will use existing behavior of _just_ the dataset name.
2. A given language parameter will be appended to the dataset name.

### Checklist
- [x] Update `CHANGELOG`
- [x] Add a non-English language test after #199 is merged

[SSDK-622]: https://mapbox.atlassian.net/browse/SSDK-622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ