### PR TITLE
Fix warnings and revise swiftlint rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -29,7 +29,10 @@ nesting:
 
 custom_rules:
   dont_use_print:
-    included: ".*\\.swift"
+    included:
+      - ".*\\.swift"
+    excluded:
+      - "Sources/Demo"
     name: "Don't use `print`"
     regex: "(^|[^\\w])(print)\\("
     match_kinds:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -40,3 +40,11 @@ custom_rules:
     capture_group: 2
     message: "Use Log[<category>] from Common shared library (not MapboxCommon) instead of `print`s."
     severity: warning
+  _preferWillMoveToWindow:
+    name: Warning on willMove(toSuperview:)
+    regex: '(override func willMove\(toSuperview|override func awakeFromNib\(\))'
+    message: "'configuration' variable is not accessible yet. Use `willMove(toWindow:)` instead"
+    match_kinds:
+      - attribute.builtin
+      - keyword
+      - identifier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
+- [Address] Change Country.ISO3166_1_alpha2 enum to public
+
 ## 2.0.3
 
 - [Core] Change MapboxCommon dependency to use exact versions in SPM and CocoaPods

--- a/MapboxSearch.xcodeproj/project.pbxproj
+++ b/MapboxSearch.xcodeproj/project.pbxproj
@@ -2066,7 +2066,6 @@
 				F9C557992670CB0400BE8B94 /* Frameworks */,
 				F9C5579F2670CB0400BE8B94 /* Resources */,
 				F9C557AB2670CB0400BE8B94 /* SwiftLint */,
-				F9C557AC2670CB0400BE8B94 /* Inject Mapbox API key */,
 			);
 			buildRules = (
 			);
@@ -2454,29 +2453,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if [[ \"$(uname -m)\" == \"arm64\" ]]; then\n  export PATH=\"/opt/homebrew/bin:${PATH}\"\nfi\nif which swiftlint >/dev/null; then\n    swiftlint --config \"${SRCROOT}/.swiftlint.yml\" \"${SRCROOT}/Tests/MapboxSearchTests\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		F9C557AC2670CB0400BE8B94 /* Inject Mapbox API key */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
-				"$(HOME)/.mapbox",
-				"$(HOME)/mapbox",
-				"$(SRCROOT)/.mapbox",
-			);
-			name = "Inject Mapbox API key";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Source: https://docs.mapbox.com/help/troubleshooting/private-access-token-android-and-ios/#ios\n# Look for a global file named 'mapbox' or '.mapbox' within the home directory\ntoken_file=\"${SCRIPT_INPUT_FILE_1}\"\ntoken_file2=\"${SCRIPT_INPUT_FILE_2}\"\ntoken_file3=\"${SCRIPT_INPUT_FILE_3}\"\ntoken=\"$(cat \"$token_file3\" 2>/dev/null || cat \"$token_file\" 2>/dev/null || cat \"$token_file2\" 2>/dev/null)\"\nif [ \"$token\" ]; then\n  plutil -replace MBXAccessToken -string \"$token\" \"$SCRIPT_INPUT_FILE_0\"\nelse\n  echo 'warning: Missing Mapbox access token'\n  open 'https://www.mapbox.com/account/access-tokens/'\n  echo \"warning: Get an access token from <https://www.mapbox.com/account/access-tokens/>, then create a new file at \"$token_file3\" or \"$token_file\" or \"$token_file2\" that contains the access token.\"\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		FEBC00E5243C6D96000B268B /* Inject Mapbox API key */ = {

--- a/MapboxSearch.xcodeproj/project.pbxproj
+++ b/MapboxSearch.xcodeproj/project.pbxproj
@@ -2380,6 +2380,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		0474F7C92B4609610079D74D /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -2398,6 +2399,7 @@
 		};
 		3A2CBBD4238B0FF400A5BA69 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -2417,6 +2419,7 @@
 		};
 		3A2CBBD5238B105500A5BA69 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -2436,6 +2439,7 @@
 		};
 		F9C557AB2670CB0400BE8B94 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -2524,6 +2528,7 @@
 		};
 		FEBC00E6243C6DE4000B268B /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -2561,6 +2566,7 @@
 		};
 		FEEDD3D42508E5E600DC0A98 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/MapboxSearch.xcodeproj/project.pbxproj
+++ b/MapboxSearch.xcodeproj/project.pbxproj
@@ -2020,7 +2020,6 @@
 				3A0D7E52233522D4006D81BB /* Frameworks */,
 				3A0D7E53233522D4006D81BB /* Resources */,
 				3A2CBBD5238B105500A5BA69 /* SwiftLint */,
-				FE1439F823C5CE08009D98D2 /* Inject Mapbox API key */,
 			);
 			buildRules = (
 			);
@@ -2458,29 +2457,6 @@
 			showEnvVarsInLog = 0;
 		};
 		F9C557AC2670CB0400BE8B94 /* Inject Mapbox API key */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
