### PR TITLE
Prepare Release v1.0.0, SDK fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ workflows:
 jobs:
   pre-check:
     macos:
-      xcode: 14.1
+      xcode: 15.2
     steps:
       - checkout
       - ios-install-carthage-dependencies
@@ -86,7 +86,7 @@ jobs:
 
   release-pre-check:
     macos:
-      xcode: 14.1
+      xcode: 15.2
     steps:
       - parse-release-version
       - run:
@@ -96,7 +96,7 @@ jobs:
 
   build:
     macos:
-      xcode: 14.1 # Specify the Xcode version to use
+      xcode: 15.2 # Specify the Xcode version to use
     environment:
       FL_OUTPUT_DIR: ../output
     steps:
@@ -134,7 +134,7 @@ jobs:
 
   release-documentation:
     macos:
-      xcode: 14.1
+      xcode: 15.2
     steps:
       - checkout
       - parse-release-version
@@ -158,7 +158,7 @@ jobs:
 
   documentation-pr:
     macos:
-      xcode: 14.1
+      xcode: 15.2
     steps:
       - checkout
       - parse-release-version
@@ -181,7 +181,7 @@ jobs:
 
   build-for-release:
     macos:
-      xcode: 14.1
+      xcode: 15.2
     steps:
       - checkout
       - setup-authentication
@@ -200,7 +200,7 @@ jobs:
 
   release-ios:
     macos:
-      xcode: 14.1
+      xcode: 15.2
     steps:
       - checkout
       - setup-authentication
@@ -226,7 +226,7 @@ jobs:
 
   post-SDK_Registry-release:
     macos:
-      xcode: 14.1
+      xcode: 15.2
     steps:
       - checkout
       - parse-release-version
@@ -244,7 +244,7 @@ jobs:
 
   spm-build:
     macos:
-      xcode: 14.1
+      xcode: 15.2
     steps:
       - checkout
       - setup-authentication
@@ -286,7 +286,7 @@ commands:
   ios-install-carthage-dependencies:
     steps:
       - setup-authentication
-      # Xcode 14.1 image has Carthage 0.38 so v1 must always update carthage
+      # Always update carthage on v1 due to previous Xcode 14 image
       - upgrade-carthage
       - run: make deps
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,7 @@ jobs:
       - checkout
       - parse-release-version
       - setup-authentication
+      - upgrade-carthage
       - install-mbx-ci-darwin
       - restore_cache:
           keys:
@@ -204,6 +205,7 @@ jobs:
       - checkout
       - setup-authentication
       - parse-release-version
+      - upgrade-carthage
       - run: rm '/usr/local/lib/python3.9/site-packages/six.py'
       - run: brew install awscli gh
       - attach_workspace:
@@ -229,6 +231,7 @@ jobs:
       - checkout
       - parse-release-version
       - setup-authentication
+      - upgrade-carthage
       - install-mbx-ci-darwin
       - run: scripts/generate_podspecs.sh
       - run:

--- a/Brewfile.lock.json
+++ b/Brewfile.lock.json
@@ -95,84 +95,84 @@
         }
       },
       "swiftformat": {
-        "version": "0.53.0",
+        "version": "0.53.8",
         "bottle": {
           "rebuild": 0,
           "root_url": "https://ghcr.io/v2/homebrew/core",
           "files": {
             "arm64_sonoma": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/swiftformat/blobs/sha256:aa82d01460cb74f18d6a7883f1d0238376021f688d8b9b6d4a957d268c0168b9",
-              "sha256": "aa82d01460cb74f18d6a7883f1d0238376021f688d8b9b6d4a957d268c0168b9"
+              "url": "https://ghcr.io/v2/homebrew/core/swiftformat/blobs/sha256:1ddef3d4ed968ab4b125f2afc912fa98d230c82f1887508617d004c830de7ba3",
+              "sha256": "1ddef3d4ed968ab4b125f2afc912fa98d230c82f1887508617d004c830de7ba3"
             },
             "arm64_ventura": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/swiftformat/blobs/sha256:e523a4a0eb43355c54bf957bd46efe114c3d57d59baca6bac45945be052f3f97",
-              "sha256": "e523a4a0eb43355c54bf957bd46efe114c3d57d59baca6bac45945be052f3f97"
+              "url": "https://ghcr.io/v2/homebrew/core/swiftformat/blobs/sha256:1bd1c63ed5e620ef6d183e989988c082c0b8e86ee2f3f4e171496a4945371859",
+              "sha256": "1bd1c63ed5e620ef6d183e989988c082c0b8e86ee2f3f4e171496a4945371859"
             },
             "arm64_monterey": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/swiftformat/blobs/sha256:1793afbeafcb6fe60d8255df281330377a2f371ef60a9b7416e431b2927f17f5",
-              "sha256": "1793afbeafcb6fe60d8255df281330377a2f371ef60a9b7416e431b2927f17f5"
+              "url": "https://ghcr.io/v2/homebrew/core/swiftformat/blobs/sha256:b9a134644f14a2c0876722dc94a68c494b5d0c0dbf194a4ccf89c45d1dad2134",
+              "sha256": "b9a134644f14a2c0876722dc94a68c494b5d0c0dbf194a4ccf89c45d1dad2134"
             },
             "sonoma": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/swiftformat/blobs/sha256:0405f4bcc38dab6929e121a8325f4a9f3466c5877319405bf5be3113ca0da440",
