### PR TITLE
Add latest versions in Cocoapods and SPM to top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 [![Swift version](https://img.shields.io/badge/swift-5.10+-orange.svg?style=flat&logo=swift)](https://developer.apple.com/swift)
 [![iOS version](https://img.shields.io/badge/iOS-12.0+-green.svg?style=flat&logo=apple)](https://developer.apple.com/ios/)
 [![Xcode version](https://img.shields.io/badge/Xcode-15.3+-DeepSkyBlue.svg?style=flat&logo=xcode&logoColor=lightGray)](https://developer.apple.com/xcode/)
-[![codecov](https://codecov.io/gh/mapbox/mapbox-search-ios/branch/develop/graph/badge.svg?token=js3DSKdda4)](https://codecov.io/gh/mapbox/mapbox-search-ios)
 [![swift-doc](https://img.shields.io/badge/swift--doc-64.94%25-orange?logo=read-the-docs)](https://github.com/SwiftDocOrg/swift-doc)
 # Mapbox Search SDK for iOS
+
+Latest release: [![Cocoapods Release](https://img.shields.io/cocoapods/v/MapboxSearch)](https://github.com/mapbox/mapbox-search-ios/releases) | [![Latest SPM Release](https://img.shields.io/github/v/release/mapbox/mapbox-search-ios)](https://github.com/mapbox/mapbox-search-ios/releases)
+
 
 # Table of contents
 


### PR DESCRIPTION
### Description

This change makes working with mapbox-search-ios in Swift Package Manager and swiftpackageindex.com much easier by prominently displaying the latest version.

| Previously (inside Xcode) | Updated (README on GitHub) |
| -- | -- |
| <img width="1111" alt="Screenshot 2024-06-27 at 15 08 59" src="https://github.com/mapbox/mapbox-search-ios/assets/384288/5d606033-27b9-4b2f-a6a6-9a20484cd931"> | <img width="618" alt="Screenshot 2024-06-27 at 15 09 45" src="https://github.com/mapbox/mapbox-search-ios/assets/384288/87413448-23a5-488a-b4c9-9d103b374b7d"> | 

### Checklist
- [ ] Update `CHANGELOG`
