### PR TITLE
Raise the next major version of the MapboxSearchUI podspec version range

### DIFF
--- a/scripts/generate_podspecs.sh
+++ b/scripts/generate_podspecs.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+# Version will be populated from the branch name in the `parse-release-version` CI step
 set +u
 if [[ -z $VERSION ]];then
     exit 1
@@ -8,4 +9,4 @@ set -u
 
 sed -i '' "s/\(s.version.*\)=.*/\1= '${VERSION}'/g" MapboxSearch.podspec
 sed -i '' "s/\(s.version.*\)=.*/\1= '${VERSION}'/g" MapboxSearchUI.podspec
-sed -i '' "s/\(dependency 'MapboxSearch', \).*/\1\">= ${VERSION}\", \"< 2.0\"/g" MapboxSearchUI.podspec
+sed -i '' "s/\(dependency 'MapboxSearch', \).*/\1\">= ${VERSION}\", \"< 3.0\"/g" MapboxSearchUI.podspec


### PR DESCRIPTION
### Description
- Now that `main` is on release v2 the podspec needs to use a higher next-major-version for release builds to succeed

#### Steps to reproduce

1. `export VERSION="2.0.0"`
2. ./scripts/generate_podspecs.sh
3. Inspect MapboxSearchUI.podspec specifically for `s.dependency 'MapboxSearch', ">= 2.0.0", "< 3.0"`

### Checklist
- [NA] Update `CHANGELOG`
