### PR TITLE
Update MapboxCoreSearch to 2.0.3 and MapboxCommon to 24.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 - [Address] Change Country.ISO3166_1_alpha2 enum to public
 
+**MapboxCommon**: v24.4.0
+**MapboxCoreSearch**: v2.0.3
+
 ## 2.0.3
 
 - [Core] Change MapboxCommon dependency to use exact versions in SPM and CocoaPods

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.0.2
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.3.1
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.0.3
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.4.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.3.1"
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.0.2"
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.4.0"
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.0.3"

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -24,5 +24,5 @@ Some iOS platform specifics applies.
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency "MapboxCommon", '24.3.1'
+  s.dependency "MapboxCommon", '24.4.0'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -4,9 +4,9 @@
 import PackageDescription
 import Foundation
 
-let (coreSearchVersion, coreSearchVersionHash) = ("2.0.2", "56538985a977f935b211a0cd16065c5d49afd739fa12315b55edf1aeb3985a5b")
+let (coreSearchVersion, coreSearchVersionHash) = ("2.0.3", "c6e9c8cc37439e11fdc0742f053f7bdbf3c10297ed2a197fd550240435db2b39")
 
-let mapboxCommonSDKVersion = Version("24.3.1")
+let mapboxCommonSDKVersion = Version("24.4.0")
 
 let package = Package(
     name: "MapboxSearch",


### PR DESCRIPTION
### Description

Update package dependencies for:

- MapboxCommon 24.4.0
- MapboxCoreSearch 2.0.3

### Checklist
- [x] Update `CHANGELOG`