-              "sha256": "0405f4bcc38dab6929e121a8325f4a9f3466c5877319405bf5be3113ca0da440"
+              "url": "https://ghcr.io/v2/homebrew/core/swiftformat/blobs/sha256:8afd7ce153fdd12702933ff900f8d77e5a44984f4db871968ef68ed94a23524f",
+              "sha256": "8afd7ce153fdd12702933ff900f8d77e5a44984f4db871968ef68ed94a23524f"
             },
             "ventura": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/swiftformat/blobs/sha256:b657bf5179f3a3f37034a4ac8fa6cf2034e26b299893962abe6a5797056419da",
-              "sha256": "b657bf5179f3a3f37034a4ac8fa6cf2034e26b299893962abe6a5797056419da"
+              "url": "https://ghcr.io/v2/homebrew/core/swiftformat/blobs/sha256:eab0600963983c83b7eaada1572f7ff7520a501de627da32655ccdd6f4fa4827",
+              "sha256": "eab0600963983c83b7eaada1572f7ff7520a501de627da32655ccdd6f4fa4827"
             },
             "monterey": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/swiftformat/blobs/sha256:49c4ad218030c4838c6f580c756361ad2f7aafbe5e3bcf066852eb301b9da1c4",
-              "sha256": "49c4ad218030c4838c6f580c756361ad2f7aafbe5e3bcf066852eb301b9da1c4"
+              "url": "https://ghcr.io/v2/homebrew/core/swiftformat/blobs/sha256:fbbd4736efe82680d21f5cc0778c7755d9718d96340b26287ae7e274f46fcde2",
+              "sha256": "fbbd4736efe82680d21f5cc0778c7755d9718d96340b26287ae7e274f46fcde2"
             },
             "x86_64_linux": {
               "cellar": "/home/linuxbrew/.linuxbrew/Cellar",
-              "url": "https://ghcr.io/v2/homebrew/core/swiftformat/blobs/sha256:7902b0f146262c46433aaa2289eab30d133bcbcd83ec3dfdd9f182a39d087ebe",
-              "sha256": "7902b0f146262c46433aaa2289eab30d133bcbcd83ec3dfdd9f182a39d087ebe"
+              "url": "https://ghcr.io/v2/homebrew/core/swiftformat/blobs/sha256:9ed455d558a4ff04259d556f748b35fb28b155897024244b89a524648aee8bd0",
+              "sha256": "9ed455d558a4ff04259d556f748b35fb28b155897024244b89a524648aee8bd0"
             }
           }
         }
       },
       "xcodegen": {
-        "version": "2.38.0",
+        "version": "2.40.1",
         "bottle": {
           "rebuild": 0,
           "root_url": "https://ghcr.io/v2/homebrew/core",
           "files": {
             "arm64_sonoma": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/xcodegen/blobs/sha256:422fb8dfbc7e2ed59125d22b4687bb54a1ab3f0ddef044a3875b624121f9be47",
-              "sha256": "422fb8dfbc7e2ed59125d22b4687bb54a1ab3f0ddef044a3875b624121f9be47"
+              "url": "https://ghcr.io/v2/homebrew/core/xcodegen/blobs/sha256:97ef2bd7b87e9bbe2fea19d075453a2e00c8514fe6ed359a109153f87518c0dc",
+              "sha256": "97ef2bd7b87e9bbe2fea19d075453a2e00c8514fe6ed359a109153f87518c0dc"
             },
             "arm64_ventura": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/xcodegen/blobs/sha256:5b2d9dfdf8bc9912ecef48ecc4a03cfb4ba68f35f03c4ab4fc9e893b077f8796",
-              "sha256": "5b2d9dfdf8bc9912ecef48ecc4a03cfb4ba68f35f03c4ab4fc9e893b077f8796"
+              "url": "https://ghcr.io/v2/homebrew/core/xcodegen/blobs/sha256:01ae513fb69bac9e8d43ca2d811fb9a55a332a3b61b584bb4938283114e912de",
+              "sha256": "01ae513fb69bac9e8d43ca2d811fb9a55a332a3b61b584bb4938283114e912de"
             },
             "arm64_monterey": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/xcodegen/blobs/sha256:7a239feca86c46f78ae91d631858d957cb2e7e63ea7230b30f3d618097774bff",
-              "sha256": "7a239feca86c46f78ae91d631858d957cb2e7e63ea7230b30f3d618097774bff"
+              "url": "https://ghcr.io/v2/homebrew/core/xcodegen/blobs/sha256:cf8e788bd89f036e9b96103cb0e687bda487f72bff0f9f2ff4d2a3ebeb889e01",
+              "sha256": "cf8e788bd89f036e9b96103cb0e687bda487f72bff0f9f2ff4d2a3ebeb889e01"
             },
             "sonoma": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/xcodegen/blobs/sha256:346164300a7e835f8516c70b25793702bab2437d7e9fb606b5394ab757dab4f5",
