### PR TITLE
Add tap to view detail annotation on SearchUI map root

### DIFF
--- a/MapboxSearch.xcodeproj/project.pbxproj
+++ b/MapboxSearch.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		04C0848D2B4C82F3002F9C69 /* SdkInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C0848C2B4C82F3002F9C69 /* SdkInformation.swift */; };
 		04C127552B62F6BC00884325 /* ApiType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C127542B62F6BC00884325 /* ApiType.swift */; };
 		04C127582B62FFDB00884325 /* ApiType+Core.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C127572B62FFDB00884325 /* ApiType+Core.swift */; };
+		04CECA012C3EE28B007117E4 /* ResultDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04CECA002C3EE28B007117E4 /* ResultDetailViewController.swift */; };
 		04DAF7582BDAAB4C002719E2 /* OfflineDemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04DAF7572BDAAB4C002719E2 /* OfflineDemoViewController.swift */; };
 		04DFB40C2B8CF1ED00231830 /* search-box-suggestions-categories.json in Resources */ = {isa = PBXBuildFile; fileRef = 04DFB40B2B8CF1ED00231830 /* search-box-suggestions-categories.json */; };
 		04DFB40D2B8CF1ED00231830 /* search-box-suggestions-categories.json in Resources */ = {isa = PBXBuildFile; fileRef = 04DFB40B2B8CF1ED00231830 /* search-box-suggestions-categories.json */; };
@@ -550,6 +551,7 @@
 		04C0848C2B4C82F3002F9C69 /* SdkInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdkInformation.swift; sourceTree = "<group>"; };
 		04C127542B62F6BC00884325 /* ApiType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiType.swift; sourceTree = "<group>"; };
 		04C127572B62FFDB00884325 /* ApiType+Core.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ApiType+Core.swift"; sourceTree = "<group>"; };
+		04CECA002C3EE28B007117E4 /* ResultDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultDetailViewController.swift; sourceTree = "<group>"; };
 		04DAF7572BDAAB4C002719E2 /* OfflineDemoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineDemoViewController.swift; sourceTree = "<group>"; };
 		04DFB40B2B8CF1ED00231830 /* search-box-suggestions-categories.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "search-box-suggestions-categories.json"; sourceTree = "<group>"; };
 		04DFB40F2B8CF46D00231830 /* search-box-retrieve-categories.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "search-box-retrieve-categories.json"; sourceTree = "<group>"; };
@@ -1304,6 +1306,7 @@
 			children = (
 				FEEDD3C62508E3FB00DC0A98 /* Resources */,
 				FEEDD3B52508E3CD00DC0A98 /* MapRootController.swift */,
+				04CECA002C3EE28B007117E4 /* ResultDetailViewController.swift */,
 			);
 			name = "Search UI";
 			sourceTree = "<group>";
@@ -2830,6 +2833,7 @@
 				1440BF4F290019AD009B3679 /* AddressAutofillResultViewController.swift in Sources */,
 				04DAF7582BDAAB4C002719E2 /* OfflineDemoViewController.swift in Sources */,
 				1440BF4D28FD75A9009B3679 /* AddressAutofillMainViewController.swift in Sources */,
+				04CECA012C3EE28B007117E4 /* ResultDetailViewController.swift in Sources */,
 				041DAFD92BCDA45B0071F9EB /* DiscoverViewController.swift in Sources */,
 				FEEDD3C32508E3CD00DC0A98 /* AppDelegate.swift in Sources */,
 				14F7186D29A139BF00D5BC2E /* PlaceAutocompleteDetailsViewController.swift in Sources */,

