### PR TITLE
Add podspec for MapboxCoreSearch v2.1.0 alongside mapbox-search-ios

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,7 +240,7 @@ jobs:
       - run:
           name: Push podspecs to CocoaPods CDN Trunk
           command: |
-            pod trunk push MapboxCoreSearch.podspec
+            # pod trunk push MapboxCoreSearch.podspec # Inactive for the time being
             pod trunk push MapboxSearch.podspec --synchronous
             pod trunk push MapboxSearchUI.podspec --synchronous
       - run: brew install gh taiki-e/tap/parse-changelog

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,7 +240,8 @@ jobs:
       - run:
           name: Push podspecs to CocoaPods CDN Trunk
           command: |
-            pod trunk push MapboxSearch.podspec
+            pod trunk push MapboxCoreSearch.podspec
+            pod trunk push MapboxSearch.podspec --synchronous
             pod trunk push MapboxSearchUI.podspec --synchronous
       - run: brew install gh taiki-e/tap/parse-changelog
       - run: scripts/release_notes.sh

--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,9 @@ pristine:
 	git reset --hard && git clean -dfx && git submodule foreach "git reset --hard && git clean -dfx"
 
 lint:
-	pod spec lint MapboxSearch.podspec --silent
-	pod lib lint MapboxSearchUI.podspec --include-podspecs=MapboxSearch.podspec --silent
+	pod spec lint MapboxCoreSearch.podspec
+	pod lib lint MapboxSearch.podspec --include-podspecs=MapboxCoreSearch.podspec
+	pod lib lint MapboxSearchUI.podspec --include-podspecs=MapboxSearch.podspec
 
 # This target send local podspecs to the official CocoaPods repository
 push-trunk:

--- a/MapboxCoreSearch.podspec
+++ b/MapboxCoreSearch.podspec
@@ -1,0 +1,35 @@
+Pod::Spec.new do |s|
+  s.name             = 'MapboxCoreSearch'
+  s.version          = '2.1.0'
+  s.summary          = 'Search Core SDK for Mapbox Search API'
+
+  s.description      = <<-DESC
+MapboxSearchSDK implement basic search functionality over Mapbox Search API
+Some iOS platfrom specifics applies.
+                        DESC
+
+  s.homepage         = 'https://www.mapbox.com/search-service'
+  s.license          = { :type => 'Mapbox TOS', :text => <<-LICENSE
+                          Copyright © 2024 Mapbox, Inc.
+                          You may use this code with your Mapbox account and under the Mapbox Terms of Service (available at: https://www.mapbox.com/legal/tos).
+                          All other rights reserved.
+                        LICENSE
+                      }
+  s.author           = { 'Mapbox' => 'mobile@mapbox.com'  }
+  s.source           = { :http => "https://api.mapbox.com/downloads/v2/search-core-sdk/releases/ios/packages/#{s.version.to_s}/#{s.name}.xcframework.zip" }
+
+  s.ios.deployment_target = '12.0'
+  s.library = "stdc++"
+  s.frameworks = "CoreLocation"
+  s.cocoapods_version = ">= 1.9.0" # The first public version with XCFrameworks support
+
+  # Force user_target_xcconfig instead of pod_target_xcconfig cause binary framework will not work with pod config.
+  # It looks like c++ integration will be ignored for Aggregate target that CocoaPods make for binary frameworks
+  s.user_target_xcconfig = {
+    'CLANG_CXX_LIBRARY' => 'libc++',
+    'OTHER_LDFLAGS' => '$(inherited) -ObjC'
+  }
+
+  s.vendored_frameworks = "**/#{s.name}.xcframework"
+  s.dependency "MapboxCommon", "24.4.0"
+end

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -24,5 +24,6 @@ Some iOS platform specifics applies.
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
+  # s.dependency "MapboxCoreSearch", '2.1.0'
   s.dependency "MapboxCommon", '24.4.0'
 end

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -24,6 +24,6 @@ Some iOS platform specifics applies.
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  # s.dependency "MapboxCoreSearch", '2.1.0'
+  s.dependency "MapboxCoreSearch", '2.1.0'
   s.dependency "MapboxCommon", '24.4.0'
 end


### PR DESCRIPTION
### Description
Fixes [SSDK-827](https://mapbox.atlassian.net/browse/SSDK-827)

- Add podspec for MapboxCoreSearch v2.1.0 as required dependency for MapboxSearch
    - MapboxSearch is a required dependency for MapboxSearchUI
- Requires synchronized releases for Core Search and Search iOS
- Before updating v2 releases for Xcode 15.3 (alongside, but not entirely due to, PrivacyInfo.xcprivacy) framework format changes the Core Search framework did not use it's own pod.
    - Going forward MapboxCoreSearch.podspec will need to be published for all v2 Core releases
- `make lint` will pass after MapboxCoreSearch.podspec is published

### Checklist
- [N/A] Update `CHANGELOG`


[SSDK-827]: https://mapbox.atlassian.net/browse/SSDK-827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