-              "sha256": "346164300a7e835f8516c70b25793702bab2437d7e9fb606b5394ab757dab4f5"
+              "url": "https://ghcr.io/v2/homebrew/core/xcodegen/blobs/sha256:65ec3152dae81228b5cf4aefd85743277d755cf3036b6822c5395d53e1e4137c",
+              "sha256": "65ec3152dae81228b5cf4aefd85743277d755cf3036b6822c5395d53e1e4137c"
             },
             "ventura": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/xcodegen/blobs/sha256:2bca799f6fee1e679a3f826a9a977449a23f81f02896b22a525056f6cd4a07dd",
-              "sha256": "2bca799f6fee1e679a3f826a9a977449a23f81f02896b22a525056f6cd4a07dd"
+              "url": "https://ghcr.io/v2/homebrew/core/xcodegen/blobs/sha256:02ca0a9a4947ab51dcc400f48f0ca12e0e18788954c4dadd8c6b6376534d55a4",
+              "sha256": "02ca0a9a4947ab51dcc400f48f0ca12e0e18788954c4dadd8c6b6376534d55a4"
             },
             "monterey": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/xcodegen/blobs/sha256:3e306a4b9ad078c77b61d93090c224304c7dac35ca119808db87792edb983be8",
-              "sha256": "3e306a4b9ad078c77b61d93090c224304c7dac35ca119808db87792edb983be8"
+              "url": "https://ghcr.io/v2/homebrew/core/xcodegen/blobs/sha256:5b8a174ea297454f4aa1f26753e361f7c051ee73a2b4b1529e999dac090edf24",
+              "sha256": "5b8a174ea297454f4aa1f26753e361f7c051ee73a2b4b1529e999dac090edf24"
             }
           }
         }
@@ -188,6 +188,14 @@
         "CLT": "15.1.0.0.1.1700200546",
         "Xcode": "14.1",
         "macOS": "13.6.3"
+      },
+      "sonoma": {
+        "HOMEBREW_VERSION": "4.2.20",
+        "HOMEBREW_PREFIX": "/opt/homebrew",
+        "Homebrew/homebrew-core": "api",
+        "CLT": "15.3.0.0.1.1708646388",
+        "Xcode": "15.2",
+        "macOS": "14.4.1"
       }
     }
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Guide: https://keepachangelog.com/en/1.0.0/
 - [Address] Added SearchAddressRegion containing name, regionCode, and regionCodeFull fields.
 - [Address] Added SearchAddressCountry containing name, countryCode, and regionCodeFull fields.
 - [Address] Added fields searchAddressRegion and searchAddressCountry to Address alongside existing country and region.
+- [Core] Add `SearchResultAccuracy.proximate` case which "is a known address point but does not intersect a known rooftop/parcel."
 - [Core] Update to MapboxCoreSearch v1.0.1 with PrivacyInfo.xcprivacy and compatibility with Xcode 15.3
 - [Core] Build with Xcode 15.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