-				"$(HOME)/.mapbox",
-				"$(HOME)/mapbox",
-				"$(SRCROOT)/.mapbox",
-			);
-			name = "Inject Mapbox API key";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Source: https://docs.mapbox.com/help/troubleshooting/private-access-token-android-and-ios/#ios\n# Look for a global file named 'mapbox' or '.mapbox' within the home directory\ntoken_file=\"${SCRIPT_INPUT_FILE_1}\"\ntoken_file2=\"${SCRIPT_INPUT_FILE_2}\"\ntoken_file3=\"${SCRIPT_INPUT_FILE_3}\"\ntoken=\"$(cat \"$token_file3\" 2>/dev/null || cat \"$token_file\" 2>/dev/null || cat \"$token_file2\" 2>/dev/null)\"\nif [ \"$token\" ]; then\n  plutil -replace MBXAccessToken -string \"$token\" \"$SCRIPT_INPUT_FILE_0\"\nelse\n  echo 'warning: Missing Mapbox access token'\n  open 'https://www.mapbox.com/account/access-tokens/'\n  echo \"warning: Get an access token from <https://www.mapbox.com/account/access-tokens/>, then create a new file at \"$token_file3\" or \"$token_file\" or \"$token_file2\" that contains the access token.\"\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		FE1439F823C5CE08009D98D2 /* Inject Mapbox API key */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (

--- a/MapboxSearch.xcodeproj/project.pbxproj
+++ b/MapboxSearch.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -2150,8 +2150,9 @@
 		3A0D7E43233522D4006D81BB /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1250;
