### PR TITLE
Align dependencies on fixed versions, prepare 2.0.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
+- [Core] Align MapboxCommon dependency with 24.3.1
+
+**MapboxCommon**: v24.3.1
+
 ## 2.0.2
 
 - [Core] Update to MapboxCoreSearch v2.0.1 for corrected compatibility with Xcode 15.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ Guide: https://keepachangelog.com/en/1.0.0/
 ## 2.0.3
 
 - [Core] Change MapboxCommon dependency to use exact versions in SPM and CocoaPods
-- [Core] Align MapboxCommon dependency with 24.3.1
+- [Core] Align MapboxCommon dependency with exact version 24.3.1
+- [Core] Update to MapboxCoreSearch v2.0.2 to align dependencies
 
 **MapboxCommon**: v24.3.1
+**MapboxCoreSearch**: v2.0.2
 
 ## 2.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 ## 2.0.3
 
+- [Core] Change MapboxCommon dependency to use exact versions in SPM and CocoaPods
 - [Core] Align MapboxCommon dependency with 24.3.1
 
 **MapboxCommon**: v24.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
+## 2.0.3
+
 - [Core] Align MapboxCommon dependency with 24.3.1
 
 **MapboxCommon**: v24.3.1

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.0.1
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.0.2
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.3.1

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.0.1
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.4.0-beta.2
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.3.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.3.1"
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.0.1"
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.0.2"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.4.0-beta.2"
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.3.1"
 binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.0.1"

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem "cocoapods"
 gem "fastlane"
 gem "jazzy", "~> 0.14.4"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -305,9 +305,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  cocoapods
   fastlane
   fastlane-plugin-versioning
-  jazzy
+  jazzy (~> 0.14.4)
 
 BUNDLED WITH
    2.5.9

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -24,5 +24,5 @@ Some iOS platform specifics applies.
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency "MapboxCommon", '~> 24.4.0-beta.2'
+  s.dependency "MapboxCommon", '~> 24.3.1'
 end

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -24,5 +24,5 @@ Some iOS platform specifics applies.
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency "MapboxCommon", '~> 24.3.1'
+  s.dependency "MapboxCommon", '24.3.1'
 end

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearch'
-  s.version          = '2.0.2'
+  s.version          = '2.0.3'
   s.summary          = 'Search SDK for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.

--- a/MapboxSearchUI.podspec
+++ b/MapboxSearchUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearchUI'
-  s.version          = '2.0.2'
+  s.version          = '2.0.3'
   s.summary          = 'Search UI for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.
@@ -23,5 +23,5 @@ Card style custom UI with full search functionality powered by Mapbox Search API
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency 'MapboxSearch', "2.0.2"
+  s.dependency 'MapboxSearch', "2.0.3"
 end

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import Foundation
 
 let (coreSearchVersion, coreSearchVersionHash) = ("2.0.1", "d8f5b2af3a42aa0957799b7b9a3874050fc5e0d2402dbe5a6a9105f3765432b1")
 
-let commonMinVersion = Version("24.4.0-beta.2")
+let commonMinVersion = Version("24.3.1")
 let commonMaxVersion = Version("25.0.0")
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 import Foundation
 
-let (coreSearchVersion, coreSearchVersionHash) = ("2.0.1", "d8f5b2af3a42aa0957799b7b9a3874050fc5e0d2402dbe5a6a9105f3765432b1")
+let (coreSearchVersion, coreSearchVersionHash) = ("2.0.2", "56538985a977f935b211a0cd16065c5d49afd739fa12315b55edf1aeb3985a5b")
 
 let mapboxCommonSDKVersion = Version("24.3.1")
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,8 +6,7 @@ import Foundation
 
 let (coreSearchVersion, coreSearchVersionHash) = ("2.0.1", "d8f5b2af3a42aa0957799b7b9a3874050fc5e0d2402dbe5a6a9105f3765432b1")
 
-let commonMinVersion = Version("24.3.1")
-let commonMaxVersion = Version("25.0.0")
+let mapboxCommonSDKVersion = Version("24.3.1")
 
 let package = Package(
     name: "MapboxSearch",
@@ -25,7 +24,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", commonMinVersion..<commonMaxVersion),
+        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", .exact(mapboxCommonSDKVersion)),
         .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", from: "2.0.0")
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ Once you've installed the prerequisites, no additional steps are needed: Open th
 
 You can find the following documentation pages helpful:
 - [Search SDK for iOS guide](https://docs.mapbox.com/ios/search/guides/)
-- [MapboxSearch reference](https://docs.mapbox.com/ios/search/api/core/2.0.2/)
-- [MapboxSearchUI reference](https://docs.mapbox.com/ios/search/api/ui/2.0.2/)
+- [MapboxSearch reference](https://docs.mapbox.com/ios/search/api/core/2.0.3/)
+- [MapboxSearchUI reference](https://docs.mapbox.com/ios/search/api/ui/2.0.3/)
 
 ## Project structure overview
 
@@ -108,13 +108,13 @@ MapboxSearchDemoApplication provides a Demo app wih MapboxSearchUI.framework pre
 ##### MapboxSearch
 To integrate latest preview version of `MapboxSearch` into your Xcode project using CocoaPods, specify it in your `Podfile`:  
 ```
-pod 'MapboxSearch', ">= 2.0.2", "< 3.0"
+pod 'MapboxSearch', ">= 2.0.3", "< 3.0"
 ```
 
 ##### MapboxSearchUI
 To integrate latest preview version of `MapboxSearchUI` into your Xcode project using CocoaPods, specify it in your `Podfile`:  
 ```
-pod 'MapboxSearchUI', ">= 2.0.2", "< 3.0"
+pod 'MapboxSearchUI', ">= 2.0.3", "< 3.0"
 ```
 
 ### Swift Package Manager

--- a/Search Documentation.docc/Installation.md
+++ b/Search Documentation.docc/Installation.md
@@ -59,7 +59,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearchUI', ">= 2.0.2", "< 3.0"
+      pod 'MapboxSearchUI', ">= 2.0.3", "< 3.0"
     end
     ```
 
@@ -68,7 +68,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearch', ">= 2.0.2", "< 3.0"
+      pod 'MapboxSearch', ">= 2.0.3", "< 3.0"
     end
     ```
 

--- a/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
+++ b/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
@@ -1,2 +1,2 @@
 /// Mapbox Search SDK version variable
-public let mapboxSearchSDKVersion = "2.0.2"
+public let mapboxSearchSDKVersion = "2.0.3"


### PR DESCRIPTION
### Description

- Prepare MapboxSearch and MapboxSearchUI v2.0.3 release
- [Core] Change MapboxCommon dependency to use exact versions in SPM and CocoaPods
- [Core] Align MapboxCommon dependency with exact version 24.3.1
- [Core] Update to MapboxCoreSearch v2.0.2 to align dependencies

### Checklist
- [x] Update `CHANGELOG`