-## 1.0.0-rc.10 - 2024-04-29
+## 1.0.0 - 2024-04-30
 
 - [SearchResult] Add support for mapboxId field when available.
 - [FavoriteRecord] Add support for mapboxId field when available.
@@ -22,6 +22,7 @@ Guide: https://keepachangelog.com/en/1.0.0/
 - [Address] Added fields searchAddressRegion and searchAddressCountry to Address alongside existing country and region.
 - [Core] Update to MapboxCoreSearch v1.0.1 with PrivacyInfo.xcprivacy and compatibility with Xcode 15.3
 
+**MapboxCommon**: v23.0.0
 **MapboxCoreSearch**: v1.0.1
 
 ## 1.0.0-rc.9 - 2024-04-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Guide: https://keepachangelog.com/en/1.0.0/
 - [Core] Update to MapboxCoreSearch v1.0.1 with PrivacyInfo.xcprivacy and compatibility with Xcode 15.3
 - [Core] Build with Xcode 15.2
 
-**MapboxCommon**: v23.0.0
+**MapboxCommon**: v23.9.2
 **MapboxCoreSearch**: v1.0.1
 
 ## 1.0.0-rc.9 - 2024-04-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Guide: https://keepachangelog.com/en/1.0.0/
 - [Address] Added SearchAddressCountry containing name, countryCode, and regionCodeFull fields.
 - [Address] Added fields searchAddressRegion and searchAddressCountry to Address alongside existing country and region.
 - [Core] Update to MapboxCoreSearch v1.0.1 with PrivacyInfo.xcprivacy and compatibility with Xcode 15.3
+- [Core] Build with Xcode 15.2
 
 **MapboxCommon**: v23.0.0
 **MapboxCoreSearch**: v1.0.1

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 1.0.1
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 23.6.0
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 23.9.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "23.6.0"
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "23.9.2"
 binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "1.0.1"

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearch'
-  s.version          = '1.0.0-rc.9'
+  s.version          = '1.0.0'
   s.summary          = 'Search SDK for Mapbox Search API '
 
 # This description is used to generate tags and improve search results.

--- a/MapboxSearchUI.podspec
+++ b/MapboxSearchUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearchUI'
-  s.version          = '1.0.0-rc.9'
+  s.version          = '1.0.0'
   s.summary          = 'Search UI for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.
@@ -23,5 +23,5 @@ Card style custom UI with full search functionality powered by Mapbox Search API
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency 'MapboxSearch', "1.0.0-rc.9"
+  s.dependency 'MapboxSearch', "1.0.0"
 end

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import Foundation
 
 let (coreSearchVersion, coreSearchVersionHash) = ("1.0.1", "5eb2eedb0d121ffde307ce36a10d2d62bb40cc7c0c0b75abe4364181bd5287d4")
 
