### PR TITLE
[SSDK-582] Prepare v1.0.0-rc.10 with MapboxCoreSearch update, mapboxId, and Address enhancements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,6 +283,8 @@ commands:
   ios-install-carthage-dependencies:
     steps:
       - setup-authentication
+      # Xcode 14.1 image has Carthage 0.38 so v1 must always update carthage
+      - upgrade-carthage
       - run: make deps
 
   ios-prestart-simulator:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,19 +10,23 @@ workflows:
   develop-build:
     jobs:
       - pre-check:
+          context: SDK Registry Token
           filters:
             tags:
               only: /v.*/
       - build:
+          context: SDK Registry Token
           requires:
             - pre-check
           filters:
             tags:
               only: /v.*/
       - spm-build:
+          context: SDK Registry Token
           requires:
             - pre-check
       - release-pre-check:
+          context: SDK Registry Token
           requires:
             - pre-check
           filters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,47 +8,44 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
+- [SearchResult] Add support for mapboxId field when available.
+- [FavoriteRecord] Add support for mapboxId field when available.
+- [HistoryRecord] Add support for mapboxId field when available.
+- [Discover] Add support for mapboxId field when available.
+- [Address Autofill] Add support for mapboxId field when available.
+- [Place Autocomplete] Add support for mapboxId field when available.
+- [Demo] Add mapboxId table view cell to PlaceAutocomplete detail view controller when available.
+- [Address] Added SearchAddressRegion containing name, regionCode, and regionCodeFull fields.
+- [Address] Added SearchAddressCountry containing name, countryCode, and regionCodeFull fields.
+- [Address] Added fields searchAddressRegion and searchAddressCountry to Address alongside existing country and region.
+
+**MapboxCoreSearch**: v1.0.0
+
 ## 1.0.0-rc.9 - 2024-04-15
 
 - [UI] Add Right-to-Left language support for Categories/Favorites segment control and fix xib errors.
 - [UI] Add Preview file for CategoriesFavoritesSegmentControl to fix compiler problems.
-
 - [Core] Add SearchError.owningObjectDeallocated when network responses fail to unwrap guard-let-self. If you encounter this error you must own the reference to the search engine.
 - [Tests] Add UnownedObjectError tests to validate behavior of SearchError.owningObjectDeallocated.
-
 - [Tests] Reorganize tests based on API type
-
 - [Privacy] Add Search history collected data for the purpose of product personalization (used for displaying the search history)
-
 - [License] Update license to reflect 2024 usage
-
 - [Tests] Change MockResponse into a protocol, create separate enums conforming to MockResponse for each API type (geocoding, sbs, autofill), add MockResponse as generic to each test base class and MockWebServer.
-
 - [SearchUI] Add `distanceFormatter` field to Configuration to support changing the search suggestions distance format. Nil values will use the default behavior.
-
 - [Core] Add xcprivacy for MapboxSearch and MapboxSearchUI
-
 - [Unit Tests] Update and correct tests for iOS 17 using all mocked data.
 - [UI Tests] Update and correct tests for iOS 17 using all mocked data.
-
 - [Search] Rename `SearchEngine.reverseGeocoding` function to `SearchEngine.reverse`.
-
 - [Core] Stop reading "MapboxAPIBaseURL" from UserDefaults in `ServiceProvider.createEngine`. (Providing a value in Info.plist is still supported).
-
 - [Core] Updated to Xcode 14.1 minimum version
 - [Core] Updated deployment target to iOS 12
-
 - [Core] Remove Swifter library dependency from MapboxSearch target (only used in Test targets)
-
 - [Discover] Fix charging station category canonical ID
-
 - [Core] Update SwiftLint to 0.54.0 and SwiftFormat to 0.52.11
 - [Core] Fix project compliance with linter, reformat Swift files
 - [Core] Add Brewfile for project
 - [Core] Remove legacy `MGLMapboxAccessToken`.
-
 - [SearchExample] Update Examples/SearchExample.xcworkspace to use the local package (parent directory) for MapboxSearch.
-
 - [Address Autofill] Suggestions no longer perform a `retrieve` call.
 - [Address Autofill] `Suggestion.coordinate` is now an optional. `init` requires an Underlying enum parameter.
 - [Address Autofill] Added new AddressAutofill.Suggestion.Underlying enum parameter with cases for suggestion and result inputs.
@@ -57,21 +54,9 @@ Guide: https://keepachangelog.com/en/1.0.0/
 - [Place Autocomplete] `Result.coordinate` is now an optional.
 - [Core] Remove legacy `MGLMapboxAccessToken`.
 - [Core] Remove bitcode support
-- [Core] Updated API usage:
-	- Removed parameter-based Access Token. Be sure to provide your token in Info.plist.
-	- Renamed `CoreSuggestAction.isMultiRetrivable` to `multiRetrievable`.
-	- Renamed `CoreSearchResult.center` to `.centerLocation`.
-	- Renamed `CoreSearchOptions.isIgnoreUR` to `ignoreUR`.
-	- Renamed `TileRegionLoadOptions` initializer parameter `start` to `startLocation`.
-	- Replace some `CLLocation` fields with `Coordinate2D` wrapper containing a value of `CLLocationCoordinate2D`. This changes the call-site from `.coordinate` to `.value`.
-	- Added `SdkInformation.defaultInfo` default value for various Core initializer parameters.
-	- Added `SearchAddressRegion` containing `name`, `regionCode`, and `regionCodeFull` fields.
-	- Added `SearchAddressCountry` containing `name`, `countryCode`, and `regionCodeFull` fields.
-	- Added fields `searchAddressRegion` and `searchAddressCountry` to `Address` alongside existing `country` and `region`.
-	- Remove access token parameter from `SearchTileStore`.
 
 **MapboxCommon**: v23.0.0
-**MapboxCoreSearch**: v2.0.0
+**MapboxCoreSearch**: v1.0.0
 
 ## 1.0.0-rc.8 - 2023-10-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
+## 1.0.0-rc.10 - 2024-04-29
+
 - [SearchResult] Add support for mapboxId field when available.
 - [FavoriteRecord] Add support for mapboxId field when available.
 - [HistoryRecord] Add support for mapboxId field when available.
@@ -18,8 +20,9 @@ Guide: https://keepachangelog.com/en/1.0.0/
 - [Address] Added SearchAddressRegion containing name, regionCode, and regionCodeFull fields.
 - [Address] Added SearchAddressCountry containing name, countryCode, and regionCodeFull fields.
 - [Address] Added fields searchAddressRegion and searchAddressCountry to Address alongside existing country and region.
+- [Core] Update to MapboxCoreSearch v1.0.1 with PrivacyInfo.xcprivacy and compatibility with Xcode 15.3
 