-				LastUpgradeCheck = 1340;
+				LastUpgradeCheck = 1530;
 				ORGANIZATIONNAME = Mapbox;
 				TargetAttributes = {
 					3A0D7E4B233522D4006D81BB = {
@@ -3117,6 +3118,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 4;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -3146,6 +3148,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 4;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -3400,6 +3403,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = "";
@@ -3434,6 +3438,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = "";

--- a/MapboxSearch.xcodeproj/project.pbxproj
+++ b/MapboxSearch.xcodeproj/project.pbxproj
@@ -2496,6 +2496,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/$(INFOPLIST_PATH)",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/MapboxSearch.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
+++ b/MapboxSearch.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1340"
+   LastUpgradeVersion = "1530"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MapboxSearch.xcodeproj/xcshareddata/xcschemes/MapboxSearch.xcscheme
+++ b/MapboxSearch.xcodeproj/xcshareddata/xcschemes/MapboxSearch.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1340"
+   LastUpgradeVersion = "1530"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MapboxSearch.xcodeproj/xcshareddata/xcschemes/MapboxSearchTests.xcscheme
+++ b/MapboxSearch.xcodeproj/xcshareddata/xcschemes/MapboxSearchTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1340"
+   LastUpgradeVersion = "1530"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MapboxSearch.xcodeproj/xcshareddata/xcschemes/MapboxSearchUI.xcscheme
+++ b/MapboxSearch.xcodeproj/xcshareddata/xcschemes/MapboxSearchUI.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1340"
+   LastUpgradeVersion = "1530"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MapboxSearch.xcodeproj/xcshareddata/xcschemes/MapboxSearchUIResources.xcscheme
+++ b/MapboxSearch.xcodeproj/xcshareddata/xcschemes/MapboxSearchUIResources.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1340"
+   LastUpgradeVersion = "1530"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sources/MapboxSearch/PublicAPI/Common/Models/Country/Country+ISO3166-1.swift
+++ b/Sources/MapboxSearch/PublicAPI/Common/Models/Country/Country+ISO3166-1.swift
@@ -2,7 +2,7 @@
 // swiftlint:disable type_name
 
 extension Country {
-    enum ISO3166_1_alpha2: String {
+    public enum ISO3166_1_alpha2: String {
         case af = "AF"
         case ax = "AX"
         case al = "AL"

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Discover/Models/Discover+Options.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Discover/Models/Discover+Options.swift
@@ -17,7 +17,7 @@ extension Discover {
         /// English (en) language parameter, but Frankreich (“France”) with a German (de) language parameter.
         public let language: Language
 
-        /// See ``MapboxSearch.Country.ISO3166_1_alpha2`` for the list of ISO 3166 alpha 2 country codes.
+        /// See ``MapboxSearch/Country/ISO3166_1_alpha2`` for the list of ISO 3166 alpha 2 country codes.
         /// The default value is nil.
         public let country: Country?
 

--- a/Sources/MapboxSearchUI/Configuration.swift
+++ b/Sources/MapboxSearchUI/Configuration.swift
@@ -48,8 +48,8 @@ public struct Configuration {
     /// It's possible to change style on the fly. Non-animatable.
     public var style = Style()
 
-    /// Override the default ``MKDistanceFormatter`` behavior used by ``SearchSuggestionCell`` to display search
-    /// results in a specific unit system. A nil value will use the ``MKDistanceFormatter`` system behavior to infer
+    /// Override the default `MKDistanceFormatter` behavior used by `SearchSuggestionCell` to display search
+    /// results in a specific unit system. A nil value will use the `MKDistanceFormatter` system behavior to infer
     /// the unit system based on the device locale.
     public var distanceFormatter: MKDistanceFormatter?
 }

--- a/Sources/MapboxSearchUI/Helpers/PlaceholderView.swift
+++ b/Sources/MapboxSearchUI/Helpers/PlaceholderView.swift
@@ -8,14 +8,15 @@ class PlaceholderView: UIView {
 
     private func placeholdedView() -> UIView {
         guard let restorationIdentifier else {
-            print("PlaceholderView: RestorationIdentifier is empty. Cannot instantiate an replacement")
+            _Logger.searchSDK
+                .warning("PlaceholderView: RestorationIdentifier is empty. Cannot instantiate an replacement")
             return self
         }
 
         let nibName = restorationIdentifier.trimmingCharacters(in: .decimalDigits)
         let nib = UINib(nibName: nibName, bundle: .mapboxSearchUI)
         guard let view = nib.instantiate(withOwner: nil, options: nil).first as? UIView else {
-            print("PlaceholderView: First object in nib is not a UIView (nibName=\(nibName)")
+            _Logger.searchSDK.warning("PlaceholderView: First object in nib is not a UIView (nibName=\(nibName)")
             return self
         }
         view.translatesAutoresizingMaskIntoConstraints = translatesAutoresizingMaskIntoConstraints

--- a/Sources/MapboxSearchUI/Helpers/PlaceholderView.swift
+++ b/Sources/MapboxSearchUI/Helpers/PlaceholderView.swift
@@ -16,7 +16,7 @@ class PlaceholderView: UIView {
         let nibName = restorationIdentifier.trimmingCharacters(in: .decimalDigits)
         let nib = UINib(nibName: nibName, bundle: .mapboxSearchUI)
         guard let view = nib.instantiate(withOwner: nil, options: nil).first as? UIView else {
-            _Logger.searchSDK.warning("PlaceholderView: First object in nib is not a UIView (nibName=\(nibName)")
+            _Logger.searchSDK.error("PlaceholderView: First object in nib is not a UIView (nibName=\(nibName)")
             return self
         }
         view.translatesAutoresizingMaskIntoConstraints = translatesAutoresizingMaskIntoConstraints

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/CoreSearchEngineStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/CoreSearchEngineStub.swift
@@ -132,7 +132,7 @@ extension CoreSearchEngineStub: CoreSearchEngineProtocol {
     }
 
     func onSelected(forRequest request: CoreRequestOptions, result: CoreSearchResultProtocol) {
-        print("\(#function): No-op")
+        _Logger.searchSDK.info("\(#function): No-op")
     }
 
     func createEventTemplate(forName name: String) -> String {

--- a/Tests/MapboxSearchTests/Legacy/CategorySearchEngineTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/CategorySearchEngineTests.swift
@@ -106,6 +106,7 @@ class CategorySearchEngineTests: XCTestCase {
             let assertionError = catchBadInstruction {
                 callback()
             }
+            XCTAssertNil(assertionError)
 
             var error: SearchError?
             let expectation = XCTestExpectation(description: "Expecting results")

--- a/Tests/MapboxSearchTests/Legacy/SearchEngineTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/SearchEngineTests.swift
@@ -360,6 +360,8 @@ class SearchEngineTests: XCTestCase {
             let assertionError = catchBadInstruction {
                 callback()
             }
+            XCTAssertNil(assertionError)
+
             do {
                 let engine = try XCTUnwrap(searchEngine.engine as? CoreSearchEngineStub)
                 engine.callbackWrapper = { callback in
@@ -392,6 +394,7 @@ class SearchEngineTests: XCTestCase {
             let assertionError = catchBadInstruction {
                 callback()
             }
+            XCTAssertNil(assertionError)
 
             let expectation = XCTestExpectation()
             var error: SearchError?


### PR DESCRIPTION
### Description

Update project and build settings to reduce warnings.

- Update recommended project settings to disable code signing
- Enable test parallelization
- Remove Inject Mapbox API Key from integration tests build phase
- Remove Inject Mapbox API Key from unit tests build phase
- Add output file to Demo > Inject Mapbox API Key build phase to solve dependency analysis warning
- Turn off Based-on-dependency-analysis for SwiftLint build phases, always run swiftlint
- Add test assertion to fix unused variable warnings
- Fix broken links to non-public/non-local symbols in Configuration.swift documentation
- Change Country.ISO3166_1_alpha2 enum to public, 
    - fix documentation link in Discover for MapboxSearch documentation
- Restore `_preferWillMoveToWindow` linter rule
- Exclude `dont_use_print` from Demo project
    - Include all swift files by default

| Before | After |
| -- | -- |
| 25 total warnings | 2 warnings |
| <img width="317" alt="Screenshot 2024-05-16 at 14 15 27" src="https://github.com/mapbox/mapbox-search-ios/assets/384288/df2327f9-3ff9-4f9e-8f8e-d43c2d85d345"> | <img width="319" alt="Screenshot 2024-05-16 at 14 07 20" src="https://github.com/mapbox/mapbox-search-ios/assets/384288/3babfd2f-ce2e-46e4-93e0-b0caf35f52bc"> |

### Checklist

- [x] Update `CHANGELOG`
