### PR TITLE
Prepare v2.2.0-beta.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
+## 2.2.0-beta.1
+
+- [Core] Update MapboxCommon and MapboxCoreSearch package dependencies
+
+**MapboxCommon**: v24.5.0-beta.4
+**MapboxCoreSearch**: v2.2.0-beta.1
+
 ## 2.1.1
 
 - [Core] Fix MapboxCoreSearch dependency when using cocoapods

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.1.0
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.4.0
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.2.0-beta.1
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.5.0-beta.4

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.4.0"
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.1.0"
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.5.0-beta.4"
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.2.0-beta.1"

--- a/MapboxCoreSearch.podspec
+++ b/MapboxCoreSearch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxCoreSearch'
-  s.version          = '2.1.0'
+  s.version          = '2.2.0-beta.1'
   s.summary          = 'Search Core SDK for Mapbox Search API'
 
   s.description      = <<-DESC
@@ -31,5 +31,5 @@ Some iOS platfrom specifics applies.
   }
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
-  s.dependency "MapboxCommon", "24.4.0"
+  s.dependency "MapboxCommon", "24.5.0-beta.4"
 end

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearch'
-  s.version          = '2.1.1'
+  s.version          = '2.2.0-beta.1'
   s.summary          = 'Search SDK for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.
@@ -24,6 +24,6 @@ Some iOS platform specifics applies.
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency "MapboxCoreSearch", '2.1.0'
-  s.dependency "MapboxCommon", '24.4.0'
+  s.dependency "MapboxCoreSearch", '2.2.0-beta.1'
+  s.dependency "MapboxCommon", '24.5.0-beta.4'
 end

--- a/MapboxSearchUI.podspec
+++ b/MapboxSearchUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearchUI'
-  s.version          = '2.1.1'
+  s.version          = '2.2.0-beta.1'
   s.summary          = 'Search UI for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.
@@ -23,5 +23,5 @@ Card style custom UI with full search functionality powered by Mapbox Search API
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency 'MapboxSearch', "2.1.1"
+  s.dependency 'MapboxSearch', "2.2.0-beta.1"
 end

--- a/Package.swift
+++ b/Package.swift
@@ -4,9 +4,9 @@
 import PackageDescription
 import Foundation
 
-let (coreSearchVersion, coreSearchVersionHash) = ("2.1.0", "adbcf5456e384a0313f65459a86600e10cc9a9837c08f5273fbef43de31bf8f4")
+let (coreSearchVersion, coreSearchVersionHash) = ("2.2.0-beta.1", "e32bc6d639a45de31b1c820d2668d5d356c690c7fa6e25421272b8d0d6db8ec1")
 
-let mapboxCommonSDKVersion = Version("24.4.0")
+let mapboxCommonSDKVersion = Version("24.5.0-beta.4")
 
 let package = Package(
     name: "MapboxSearch",

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ Once you've installed the prerequisites, no additional steps are needed: Open th
 
 You can find the following documentation pages helpful:
 - [Search SDK for iOS guide](https://docs.mapbox.com/ios/search/guides/)
-- [MapboxSearch reference](https://docs.mapbox.com/ios/search/api/core/2.1.1/)
-- [MapboxSearchUI reference](https://docs.mapbox.com/ios/search/api/ui/2.1.1/)
+- [MapboxSearch reference](https://docs.mapbox.com/ios/search/api/core/2.2.0-beta.1/)
+- [MapboxSearchUI reference](https://docs.mapbox.com/ios/search/api/ui/2.2.0-beta.1/)
 
 ## Project structure overview
 
@@ -108,13 +108,13 @@ MapboxSearchDemoApplication provides a Demo app wih MapboxSearchUI.framework pre
 ##### MapboxSearch
 To integrate latest preview version of `MapboxSearch` into your Xcode project using CocoaPods, specify it in your `Podfile`:  
 ```
-pod 'MapboxSearch', ">= 2.1.1", "< 3.0"
+pod 'MapboxSearch', ">= 2.2.0-beta.1", "< 3.0"
 ```
 
 ##### MapboxSearchUI
 To integrate latest preview version of `MapboxSearchUI` into your Xcode project using CocoaPods, specify it in your `Podfile`:  
 ```
-pod 'MapboxSearchUI', ">= 2.1.1", "< 3.0"
+pod 'MapboxSearchUI', ">= 2.2.0-beta.1", "< 3.0"
 ```
 
 ### Swift Package Manager

--- a/Search Documentation.docc/Installation.md
+++ b/Search Documentation.docc/Installation.md
@@ -59,7 +59,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearchUI', ">= 2.1.1", "< 3.0"
+      pod 'MapboxSearchUI', ">= 2.2.0-beta.1", "< 3.0"
     end
     ```
 
@@ -68,7 +68,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearch', ">= 2.1.1", "< 3.0"
+      pod 'MapboxSearch', ">= 2.2.0-beta.1", "< 3.0"
     end
     ```
 

--- a/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
+++ b/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
@@ -1,2 +1,2 @@
 /// Mapbox Search SDK version variable
-public let mapboxSearchSDKVersion = "2.1.1"
+public let mapboxSearchSDKVersion = "2.2.0-beta.1"


### PR DESCRIPTION
### Description

Update frameworks that Search iOS depends on
**MapboxCommon**: v24.5.0-beta.4
**MapboxCoreSearch**: v2.2.0-beta.1

### Checklist
- [x] Update `CHANGELOG`
- [x] Publish MapboxCoreSearch [v2.2.0-beta.1 podspec](https://github.com/CocoaPods/Specs/blob/master/Specs/6/8/5/MapboxCoreSearch/2.2.0-beta.1/MapboxCoreSearch.podspec.json)