--- a/Sources/Demo/MapRootController.swift
+++ b/Sources/Demo/MapRootController.swift
@@ -52,9 +52,8 @@ class MapRootController: UIViewController {
             UIImage(named: "pin").map { point.image = .init(image: $0, name: "pin") }
 
             // Present a detail view upon annotation tap
-            point.tapHandler = ((MapContentGestureContext) -> Bool)? { [weak self] _ in
-                self?.present(result: result)
-                return false
+            point.tapHandler = { [weak self] _ in
+                return self?.present(result: result) ?? false
             }
             return point
         }

--- a/Sources/Demo/ResultDetailViewController.swift
+++ b/Sources/Demo/ResultDetailViewController.swift
@@ -1,0 +1,158 @@
+// Copyright © 2024 Mapbox. All rights reserved.
+
+import MapboxMaps
+import MapboxSearch
+import UIKit
+
+class ResultDetailViewController: UIViewController {
+    private var tableView = UITableView()
+    private var mapView: MapView
+
+    var result: SearchResult
+    private var resultComponents: [(name: String, value: String)] = []
+
+    init(result: SearchResult) {
+        self.result = result
+        self.resultComponents = result.toComponents()
+
+        let inset: CGFloat = 8
+        let padding = UIEdgeInsets(top: inset, left: inset, bottom: inset, right: inset)
+        self.mapView = MapView(
+            frame: .zero,
+            mapInitOptions: MapInitOptions(cameraOptions: CameraOptions(
+                center: result.coordinate,
+                padding: padding,
+                zoom: 15.5
+            ))
+        )
+
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("\(#function) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        tableView.dataSource = self
+        tableView.allowsSelection = false
+
+        for child in [tableView, mapView] {
+            child.translatesAutoresizingMaskIntoConstraints = false
+            view.addSubview(child)
+        }
+
+        NSLayoutConstraint.activate([
+            mapView.topAnchor.constraint(equalTo: view.topAnchor),
+            mapView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            mapView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            mapView.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 0.4),
+
+            tableView.topAnchor.constraint(equalTo: mapView.bottomAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+
+        /// Add annotations and set camera
+        let annotationsManager = mapView.annotations.makePointAnnotationManager()
+        annotationsManager.annotations = [result].map { result in
+            var point = PointAnnotation(coordinate: result.coordinate)
+            point.textField = result.name
+            UIImage(named: "pin").map { point.image = .init(image: $0, name: "pin") }
+            return point
+        }
+
+        if let annotation = annotationsManager.annotations.first {
+            mapView.camera.fly(
+                to: .init(center: annotation.point.coordinates, zoom: 15),
+                duration: 0.25,
+                completion: nil
+            )
+        }
+    }
+}
+
+extension ResultDetailViewController: UITableViewDataSource {
+    func numberOfSections(in tableView: UITableView) -> Int {
+        2
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        switch section {
+        case 0:
+            resultComponents.count
+        default:
+            0
+        }
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cellIdentifier = "result-cell"
+
+        let tableViewCell: UITableViewCell = if let cachedTableViewCell = tableView
+            .dequeueReusableCell(withIdentifier: cellIdentifier)
+        {
+            cachedTableViewCell
+        } else {
+            UITableViewCell(style: .value1, reuseIdentifier: cellIdentifier)
+        }
+
+        let component = resultComponents[indexPath.row]
+
+        tableViewCell.textLabel?.text = component.name
+        tableViewCell.detailTextLabel?.text = component.value
+        tableViewCell.detailTextLabel?.textColor = UIColor.darkGray
+
+        return tableViewCell
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        tableView.reloadData()
+    }
+}
+
+extension SearchResult {
+    func toComponents() -> [(name: String, value: String)] {
+        var components = [
+            (name: "Name", value: name),
+            (name: "Type", value: "\(type == .POI ? "POI" : "Address")"),
+        ]
+
+        if let address, let formattedAddress = address.formattedAddress(style: .short) {
+            components.append(
+                (name: "Address", value: formattedAddress)
+            )
+        }
+
+        if let estimatedTime {
+            components.append(
+                (
+                    name: "Estimated time",
+                    value: PlaceAutocomplete.Result.measurementFormatter.string(from: estimatedTime)
+                )
+            )
+        }
+
+        if let categories, !categories.isEmpty {
+            let categories = categories.count > 2 ? Array(categories.dropFirst(2)) : categories
+
+            components.append(
+                (name: "Categories", value: categories.joined(separator: ","))
+            )
+        }
+
+        if let mapboxId {
+            components.append(
+                (name: "Mapbox ID", value: mapboxId)
+            )
+        }
+
+        return components
+    }
+}

--- a/Sources/Demo/ResultDetailViewController.swift
+++ b/Sources/Demo/ResultDetailViewController.swift
@@ -77,17 +77,8 @@ class ResultDetailViewController: UIViewController {
 }
 
 extension ResultDetailViewController: UITableViewDataSource {
-    func numberOfSections(in tableView: UITableView) -> Int {
-        2
-    }
-
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        switch section {
-        case 0:
-            resultComponents.count
-        default:
-            0
-        }
+        resultComponents.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {


### PR DESCRIPTION
### Description

Add result detail view for Demo > SearchUI tab to expose additional information from a map annotation

![Simulator Screen Recording - iPhone 15 - 2024-07-10 at 12 49 17](https://github.com/mapbox/mapbox-search-ios/assets/384288/3090664e-f7d9-443b-b9d2-c949411cfa93)

### Checklist
- [NA] Update `CHANGELOG`
