### PR TITLE
Prepare 2.0.2 release, update MapboxCoreSearch for Xcode 15.3, Privacy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
+- [Core] Update to MapboxCoreSearch v2.0.1 for corrected compatibility with Xcode 15.3
+- [Core] Update to MapboxCoreSearch for corrected PrivacyInfo.xcprivacy
+
+**MapboxCoreSearch**: v2.0.1
+
 ## 2.0.1
 
 - [Core] Update to MapboxCoreSearch v2.0.0-beta.19 for compatibility with Xcode 15.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
+## 2.0.2
+
 - [Core] Update to MapboxCoreSearch v2.0.1 for corrected compatibility with Xcode 15.3
 - [Core] Update to MapboxCoreSearch for corrected PrivacyInfo.xcprivacy
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.0.0-beta.19
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.0.1
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.4.0-beta.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.4.0-beta.2"
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.0.0-beta.19"
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.0.1"

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearch'
-  s.version          = '2.0.1'
+  s.version          = '2.0.2'
   s.summary          = 'Search SDK for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.

--- a/MapboxSearchUI.podspec
+++ b/MapboxSearchUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearchUI'
-  s.version          = '2.0.1'
+  s.version          = '2.0.2'
   s.summary          = 'Search UI for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.
@@ -23,5 +23,5 @@ Card style custom UI with full search functionality powered by Mapbox Search API
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency 'MapboxSearch', "2.0.1"
+  s.dependency 'MapboxSearch', "2.0.2"
 end

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 import Foundation
 
-let (coreSearchVersion, coreSearchVersionHash) = ("2.0.0-beta.19", "129cb128da68ffd156dc1cd62d9f6600ee875fd8b1225c7b701ae1f579558849")
+let (coreSearchVersion, coreSearchVersionHash) = ("2.0.1", "d8f5b2af3a42aa0957799b7b9a3874050fc5e0d2402dbe5a6a9105f3765432b1")
 
 let commonMinVersion = Version("24.4.0-beta.2")
 let commonMaxVersion = Version("25.0.0")

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ Once you've installed the prerequisites, no additional steps are needed: Open th
 
 You can find the following documentation pages helpful:
 - [Search SDK for iOS guide](https://docs.mapbox.com/ios/search/guides/)
-- [MapboxSearch reference](https://docs.mapbox.com/ios/search/api/core/2.0.1/)
-- [MapboxSearchUI reference](https://docs.mapbox.com/ios/search/api/ui/2.0.1/)
+- [MapboxSearch reference](https://docs.mapbox.com/ios/search/api/core/2.0.2/)
+- [MapboxSearchUI reference](https://docs.mapbox.com/ios/search/api/ui/2.0.2/)
 
 ## Project structure overview
 
@@ -108,13 +108,13 @@ MapboxSearchDemoApplication provides a Demo app wih MapboxSearchUI.framework pre
 ##### MapboxSearch
 To integrate latest preview version of `MapboxSearch` into your Xcode project using CocoaPods, specify it in your `Podfile`:  
 ```
-pod 'MapboxSearch', ">= 2.0.1", "< 3.0"
+pod 'MapboxSearch', ">= 2.0.2", "< 3.0"
 ```
 
 ##### MapboxSearchUI
 To integrate latest preview version of `MapboxSearchUI` into your Xcode project using CocoaPods, specify it in your `Podfile`:  
 ```
-pod 'MapboxSearchUI', ">= 2.0.1", "< 3.0"
+pod 'MapboxSearchUI', ">= 2.0.2", "< 3.0"
 ```
 
 ### Swift Package Manager

--- a/Search Documentation.docc/Installation.md
+++ b/Search Documentation.docc/Installation.md
@@ -59,7 +59,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearchUI', ">= 2.0.1", "< 3.0"
+      pod 'MapboxSearchUI', ">= 2.0.2", "< 3.0"
     end
     ```
 
@@ -68,7 +68,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearch', ">= 2.0.1", "< 3.0"
+      pod 'MapboxSearch', ">= 2.0.2", "< 3.0"
     end
     ```
 

--- a/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
+++ b/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
@@ -1,2 +1,2 @@
 /// Mapbox Search SDK version variable
-public let mapboxSearchSDKVersion = "2.0.1"
+public let mapboxSearchSDKVersion = "2.0.2"


### PR DESCRIPTION
### Description

- Update MapboxCoreSearch to v2.0.1 to correct Xcode 15.3 compatibility and PrivacyInfo.xcprivacy
- Increment MapboxSearch and MapboxSearchUI version to 2.0.2

### Checklist
- [x] Update `CHANGELOG`
