### PR TITLE
Change podpsec to use swift_version with string value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
+- [Project] Update Podspec `swift_version = "5.10"`
+
 ## 2.2.0-rc.1
 
 - [Project] Update Package from Swift 5.7 to 5.10

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -20,7 +20,7 @@ Some iOS platform specifics applies.
   s.source           = { :http => "https://api.mapbox.com/downloads/v2/search-sdk/releases/ios/packages/#{s.version.to_s}/#{s.name}.zip" }
 
   s.ios.deployment_target = '12.0'
-  s.swift_versions = [5.10]
+  s.swift_version = "5.10"
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 

--- a/MapboxSearchUI.podspec
+++ b/MapboxSearchUI.podspec
@@ -19,7 +19,7 @@ Card style custom UI with full search functionality powered by Mapbox Search API
   s.source           = { :http => "https://api.mapbox.com/downloads/v2/search-sdk/releases/ios/packages/#{s.version.to_s}/#{s.name}.zip" }
 
   s.ios.deployment_target = '12.0'
-  s.swift_versions = [5.10]
+  s.swift_version = "5.10"
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 


### PR DESCRIPTION
### Description

- Previously this was a float and failed to parse correctly with the CI error below
- Changing `[5.10]` to `"5.10"` fixes this error
- Documentation: https://guides.cocoapods.org/syntax/podspec.html#swift_versions

##### Previous error

> Validating podspec
> -> MapboxSearch (2.2.0-rc.1)
>    - ERROR | [iOS] swift: Specification `MapboxSearch` specifies inconsistent `swift_versions` (`5.1`) compared to the one present in your `.swift-version` file (`5.10`). Please remove the `.swift-version` file which is now deprecated and only use the `swift_versions` attribute within your podspec.

### Checklist
- [x] Update `CHANGELOG`