-let commonMinVersion = Version("23.6.0")
+let commonMinVersion = Version("23.9.2")
 let commonMaxVersion = Version("24.0.0")
 
 let package = Package(

--- a/README.md
+++ b/README.md
@@ -108,13 +108,13 @@ MapboxSearchDemoApplication provides a Demo app wih MapboxSearchUI.framework pre
 ##### MapboxSearch
 To integrate latest preview version of `MapboxSearch` into your Xcode project using CocoaPods, specify it in your `Podfile`:  
 ```
-pod 'MapboxSearch', ">= 1.0.0-rc.9", "< 2.0"
+pod 'MapboxSearch', ">= 1.0.0", "< 2.0"
 ```
 
 ##### MapboxSearchUI
 To integrate latest preview version of `MapboxSearchUI` into your Xcode project using CocoaPods, specify it in your `Podfile`:  
 ```
-pod 'MapboxSearchUI', ">= 1.0.0-rc.9", "< 2.0"
+pod 'MapboxSearchUI', ">= 1.0.0", "< 2.0"
 ```
 
 ### Swift Package Manager

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/mapbox/mapbox-search-ios/tree/main.svg?style=shield)](https://dl.circleci.com/status-badge/redirect/gh/mapbox/mapbox-search-ios/tree/main)
 [![Swift version](https://img.shields.io/badge/swift-5.7.1+-orange.svg?style=flat&logo=swift)](https://developer.apple.com/swift)
 [![iOS version](https://img.shields.io/badge/iOS-12.0+-green.svg?style=flat&logo=apple)](https://developer.apple.com/ios/)
-[![Xcode version](https://img.shields.io/badge/Xcode-14.1+-DeepSkyBlue.svg?style=flat&logo=xcode&logoColor=lightGray)](https://developer.apple.com/xcode/)
+[![Xcode version](https://img.shields.io/badge/Xcode-15.2+-DeepSkyBlue.svg?style=flat&logo=xcode&logoColor=lightGray)](https://developer.apple.com/xcode/)
 [![codecov](https://codecov.io/gh/mapbox/mapbox-search-ios/branch/develop/graph/badge.svg?token=js3DSKdda4)](https://codecov.io/gh/mapbox/mapbox-search-ios)
 [![swift-doc](https://img.shields.io/badge/swift--doc-64.94%25-orange?logo=read-the-docs)](https://github.com/SwiftDocOrg/swift-doc)
 # Mapbox Search SDK for iOS
@@ -35,7 +35,7 @@ The Search SDK is pre-configured for autocomplete, local search biasing, and inc
 ## Requirements
 
 - iOS 12.0 and newer
-- Xcode 14 and newer
+- Xcode 15 and newer
 - Swift 5.7.1 and newer
 - Objective-C is not supported
 - macOS/tvOS/watchOS platforms currently are not supported

--- a/Search Documentation.docc/Installation.md
+++ b/Search Documentation.docc/Installation.md
@@ -59,7 +59,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearchUI', ">= 1.0.0-rc.9", "< 2.0"
+      pod 'MapboxSearchUI', ">= 1.0.0", "< 2.0"
     end
     ```
 
@@ -68,7 +68,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearch', ">= 1.0.0-rc.9", "< 2.0"
+      pod 'MapboxSearch', ">= 1.0.0", "< 2.0"
     end
     ```
 

--- a/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
+++ b/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
@@ -1,2 +1,2 @@
 /// Mapbox Search SDK version variable
-public let mapboxSearchSDKVersion = "1.0.0-rc.9"
+public let mapboxSearchSDKVersion = "1.0.0"

--- a/Sources/MapboxSearch/PublicAPI/SearchResultAccuracy.swift
+++ b/Sources/MapboxSearch/PublicAPI/SearchResultAccuracy.swift
@@ -17,6 +17,9 @@ public enum SearchResultAccuracy: String, Codable {
     /// Result is a known address point but has no specific accuracy.
     case point
 
+    /// Result is a known address point but does not intersect a known rooftop/parcel.
+    case proximate
+
     /// Result is for a specific building/entrance.
     case rooftop
 
@@ -34,6 +37,7 @@ extension SearchResultAccuracy {
         case .point: return .point
         case .rooftop: return .rooftop
         case .street: return .street
+        case .proximate: return .proximate
 
         @unknown default:
             return nil

--- a/Tests/MapboxSearchIntegrationTests/AddressAutofillIntegrationTests.swift
+++ b/Tests/MapboxSearchIntegrationTests/AddressAutofillIntegrationTests.swift
@@ -47,7 +47,7 @@ final class AddressAutofillIntegrationTests: MockServerIntegrationTestCase<Autof
             }
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 5)
+        wait(for: [expectation], timeout: 10)
 
         let expectedAddress = Address(
             houseNumber: "701",
@@ -82,7 +82,7 @@ final class AddressAutofillIntegrationTests: MockServerIntegrationTestCase<Autof
             selectionExpectation.fulfill()
         }
 
-        wait(for: [selectionExpectation], timeout: 5)
+        wait(for: [selectionExpectation], timeout: 10)
     }
 
     func testSelectSuggestionFromCoordinate() throws {
@@ -104,7 +104,7 @@ final class AddressAutofillIntegrationTests: MockServerIntegrationTestCase<Autof
             expectation.fulfill()
         }
 
-        wait(for: [expectation], timeout: 5)
+        wait(for: [expectation], timeout: 10)
 
         let expectedAddress = Address(
             houseNumber: "701",
@@ -139,7 +139,7 @@ final class AddressAutofillIntegrationTests: MockServerIntegrationTestCase<Autof
             selectionExpectation.fulfill()
         }
 
-        wait(for: [selectionExpectation], timeout: 5)
+        wait(for: [selectionExpectation], timeout: 10)
     }
 }
 


### PR DESCRIPTION
### Description

- Update MapboxCommon and MapboxCoreSearch
- Fix source compatibility with new SearchResultAccuracy enum case
- Update to Xcode 15.2 for PrivacyInfo.xcprivacy
- Apply Carthage update for release CI
- Update documentation

### Checklist
- [x] Update `CHANGELOG`