-**MapboxCoreSearch**: v1.0.0
+**MapboxCoreSearch**: v1.0.1
 
 ## 1.0.0-rc.9 - 2024-04-15
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 0.71.0
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 1.0.0
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 23.6.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 1.0.0
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 1.0.1
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 23.6.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "23.6.0"
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "0.71.0"
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "1.0.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "23.6.0"
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "1.0.0"
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "1.0.1"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CURRENT_DIR := $(shell pwd)
-CARTHAGE_MIN_VERSION = 0.38.0
+CARTHAGE_MIN_VERSION = 0.39.1
 CARTHAGE_BUILD_DIR := $(CURRENT_DIR)/Carthage/Build
 PRODUCTS_DIR := $(CURRENT_DIR)/Products
 VERSION ?= $(shell git describe --tags $(git rev-list --tags='v*' --max-count=1) --abbrev=0)

--- a/MapboxSearch.xcodeproj/project.pbxproj
+++ b/MapboxSearch.xcodeproj/project.pbxproj
@@ -82,6 +82,8 @@
 		04970F8D2B7A97C900213763 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 04970F8C2B7A97C900213763 /* PrivacyInfo.xcprivacy */; };
 		04BBC6342B61898F00E24E99 /* LocalhostMockServiceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BBC6332B61898F00E24E99 /* LocalhostMockServiceProvider.swift */; };
 		04BBC6372B61ABA500E24E99 /* FeedbackUITestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9BBFBD02604A4A500DE9C98 /* FeedbackUITestCase.swift */; };
+		04D2F4DB2BE040B300F85CFF /* SearchAddressCountry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D2F4DA2BE040B300F85CFF /* SearchAddressCountry.swift */; };
+		04D2F4E02BE0413100F85CFF /* SearchAddressRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D2F4DE2BE0413100F85CFF /* SearchAddressRegion.swift */; };
 		04E84D122B76BA230056C269 /* Resources-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 04E84D112B76BA230056C269 /* Resources-Info.plist */; };
 		04E84D132B7A8F4D0056C269 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 04E84D072B7691610056C269 /* PrivacyInfo.xcprivacy */; };
 		140D1BDC286DB479001A51C2 /* SearchResultAccuracy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140D1BDB286DB479001A51C2 /* SearchResultAccuracy.swift */; };
@@ -522,6 +524,8 @@
 		0491257C2BC04E1300D40803 /* MockResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockResponse.swift; sourceTree = "<group>"; };
 		04970F8C2B7A97C900213763 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		04BBC6332B61898F00E24E99 /* LocalhostMockServiceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalhostMockServiceProvider.swift; sourceTree = "<group>"; };
+		04D2F4DA2BE040B300F85CFF /* SearchAddressCountry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchAddressCountry.swift; sourceTree = "<group>"; };
+		04D2F4DE2BE0413100F85CFF /* SearchAddressRegion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchAddressRegion.swift; sourceTree = "<group>"; };
 		04E84CFD2B768EDA0056C269 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		04E84CFE2B768EDA0056C269 /* Brewfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Brewfile; sourceTree = "<group>"; };
 		04E84D012B768F210056C269 /* Pluginfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Pluginfile; sourceTree = "<group>"; };
@@ -990,6 +994,14 @@
 			path = Resources;
 			sourceTree = "<group>";
 		};
+		04D2F4DD2BE0413100F85CFF /* Region */ = {
+			isa = PBXGroup;
+			children = (
+				04D2F4DE2BE0413100F85CFF /* SearchAddressRegion.swift */,
+			);
+			path = Region;
+			sourceTree = "<group>";
+		};
 		04E84D002B768F210056C269 /* .fastlane */ = {
 			isa = PBXGroup;
 			children = (
@@ -1033,6 +1045,7 @@
 		14173C2C28783DDD00B20E1C /* Country */ = {
 			isa = PBXGroup;
 			children = (
+				04D2F4DA2BE040B300F85CFF /* SearchAddressCountry.swift */,
 				148DE6612857501D0085684D /* Country.swift */,
 				14173C2F2878437D00B20E1C /* Country+ISO3166-1.swift */,
 			);
@@ -1271,6 +1284,7 @@
 		148DE660285750100085684D /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				04D2F4DD2BE0413100F85CFF /* Region */,
 				14173C3B28784B8900B20E1C /* Address */,
 				14FA657D295355A500056E5B /* Administrative Unit */,
 				14F7186729A1333400D5BC2E /* Bounding Box */,
@@ -2462,6 +2476,7 @@
 				FEEDD31B2508DFE400DC0A98 /* LocalDataProviders.swift in Sources */,
 				FEEDD2F42508DFE400DC0A98 /* CoreResponseProvider.swift in Sources */,
 				FEEDD30C2508DFE400DC0A98 /* IndexableRecord.swift in Sources */,
+				04D2F4E02BE0413100F85CFF /* SearchAddressRegion.swift in Sources */,
 				043A3D4D2B30F38300DB681B /* CoreAddress+AddressComponents.swift in Sources */,
 				FE097B7B264EAA1A001EAC2F /* AddOfflineRegionError.swift in Sources */,
 				FEEDD30D2508DFE400DC0A98 /* ServiceProvider.swift in Sources */,
@@ -2522,6 +2537,7 @@
 				140D1BDC286DB479001A51C2 /* SearchResultAccuracy.swift in Sources */,
 				141789E7287C05060000AE79 /* AddressAutofill.Suggestion+SearchResult.swift in Sources */,
 				1488F78329A7AD5800CF373B /* CoreUserActivityReporter.swift in Sources */,
+				04D2F4DB2BE040B300F85CFF /* SearchAddressCountry.swift in Sources */,
 				144F32F5298D21E70082B2D5 /* AddressComponents.swift in Sources */,
 				FEEDD3122508DFE400DC0A98 /* SearchResultSuggestion.swift in Sources */,
 				148DE671285777180085684D /* NSLocking+Extensions.swift in Sources */,
@@ -2690,7 +2706,6 @@
 				F9C557BB2670CCC000BE8B94 /* SearchResultType+Extensions.swift in Sources */,
 				F9C557BA2670CCAB00BE8B94 /* TestDataProviderRecord.swift in Sources */,
 				042477C32B7290F900D870D5 /* SearchEngineGeocodingIntegrationTests.swift in Sources */,
-				F9C557672670CB0400BE8B94 /* MockResponse.swift in Sources */,
 				0405809D2BA8E67D00A54CB9 /* OwningObjectDeallocatedErrorTests.swift in Sources */,
 				04BBC6342B61898F00E24E99 /* LocalhostMockServiceProvider.swift in Sources */,
 				2C10133429F1C6200094413F /* PlaceAutocompleteIntegrationTests.swift in Sources */,

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 import Foundation
 
-let (coreSearchVersion, coreSearchVersionHash) = ("0.71.0", "252327e268abc28b9e5546a381d969c5cd1a3a8ccbd4b3ae2a31cef448a61fbc")
+let (coreSearchVersion, coreSearchVersionHash) = ("1.0.0", "d1682f2552545b1de985d4a3650b116ea2168808b8b8821e91b18de1d813ed29")
 
 let commonMinVersion = Version("23.6.0")
 let commonMaxVersion = Version("24.0.0")

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 import Foundation
 
-let (coreSearchVersion, coreSearchVersionHash) = ("1.0.0", "d1682f2552545b1de985d4a3650b116ea2168808b8b8821e91b18de1d813ed29")
+let (coreSearchVersion, coreSearchVersionHash) = ("1.0.1", "5eb2eedb0d121ffde307ce36a10d2d62bb40cc7c0c0b75abe4364181bd5287d4")
 
 let commonMinVersion = Version("23.6.0")
 let commonMaxVersion = Version("24.0.0")

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The Search SDK is pre-configured for autocomplete, local search biasing, and inc
 ## Prerequisites
 The SDK requires Carthage which you can install using Homebrew.
 1. Check that Homebrew is installed by running `brew -v`. If you don't have Homebrew, [install before proceeding.](https://brew.sh/)
-1. Update Homebrew data to install latest tools versions including Carthage (v0.38 or newer)
+1. Update Homebrew data to install latest tools versions including Carthage (v0.39.1 or newer)
     - `brew update && brew bundle install`
 1. Set up .netrc file for sdk registry access
     1. Create .netrc file in user home directory (`$HOME/.netrc`, e.g. `/Users/victorprivalov/.netrc`)

--- a/Sources/Demo/PlaceAutocompleteDetailsViewController.swift
+++ b/Sources/Demo/PlaceAutocompleteDetailsViewController.swift
@@ -168,6 +168,12 @@ extension PlaceAutocomplete.Result {
             )
         }
 
+        if let mapboxId {
+            components.append(
+                (name: "Mapbox ID", value: mapboxId)
+            )
+        }
+
         return components
     }
 }

