### PR TITLE
Prepare v2.1.1 release to update podspec dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
+## 2.1.1
+
+- [Core] Fix MapboxCoreSearch dependency when using cocoapods
+
 ## 2.1.0
 
 - [Offline] Expose selectTileset function for offline mode

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearch'
-  s.version          = '2.1.0'
+  s.version          = '2.1.1'
   s.summary          = 'Search SDK for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.

--- a/MapboxSearchUI.podspec
+++ b/MapboxSearchUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearchUI'
-  s.version          = '2.1.0'
+  s.version          = '2.1.1'
   s.summary          = 'Search UI for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.
@@ -23,5 +23,5 @@ Card style custom UI with full search functionality powered by Mapbox Search API
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency 'MapboxSearch', "2.1.0"
+  s.dependency 'MapboxSearch', "2.1.1"
 end

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ Once you've installed the prerequisites, no additional steps are needed: Open th
 
 You can find the following documentation pages helpful:
 - [Search SDK for iOS guide](https://docs.mapbox.com/ios/search/guides/)
-- [MapboxSearch reference](https://docs.mapbox.com/ios/search/api/core/2.1.0/)
-- [MapboxSearchUI reference](https://docs.mapbox.com/ios/search/api/ui/2.1.0/)
+- [MapboxSearch reference](https://docs.mapbox.com/ios/search/api/core/2.1.1/)
+- [MapboxSearchUI reference](https://docs.mapbox.com/ios/search/api/ui/2.1.1/)
 
 ## Project structure overview
 
@@ -108,13 +108,13 @@ MapboxSearchDemoApplication provides a Demo app wih MapboxSearchUI.framework pre
 ##### MapboxSearch
 To integrate latest preview version of `MapboxSearch` into your Xcode project using CocoaPods, specify it in your `Podfile`:  
 ```
-pod 'MapboxSearch', ">= 2.1.0", "< 3.0"
+pod 'MapboxSearch', ">= 2.1.1", "< 3.0"
 ```
 
 ##### MapboxSearchUI
 To integrate latest preview version of `MapboxSearchUI` into your Xcode project using CocoaPods, specify it in your `Podfile`:  
 ```
-pod 'MapboxSearchUI', ">= 2.1.0", "< 3.0"
+pod 'MapboxSearchUI', ">= 2.1.1", "< 3.0"
 ```
 
 ### Swift Package Manager

--- a/Search Documentation.docc/Installation.md
+++ b/Search Documentation.docc/Installation.md
@@ -59,7 +59,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearchUI', ">= 2.1.0", "< 3.0"
+      pod 'MapboxSearchUI', ">= 2.1.1", "< 3.0"
     end
     ```
 
@@ -68,7 +68,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearch', ">= 2.1.0", "< 3.0"
+      pod 'MapboxSearch', ">= 2.1.1", "< 3.0"
     end
     ```
 

--- a/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
+++ b/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
@@ -1,2 +1,2 @@
 /// Mapbox Search SDK version variable
-public let mapboxSearchSDKVersion = "2.1.0"
+public let mapboxSearchSDKVersion = "2.1.1"


### PR DESCRIPTION
### Description
Fixes MapboxSearch and MapboxSearchUI in cocoapods by adding dependency for MapboxCoreSearch v2.1.0 

- Resolves issue https://github.com/mapbox/mapbox-search-ios/issues/234
- Key change is dependency on MapboxCoreSearch pod https://github.com/mapbox/mapbox-search-ios/pull/244/files#diff-5bf004e7fb4ddce530ec399dfe5727dd78b65b254110db5fdca81c7ae7b4f102R27

### Checklist
- [x] Update `CHANGELOG`
