### PR TITLE
Fix missing image reference from xib

### DIFF
--- a/Sources/MapboxSearchUI/UserFavoriteCell.xib
+++ b/Sources/MapboxSearchUI/UserFavoriteCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,7 +17,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="396" height="76"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="1000" verticalHuggingPriority="251" image="maki/home" translatesAutoresizingMaskIntoConstraints="NO" id="jnc-xf-Ie9">
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="1000" verticalHuggingPriority="251" image="home" translatesAutoresizingMaskIntoConstraints="NO" id="jnc-xf-Ie9">
                         <rect key="frame" x="10" y="26" width="24" height="24"/>
                         <color key="tintColor" name="mapbox icon tint"/>
                         <constraints>
@@ -76,7 +76,7 @@
         </tableViewCell>
     </objects>
     <resources>
-        <image name="maki/home" width="24" height="24"/>
+        <image name="home" width="15" height="15"/>
         <image name="more icon" width="15" height="4"/>
         <namedColor name="mapbox background">
             <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
### Description

Before this fix the following console message was logged
```
2024-04-03 15:19:52.728231-0400 Demo[79878:948336] Could not load the "maki/home" image referenced from a nib in the bundle with identifier "com.mapbox.MapboxSearchUIResources"
2024-04-03 15:19:52.731094-0400 Demo[79878:948336] Could not load the "maki/home" image referenced from a nib in the bundle with identifier "com.mapbox.MapboxSearchUIResources"
```

### Checklist
- [NA] Update `CHANGELOG`

#### Screenshots

| Before | After |
| -- | -- |
| <img width="487" alt="Screenshot 2024-04-03 at 15 22 43" src="https://github.com/mapbox/mapbox-search-ios/assets/384288/8db27958-1fca-4c6b-98f0-0050d0fab383"> | <img width="488" alt="Screenshot 2024-04-03 at 15 22 49" src="https://github.com/mapbox/mapbox-search-ios/assets/384288/96d7fe17-6c27-4293-bb2c-141f2bfa914f"> |