--- a/Sources/MapboxSearch/InternalAPI/CoreAliases.swift
+++ b/Sources/MapboxSearch/InternalAPI/CoreAliases.swift
@@ -25,6 +25,8 @@ typealias CoreImageInfo = MapboxCoreSearch.ImageInfo
 typealias CoreOpenHours = MapboxCoreSearch.OpenHours
 typealias CoreOpenPeriod = MapboxCoreSearch.OpenPeriod
 typealias CoreAccuracy = MapboxCoreSearch.ResultAccuracy
+typealias CoreSearchAddressRegion = MapboxCoreSearch.SearchAddressRegion
+typealias CoreSearchAddressCountry = MapboxCoreSearch.SearchAddressCountry
 
 typealias CoreUserActivityReporter = MapboxCoreSearch.UserActivityReporter
 typealias CoreUserActivityReporterOptions = MapboxCoreSearch.UserActivityReporterOptions

--- a/Sources/MapboxSearch/InternalAPI/CoreSearchResultProtocol.swift
+++ b/Sources/MapboxSearch/InternalAPI/CoreSearchResultProtocol.swift
@@ -4,6 +4,9 @@ import Foundation
 protocol CoreSearchResultProtocol {
     var id: String { get }
 
+    /// A unique identifier for the geographic feature
+    var mapboxId: String? { get }
+
     var resultTypes: [CoreResultType] { get }
 
     /**

--- a/Sources/MapboxSearch/PublicAPI/Common/Models/Address/Address.swift
+++ b/Sources/MapboxSearch/PublicAPI/Common/Models/Address/Address.swift
@@ -36,9 +36,16 @@ public struct Address: Codable, Hashable {
     /// China.
     public var region: String?
 
+    /// Top-level sub-national administrative feature object containing the name (required) and ISO 3166-2 subdivision
+    /// code identifiers.
+    public var searchAddressRegion: SearchAddressRegion?
+
     /// Generally recognized countries or, in some cases like Hong Kong, an area of quasi-national administrative status
     /// that has been given a designated country code under ISO 3166-1.
     public var country: String?
+
+    /// Generally recognized country object containing the name (required) and ISO 3166-1 country code identifiers.
+    public var searchAddressCountry: SearchAddressCountry?
 
     /// The postal address associated with the location, formatted for use with the Contacts framework.
     public var postalAddress: CNPostalAddress {
@@ -89,8 +96,10 @@ extension Address {
             postcode: valueOrNil(coreAddress.postcode),
             place: valueOrNil(coreAddress.place),
             district: valueOrNil(coreAddress.district),
-            region: valueOrNil(coreAddress.region),
-            country: valueOrNil(coreAddress.country)
+            region: valueOrNil(coreAddress.region?.name),
+            searchAddressRegion: coreAddress.region.map { SearchAddressRegion($0) },
+            country: valueOrNil(coreAddress.country?.name),
+            searchAddressCountry: coreAddress.country.map { SearchAddressCountry($0) }
         )
     }
 
@@ -103,8 +112,8 @@ extension Address {
             postcode: postcode,
             place: place,
             district: district,
-            region: region,
-            country: country
+            region: searchAddressRegion?.toCore(),
+            country: searchAddressCountry?.toCore()
         )
     }
 }

--- a/Sources/MapboxSearch/PublicAPI/Common/Models/Country/SearchAddressCountry.swift
+++ b/Sources/MapboxSearch/PublicAPI/Common/Models/Country/SearchAddressCountry.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Contains values for a given country including name (required) and possibly ISO 3166-1 Alpha 2 and Alpha 3 codes.
+public struct SearchAddressCountry: Codable, Hashable, Equatable {
+    /// Name of this country
+    var name: String
+
+    /// ISO 3166-1 Alpha 2 country code
+    var countryCode: String?
+
+    /// ISO 3166-1 Alpha 3 country code
+    var countryCodeAlpha3: String?
+
+    init(_ core: CoreSearchAddressCountry) {
+        self.name = core.name
+        self.countryCode = core.countryCode
+        self.countryCodeAlpha3 = core.countryCodeAlpha3
+    }
+}
+
+extension SearchAddressCountry {
+    /// Transform a ``SearchAddressCountry`` to an object compatible with the MapboxCommon framework.
+    func toCore() -> CoreSearchAddressCountry {
+        CoreSearchAddressCountry(
+            name: name,
+            countryCode: countryCode,
+            countryCodeAlpha3: countryCodeAlpha3
+        )
+    }
+}

--- a/Sources/MapboxSearch/PublicAPI/Common/Models/Region/SearchAddressRegion.swift
+++ b/Sources/MapboxSearch/PublicAPI/Common/Models/Region/SearchAddressRegion.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Contains details for top-level sub-national administrative features, such as states in the United States or
+/// provinces in Canada or China, including name (required) and code identifiers (optional)
+public struct SearchAddressRegion: Codable, Hashable, Equatable {
+    /// Colloquial name for this region
+    let name: String
+
+    /// Subdivision portion of ISO 3166-2 code
+    let regionCode: String?
+
+    /// ISO 3166-2 region code
+    let regionCodeFull: String?
+
+    init(_ core: CoreSearchAddressRegion) {
+        self.name = core.name
+        self.regionCode = core.regionCode
+        self.regionCodeFull = core.regionCodeFull
+    }
+}
+
+extension SearchAddressRegion {
+    /// Transform a ``SearchAddressRegion`` to an object compatible with the MapboxCommon framework.
+    func toCore() -> CoreSearchAddressRegion {
+        CoreSearchAddressRegion(
+            name: name,
+            regionCode: regionCode,
+            regionCodeFull: regionCodeFull
+        )
+    }
+}

--- a/Sources/MapboxSearch/PublicAPI/FavoriteRecord.swift
+++ b/Sources/MapboxSearch/PublicAPI/FavoriteRecord.swift
@@ -5,6 +5,9 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
     /// Unique record identifier.
     public let id: String
 
+    /// A unique identifier for the geographic feature
+    public var mapboxId: String?
+
     /// Displayable name of the record.
     public var name: String
 
@@ -79,6 +82,7 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
     ///   - resultType: Favorite result type
     public init(
         id: String? = nil,
+        mapboxId: String? = nil,
         name: String,
         matchingName: String?,
         coordinate: CLLocationCoordinate2D,
@@ -93,6 +97,7 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
         metadata: SearchResultMetadata? = nil
     ) {
         self.id = id ?? UUID().uuidString
+        self.mapboxId = mapboxId
         self.name = name
         self.matchingName = matchingName
         self.coordinateCodable = .init(coordinate)
@@ -118,6 +123,7 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
     ) {
         self.init(
             id: id,
+            mapboxId: searchResult.mapboxId,
             name: name,
             matchingName: searchResult.matchingName,
             coordinate: searchResult.coordinate,

--- a/Sources/MapboxSearch/PublicAPI/HistoryRecord.swift
+++ b/Sources/MapboxSearch/PublicAPI/HistoryRecord.swift
@@ -20,6 +20,9 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
     /// Unique identifier
     public private(set) var id: String
 
+    /// A unique identifier for the geographic feature
+    public private(set) var mapboxId: String?
+
     /// Record's name
     public private(set) var name: String
 
@@ -86,6 +89,7 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
     /// History record constructor
     /// - Parameters:
     ///   - id: UUID used by default
+    ///   - mapboxId:
     ///   - name: History name
     ///   - coordinate: History coordinate
     ///   - timestamp: History timestamp
@@ -97,6 +101,7 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
     ///   - routablePoints: Coordinates of building entries
     public init(
         id: String = UUID().uuidString,
+        mapboxId: String?,
         name: String,
         matchingName: String?,
         serverIndex: Int?,
@@ -112,6 +117,7 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
         routablePoints: [RoutablePoint]? = nil
     ) {
         self.id = id
+        self.mapboxId = mapboxId
         self.name = name
         self.matchingName = matchingName
         self.serverIndex = serverIndex
@@ -138,6 +144,7 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
         timestamp: Date = Date()
     ) {
         self.id = searchResult.id
+        self.mapboxId = searchResult.mapboxId
         self.name = searchResult.name
         self.matchingName = searchResult.matchingName
         self.serverIndex = searchResult.serverIndex

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchResult.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchResult.swift
@@ -6,6 +6,9 @@ public protocol SearchResult {
     /// Result unique identifier.
     var id: String { get }
 
+    /// A unique identifier for the geographic feature
+    var mapboxId: String? { get }
+
     /// Result name.
     var name: String { get }
 

--- a/Sources/MapboxSearch/PublicAPI/Search Results/ServerSearchResult.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/ServerSearchResult.swift
@@ -35,6 +35,9 @@ class ServerSearchResult: SearchResult, SearchResultSuggestion, CoreResponseProv
 
     var id: String
 
+    /// A unique identifier for the geographic feature
+    var mapboxId: String?
+
     var name: String
 
     var matchingName: String?
@@ -61,6 +64,7 @@ class ServerSearchResult: SearchResult, SearchResultSuggestion, CoreResponseProv
         self.type = type
 
         self.id = coreResult.id
+        self.mapboxId = coreResult.mapboxId
         self.name = coreResult.names[0]
         self.matchingName = coreResult.matchingName
         self.iconName = coreResult.icon

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Address Autofill/AddressAutofill.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Address Autofill/AddressAutofill.swift
@@ -133,6 +133,7 @@ extension AddressAutofill {
             }
             let result = AddressAutofill.Result(
                 name: suggestion.name,
+                mapboxId: suggestion.mapboxId,
                 formattedAddress: suggestion.formattedAddress,
                 coordinate: coordinate,
                 addressComponents: suggestion.addressComponents
@@ -249,6 +250,7 @@ extension AddressAutofill {
 
             return Suggestion(
                 name: name,
+                mapboxId: result.mapboxId,
                 formattedAddress: fullAddress,
                 coordinate: result.center?.coordinate,
                 addressComponents: resultAddress,
@@ -288,6 +290,7 @@ extension AddressAutofill {
 
             let autofillResult = AddressAutofill.Result(
                 name: result.name,
+                mapboxId: result.mapboxId,
                 formattedAddress: formattedAddress,
                 coordinate: result.coordinate,
                 addressComponents: addressComponents

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Address Autofill/Models/AddressAutofill+Result.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Address Autofill/Models/AddressAutofill+Result.swift
@@ -5,6 +5,9 @@ extension AddressAutofill {
         /// Result name.
         public let name: String
 
+        /// A unique identifier for the geographic feature
+        public let mapboxId: String?
+
         /// Textual representation of the address.
         public let formattedAddress: String
 
@@ -16,11 +19,13 @@ extension AddressAutofill {
 
         init(
             name: String,
+            mapboxId: String?,
             formattedAddress: String,
             coordinate: CLLocationCoordinate2D,
             addressComponents: NonEmptyArray<AddressComponent>
         ) {
             self.name = name
+            self.mapboxId = mapboxId
             self.formattedAddress = formattedAddress
             self.coordinate = coordinate
             self.addressComponents = addressComponents

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Address Autofill/Models/Suggestion/AddressAutofill+Suggestion.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Address Autofill/Models/Suggestion/AddressAutofill+Suggestion.swift
@@ -6,6 +6,9 @@ extension AddressAutofill {
         /// Suggestion name.
         public let name: String
 
+        /// A unique identifier for the geographic feature
+        public let mapboxId: String?
+
         /// Textual representation of the address.
         public let formattedAddress: String
 
@@ -21,12 +24,14 @@ extension AddressAutofill {
 
         init(
             name: String,
+            mapboxId: String?,
             formattedAddress: String,
             coordinate: CLLocationCoordinate2D?,
             addressComponents: NonEmptyArray<AddressComponent>,
             underlying: Underlying
         ) {
             self.name = name
+            self.mapboxId = mapboxId
             self.formattedAddress = formattedAddress
             self.coordinate = coordinate
             self.addressComponents = addressComponents

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Address Autofill/Models/Suggestion/AddressAutofill.Suggestion+SearchResult.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Address Autofill/Models/Suggestion/AddressAutofill.Suggestion+SearchResult.swift
@@ -23,6 +23,7 @@ extension AddressAutofill.Suggestion {
 
         return try .init(
             name: searchResult.name,
+            mapboxId: searchResult.mapboxId,
             formattedAddress: formattedAddress,
             coordinate: searchResult.coordinate,
             addressComponents: address.toAutofillComponents(),

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Address Autofill/Models/Suggestion/CoreAddress+AddressComponents.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Address Autofill/Models/Suggestion/CoreAddress+AddressComponents.swift
@@ -15,8 +15,8 @@ extension CoreAddress {
         postcode.map { components.append(.init(kind: .postcode, value: $0)) }
         place.map { components.append(.init(kind: .place, value: $0)) }
         district.map { components.append(.init(kind: .district, value: $0)) }
-        region.map { components.append(.init(kind: .region, value: $0)) }
-        country.map { components.append(.init(kind: .country, value: $0)) }
+        region.map { components.append(.init(kind: .region, value: $0.name)) }
+        country.map { components.append(.init(kind: .country, value: $0.name)) }
 
         guard let first = components.first else {
             throw AutofillParsingError.emptyAddressComponents

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Discover API/Models/Discover+Result.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Discover API/Models/Discover+Result.swift
@@ -6,6 +6,9 @@ extension Discover {
         /// Result's name
         public let name: String
 
+        /// A unique identifier for the geographic feature
+        public let mapboxId: String?
+
         /// Result's address
         public let address: AddressComponents
 
@@ -34,6 +37,7 @@ extension Discover.Result {
 
         return .init(
             name: searchResult.name,
+            mapboxId: searchResult.mapboxId,
             address: .init(searchResult: searchResult),
             coordinate: searchResult.coordinate,
             routablePoints: routablePointsArray,

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/Models/PlaceAutocomplete+Result.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/Models/PlaceAutocomplete+Result.swift
@@ -5,6 +5,8 @@ extension PlaceAutocomplete {
         /// Result name.
         public let name: String
 
+        public let mapboxId: String?
+
         /// Contains formatted address.
         public let description: String?
 

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/Models/PlaceAutocomplete+Suggestion.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/Models/PlaceAutocomplete+Suggestion.swift
@@ -6,6 +6,9 @@ extension PlaceAutocomplete {
         /// Place's name.
         public let name: String
 
+        /// A unique identifier for the geographic feature
+        public let mapboxId: String?
+
         /// Contains formatted address.
         public let description: String?
 
@@ -36,6 +39,7 @@ extension PlaceAutocomplete {
 
         init(
             name: String,
+            mapboxId: String?,
             description: String?,
             coordinate: CLLocationCoordinate2D?,
             iconName: String?,
@@ -47,6 +51,7 @@ extension PlaceAutocomplete {
             underlying: Underlying
         ) {
             self.name = name
+            self.mapboxId = mapboxId
             self.description = description
             self.coordinate = coordinate
             self.iconName = iconName
@@ -69,6 +74,7 @@ extension PlaceAutocomplete.Suggestion {
     func result(for underlyingResult: SearchResult) -> PlaceAutocomplete.Result {
         .init(
             name: name,
+            mapboxId: underlyingResult.mapboxId,
             description: description,
             type: placeType,
             coordinate: coordinate,
@@ -108,6 +114,7 @@ extension PlaceAutocomplete.Suggestion {
 
         return .init(
             name: searchResult.name,
+            mapboxId: searchResult.mapboxId,
             description: searchResult.descriptionText,
             coordinate: searchResult.coordinate,
             iconName: searchResult.iconName,
@@ -136,6 +143,7 @@ extension PlaceAutocomplete.Suggestion {
 
         return .init(
             name: searchSuggestion.names.first ?? "",
+            mapboxId: searchSuggestion.mapboxId,
             description: searchSuggestion.addressDescription,
             coordinate: coordinate,
             iconName: searchSuggestion.icon,

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/PlaceAutocomplete.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/PlaceAutocomplete.swift
@@ -318,6 +318,7 @@ extension PlaceAutocomplete {
 
             return Suggestion(
                 name: name,
+                mapboxId: result.mapboxId,
                 description: result.addressDescription,
                 coordinate: result.center?.coordinate,
                 iconName: result.icon,

--- a/Tests/MapboxSearchTests/Common/Data Samples/CoreSearchResultStub+Samples.swift
+++ b/Tests/MapboxSearchTests/Common/Data Samples/CoreSearchResultStub+Samples.swift
@@ -5,17 +5,20 @@ import XCTest
 extension CoreSearchResultStub {
     static let sample1 = CoreSearchResultStub(
         id: "sample-1",
+        mapboxId: nil,
         type: .poi,
         distance: 4200,
         estimatedTime: Measurement(value: 10.5, unit: .minutes)
     )
     static let sample2 = CoreSearchResultStub(
         id: "sample-2",
+        mapboxId: nil,
         type: .category
     )
 
     static let externalRecordSample = CoreSearchResultStub(
         id: "sample-3",
+        mapboxId: nil,
         type: .userRecord,
         center: .sample1,
         layer: FavoritesProvider.providerIdentifier,
@@ -34,6 +37,7 @@ extension CoreSearchResultStub {
     static func makeSuggestion(metadata: CoreResultMetadata? = nil) -> CoreSearchResultStub {
         let result = CoreSearchResultStub(
             id: UUID().uuidString,
+            mapboxId: nil,
             type: .place,
             names: ["Some Place Name"],
             languages: ["en"],
@@ -64,12 +68,13 @@ extension CoreSearchResultStub {
     }
 
     static func makeSuggestionTypeQuery() -> CoreSearchResultStub {
-        CoreSearchResultStub(id: "recursion", type: .query, center: nil)
+        CoreSearchResultStub(id: "recursion", mapboxId: nil, type: .query, center: nil)
     }
 
     static func makeCategory() -> CoreSearchResultStub {
         CoreSearchResultStub(
             id: UUID().uuidString,
+            mapboxId: nil,
             type: .category,
             names: ["Bar"],
             languages: ["en"],
@@ -82,6 +87,7 @@ extension CoreSearchResultStub {
         let center = CLLocation(latitude: 12.0000, longitude: 10.0000)
         let result = CoreSearchResultStub(
             id: UUID().uuidString,
+            mapboxId: nil,
             type: .place,
             names: ["Some Place Name"],
             languages: ["en"],
@@ -95,6 +101,7 @@ extension CoreSearchResultStub {
     static func makeAddress() -> CoreSearchResultStub {
         let result = CoreSearchResultStub(
             id: UUID().uuidString,
+            mapboxId: nil,
             type: .address,
             names: ["Some Place Name"],
             languages: ["en"],
@@ -115,11 +122,20 @@ extension CoreSearchResultStub {
             postcode: nil,
             place: nil,
             district: "poi-land",
-            region: "poi-region",
-            country: "poi-country"
+            region: CoreSearchAddressRegion(
+                name: "poi-region",
+                regionCode: nil,
+                regionCodeFull: nil
+            ),
+            country: CoreSearchAddressCountry(
+                name: "poi-country",
+                countryCode: nil,
+                countryCodeAlpha3: nil
+            )
         )
         let result = CoreSearchResultStub(
             id: UUID().uuidString,
+            mapboxId: nil,
             type: .place,
             names: ["Some Place Name"],
             languages: ["en"],
@@ -141,11 +157,20 @@ extension CoreSearchResultStub {
             postcode: nil,
             place: nil,
             district: "pizza-land",
-            region: "pizza-region",
-            country: "pizza-country"
+            region: CoreSearchAddressRegion(
+                name: "pizza-region",
+                regionCode: nil,
+                regionCodeFull: nil
+            ),
+            country: CoreSearchAddressCountry(
+                name: "pizza-country",
+                countryCode: nil,
+                countryCodeAlpha3: nil
+            )
         )
         let result = CoreSearchResultStub(
             id: UUID().uuidString,
+            mapboxId: nil,
             type: .place,
             names: ["Some Place Name"],
             languages: ["en"],
@@ -167,11 +192,20 @@ extension CoreSearchResultStub {
             postcode: nil,
             place: nil,
             district: "history-land",
-            region: "history-region",
-            country: "history-country"
+            region: CoreSearchAddressRegion(
+                name: "history-region",
+                regionCode: nil,
+                regionCodeFull: nil
+            ),
+            country: CoreSearchAddressCountry(
+                name: "history-country",
+                countryCode: nil,
+                countryCodeAlpha3: nil
+            )
         )
         let result = CoreSearchResultStub(
             id: UUID().uuidString,
+            mapboxId: nil,
             type: .place,
             names: ["Some Place Name"],
             languages: ["en"],

--- a/Tests/MapboxSearchTests/Common/Data Samples/SearchCategorySuggestion+Samples.swift
+++ b/Tests/MapboxSearchTests/Common/Data Samples/SearchCategorySuggestion+Samples.swift
@@ -5,6 +5,7 @@ extension SearchCategorySuggestionImpl {
     static let sample1 = SearchCategorySuggestionImpl(
         coreResult: CoreSearchResultStub(
             id: "sample-2",
+            mapboxId: nil,
             type: .category,
             center: nil
         ),

--- a/Tests/MapboxSearchTests/Common/Data Samples/SearchQuerySuggestionImpl+Samples.swift
+++ b/Tests/MapboxSearchTests/Common/Data Samples/SearchQuerySuggestionImpl+Samples.swift
@@ -5,6 +5,7 @@ extension SearchQuerySuggestionImpl {
     static let sample1 = SearchQuerySuggestionImpl(
         coreResult: CoreSearchResultStub(
             id: "sample-43",
+            mapboxId: nil,
             type: .query,
             center: nil
         ),

--- a/Tests/MapboxSearchTests/Common/Data Samples/SearchResultStub+Samples.swift
+++ b/Tests/MapboxSearchTests/Common/Data Samples/SearchResultStub+Samples.swift
@@ -3,6 +3,7 @@ import MapboxSearch
 extension SearchResultStub {
     static let sample1 = SearchResultStub(
         id: "sample-1",
+        mapboxId: nil,
         categories: ["sample-1", "sample-2"],
         name: "Sample No 1",
         matchingName: nil,

--- a/Tests/MapboxSearchTests/Common/Models/Address/Address+Tests.swift
+++ b/Tests/MapboxSearchTests/Common/Models/Address/Address+Tests.swift
@@ -86,8 +86,8 @@ class AddressFormatterTests: XCTestCase {
         XCTAssertEqual(coreAddress.postcode, address.postcode)
         XCTAssertEqual(coreAddress.place, address.place)
         XCTAssertEqual(coreAddress.district, address.district)
-        XCTAssertEqual(coreAddress.region, address.region)
-        XCTAssertEqual(coreAddress.country, address.country)
+        XCTAssertEqual(coreAddress.region, address.searchAddressRegion?.toCore())
+        XCTAssertEqual(coreAddress.country, address.searchAddressCountry?.toCore())
     }
 
     func testEmptyCoreAddressConversion() {

--- a/Tests/MapboxSearchTests/Common/Models/Search Result/SearchResultSuggestionImplTests.swift
+++ b/Tests/MapboxSearchTests/Common/Models/Search Result/SearchResultSuggestionImplTests.swift
@@ -8,6 +8,7 @@ class SearchResultSuggestionImplTests: XCTestCase {
         let suggestionImpl = try XCTUnwrap(SearchResultSuggestionImpl(
             coreResult: CoreSearchResultStub(
                 id: "sample-2",
+                mapboxId: nil,
                 type: .address,
                 center: nil
             ),
@@ -24,6 +25,7 @@ class SearchResultSuggestionImplTests: XCTestCase {
         let suggestionImpl = try XCTUnwrap(SearchResultSuggestionImpl(
             coreResult: CoreSearchResultStub(
                 id: "sample-2",
+                mapboxId: nil,
                 type: .poi,
                 center: nil
             ),
@@ -40,6 +42,7 @@ class SearchResultSuggestionImplTests: XCTestCase {
         XCTAssertNil(SearchResultSuggestionImpl(
             coreResult: CoreSearchResultStub(
                 id: "sample-2",
+                mapboxId: nil,
                 type: .category,
                 center: nil
             ),
@@ -56,6 +59,7 @@ class SearchResultSuggestionImplTests: XCTestCase {
             _ = SearchResultSuggestionImpl(
                 coreResult: CoreSearchResultStub(
                     id: "sample-2",
+                    mapboxId: nil,
                     type: .category,
                     center: .sample1
                 ),

--- a/Tests/MapboxSearchTests/Common/Models/Search Result/SearchResultTests.swift
+++ b/Tests/MapboxSearchTests/Common/Models/Search Result/SearchResultTests.swift
@@ -5,6 +5,7 @@ class SearchResultTests: XCTestCase {
     func testPlacemarkGeneration() throws {
         let resultStub = SearchResultStub(
             id: "unit-test-random",
+            mapboxId: nil,
             name: "Unit Test",
             matchingName: nil,
             serverIndex: nil,

--- a/Tests/MapboxSearchTests/Common/Models/Search Result/ServerSearchResultTests.swift
+++ b/Tests/MapboxSearchTests/Common/Models/Search Result/ServerSearchResultTests.swift
@@ -4,7 +4,7 @@ import XCTest
 class ServerSearchResultTests: XCTestCase {
     func testServerSearchResultNilForUnknownType() {
         let result = ServerSearchResult(
-            coreResult: CoreSearchResultStub(id: UUID().uuidString, type: .unknown),
+            coreResult: CoreSearchResultStub(id: UUID().uuidString, mapboxId: nil, type: .unknown),
             response: CoreSearchResponseStub.failureSample
         )
 
@@ -13,7 +13,7 @@ class ServerSearchResultTests: XCTestCase {
 
     func testServerSearchResultNilForCategoryType() {
         let result = ServerSearchResult(
-            coreResult: CoreSearchResultStub(id: UUID().uuidString, type: .category),
+            coreResult: CoreSearchResultStub(id: UUID().uuidString, mapboxId: nil, type: .category),
             response: CoreSearchResponseStub.failureSample
         )
 
@@ -22,7 +22,7 @@ class ServerSearchResultTests: XCTestCase {
 
     func testServerSearchResultNilForUserRecordType() {
         let result = ServerSearchResult(
-            coreResult: CoreSearchResultStub(id: UUID().uuidString, type: .userRecord),
+            coreResult: CoreSearchResultStub(id: UUID().uuidString, mapboxId: nil, type: .userRecord),
             response: CoreSearchResponseStub.failureSample
         )
 
@@ -31,7 +31,7 @@ class ServerSearchResultTests: XCTestCase {
 
     func testServerSearchResultNilForMissingCoordinates() {
         let result = ServerSearchResult(
-            coreResult: CoreSearchResultStub(id: UUID().uuidString, type: .userRecord, center: nil),
+            coreResult: CoreSearchResultStub(id: UUID().uuidString, mapboxId: nil, type: .userRecord, center: nil),
             response: CoreSearchResponseStub.failureSample
         )
 
@@ -39,7 +39,7 @@ class ServerSearchResultTests: XCTestCase {
     }
 
     func testServerSearchResultPOIFields() throws {
-        let coreResult = CoreSearchResultStub(id: UUID().uuidString, type: .poi)
+        let coreResult = CoreSearchResultStub(id: UUID().uuidString, mapboxId: nil, type: .poi)
         let result = try XCTUnwrap(ServerSearchResult(
             coreResult: coreResult,
             response: CoreSearchResponseStub.failureSample
@@ -55,7 +55,7 @@ class ServerSearchResultTests: XCTestCase {
     }
 
     func testServerSearchResultAddressType() throws {
-        let coreResult = CoreSearchResultStub(id: UUID().uuidString, type: .address)
+        let coreResult = CoreSearchResultStub(id: UUID().uuidString, mapboxId: nil, type: .address)
         let result = try XCTUnwrap(ServerSearchResult(
             coreResult: coreResult,
             response: CoreSearchResponseStub.failureSample

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/CoreSearchResultStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/CoreSearchResultStub.swift
@@ -4,6 +4,7 @@ import CoreLocation
 class CoreSearchResultStub: CoreSearchResultProtocol {
     init(
         id: String,
+        mapboxId: String?,
         resultAccuracy: CoreAccuracy? = nil,
         type: CoreResultType,
         names: [String] = ["sample-name1", "sample-name2"],
@@ -24,6 +25,7 @@ class CoreSearchResultStub: CoreSearchResultProtocol {
         estimatedTime: Measurement<UnitDuration>? = nil
     ) {
         self.id = id
+        self.mapboxId = mapboxId
         self.resultAccuracy = resultAccuracy
         self.resultTypes = [type]
         self.names = names
@@ -46,6 +48,7 @@ class CoreSearchResultStub: CoreSearchResultProtocol {
     convenience init(dataProviderRecord: TestDataProviderRecord) {
         self.init(
             id: dataProviderRecord.id,
+            mapboxId: nil,
             type: dataProviderRecord.type.coreType,
             names: [dataProviderRecord.name],
             languages: ["en"]
@@ -53,6 +56,7 @@ class CoreSearchResultStub: CoreSearchResultProtocol {
     }
 
     var id: String
+    var mapboxId: String?
     var resultAccuracy: CoreAccuracy?
     var resultTypes: [CoreResultType]
     var type: CoreResultType { resultTypes.first ?? .unknown }
@@ -112,6 +116,7 @@ extension CoreSearchResultProtocol {
     var asCoreSearchResult: CoreSearchResult {
         CoreSearchResult(
             id: id,
+            mapboxId: nil,
             types: resultTypes.map { NSNumber(value: $0.rawValue) },
             names: names,
             languages: languages,
@@ -121,10 +126,13 @@ extension CoreSearchResultProtocol {
             fullAddress: nil,
             distance: distance,
             eta: nil,
-            center: center,
+            center: center, // center: center.map { $0.coordinate },
             accuracy: 100,
             routablePoints: routablePoints,
             categories: categories,
+            categoryIDs: [],
+            brand: [],
+            brandID: nil,
             icon: icon,
             metadata: nil,
             externalIDs: nil,

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/CoreSearchResultStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/CoreSearchResultStub.swift
@@ -126,7 +126,7 @@ extension CoreSearchResultProtocol {
             fullAddress: nil,
             distance: distance,
             eta: nil,
-            center: center, // center: center.map { $0.coordinate },
+            center: center,
             accuracy: 100,
             routablePoints: routablePoints,
             categories: categories,

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/IndexableRecordStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/IndexableRecordStub.swift
@@ -20,6 +20,7 @@ struct IndexableRecordStub: IndexableRecord {
     var asResolved: SearchResult {
         SearchResultStub(
             id: id,
+            mapboxId: nil,
             categories: nil,
             name: name,
             matchingName: nil,

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/PlaceAutocompleteSuggestionStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/PlaceAutocompleteSuggestionStub.swift
@@ -9,6 +9,7 @@ extension PlaceAutocomplete.Suggestion {
     ) -> Self {
         .init(
             name: "name",
+            mapboxId: nil,
             description: "description",
             coordinate: CLLocationCoordinate2D(latitude: 10, longitude: 10),
             iconName: "iconName",

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/SearchResultStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/SearchResultStub.swift
@@ -4,6 +4,7 @@ import CoreLocation
 class SearchResultStub: SearchResult {
     init(
         id: String,
+        mapboxId: String?,
         accuracy: SearchResultAccuracy? = nil,
         categories: [String]? = nil,
         name: String,
@@ -19,6 +20,7 @@ class SearchResultStub: SearchResult {
         dataLayerIdentifier: String = "unit-test-stub"
     ) {
         self.id = id
+        self.mapboxId = mapboxId
         self.accuracy = accuracy
         self.categories = categories
         self.name = name
@@ -37,6 +39,7 @@ class SearchResultStub: SearchResult {
     var dataLayerIdentifier: String
 
     var id: String
+    var mapboxId: String?
     var accuracy: SearchResultAccuracy?
     var categories: [String]?
     var name: String
@@ -68,6 +71,7 @@ extension SearchResultStub {
     static var `default`: SearchResultStub {
         SearchResultStub(
             id: "AddressAutofillAddressComponentTests",
+            mapboxId: nil,
             name: "AddressAutofillAddressComponentTests",
             matchingName: nil,
             serverIndex: nil,

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/TestDataProviderRecord.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/TestDataProviderRecord.swift
@@ -4,6 +4,7 @@ import CoreLocation
 struct TestDataProviderRecord: IndexableRecord, SearchResult {
     var type: SearchResultType
     var id: String = UUID().uuidString
+    var mapboxId: String?
     var accuracy: SearchResultAccuracy?
     var name: String
     var matchingName: String?

--- a/Tests/MapboxSearchTests/Legacy/CodablePersistentServiceTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/CodablePersistentServiceTests.swift
@@ -59,6 +59,7 @@ class CodablePersistentServiceTests: XCTestCase {
         let coordinate = CLLocationCoordinate2D(latitude: 10.0, longitude: 10.0)
         let record = HistoryRecord(
             id: UUID().uuidString,
+            mapboxId: nil,
             name: "DaName",
             matchingName: nil,
             serverIndex: nil,

--- a/Tests/MapboxSearchTests/Legacy/HistoryRecordTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/HistoryRecordTests.swift
@@ -5,6 +5,7 @@ class HistoryRecordTests: XCTestCase {
     func testHistoryRecordCategories() throws {
         let record = HistoryRecord(
             id: UUID().uuidString,
+            mapboxId: nil,
             name: "DaName",
             matchingName: nil,
             serverIndex: nil,
@@ -22,6 +23,7 @@ class HistoryRecordTests: XCTestCase {
     func testHistoryRecordCoordinates() {
         var record = HistoryRecord(
             id: UUID().uuidString,
+            mapboxId: nil,
             name: "DaName",
             matchingName: nil,
             serverIndex: nil,
@@ -43,6 +45,7 @@ class HistoryRecordTests: XCTestCase {
     func testHistoryRecordDescriptionText() {
         let record = HistoryRecord(
             id: UUID().uuidString,
+            mapboxId: nil,
             name: "DaName",
             matchingName: nil,
             serverIndex: nil,

--- a/Tests/MapboxSearchTests/Legacy/SearchCategorySuggestionImplTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/SearchCategorySuggestionImplTests.swift
@@ -7,6 +7,7 @@ class SearchCategorySuggestionImplTests: XCTestCase {
         let suggestionImpl = try XCTUnwrap(SearchCategorySuggestionImpl(
             coreResult: CoreSearchResultStub(
                 id: "sample-2",
+                mapboxId: nil,
                 type: .category,
                 center: nil
             ),
@@ -21,7 +22,7 @@ class SearchCategorySuggestionImplTests: XCTestCase {
 
     func testFailedInitForPOI() throws {
         XCTAssertNil(SearchCategorySuggestionImpl(
-            coreResult: CoreSearchResultStub(id: "sample-1", type: .poi, center: nil),
+            coreResult: CoreSearchResultStub(id: "sample-1", mapboxId: nil, type: .poi, center: nil),
             response: CoreSearchResponseStub(
                 id: 42,
                 options: .sample1,

--- a/Tests/MapboxSearchTests/Use Cases/Place Autocomplete/PlaceAutocomplet.Result+Tests.swift
+++ b/Tests/MapboxSearchTests/Use Cases/Place Autocomplete/PlaceAutocomplet.Result+Tests.swift
@@ -5,6 +5,7 @@ final class PlaceAutocompleteResultTests: XCTestCase {
     func testResultContainsISOCountryCodes() throws {
         let coreResult = CoreSearchResultStub(
             id: UUID().uuidString,
+            mapboxId: nil,
             type: .address
         )
         coreResult.metadata = .make(data: [

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -57,7 +57,6 @@ do
     xcodebuild -create-xcframework -output "${RESULT_PRODUCTS_DIR}/${frameworkName}.xcframework" \
       -framework "${DEVICE_ARCHIVE_NAME}/Products/Library/Frameworks/${frameworkName}.framework" \
           -debug-symbols "${DEVICE_ARCHIVE_NAME}/dSYMs/${frameworkName}.framework.dSYM" \
-          -debug-symbols "${DEVICE_ARCHIVE_NAME}/BCSymbolMaps/${DSYM_UUID}.bcsymbolmap" \
       -framework "${SIMULATOR_ARCHIVE_NAME}/Products/Library/Frameworks/${frameworkName}.framework" \
           -debug-symbols "${SIMULATOR_ARCHIVE_NAME}/dSYMs/${frameworkName}.framework.dSYM"
 


### PR DESCRIPTION
### Description
Fixes SSDK-582

- Update MapboxCoreSearch for compatibility with Xcode 15.3 and xcprivacy
- Add mapboxId fields where available
- Add SearchAddressRegion and SearchAddressCountry advanced fields to Address
- Remove bitcode support

### Checklist
- [x] Update `CHANGELOG`
