### PR TITLE
[release] Prepare v2.3.0-beta.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,14 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
+## 2.3.0-beta.1
+
 - [Demo] Update Demo app to use MapboxMaps
 - [Demo] Rename 'Discover' tab to 'Category' in Demo app target
 - [Demo] Add earlier examples into MapboxSearch.xcodeproj Demo target
 - [SearchUI] Add `Maki: RawRepresentable` conformance for `Maki(rawValue:)` initializer
 - [Core] Add public scope to several types and initializers for broader support
+- [Core] Add several new types and fields for new SearchResult functionality
 
 **MapboxCommon**: v24.5.0
 **MapboxCoreSearch**: v2.3.0-rc.1

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearch'
-  s.version          = '2.2.0'
+  s.version          = '2.3.0-beta.1'
   s.summary          = 'Search SDK for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.
@@ -24,6 +24,6 @@ Some iOS platform specifics applies.
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency "MapboxCoreSearch", '2.2.0'
-  s.dependency "MapboxCommon", '24.5.0'
+  s.dependency "MapboxCoreSearch", '2.3.0-beta.3'
+  s.dependency "MapboxCommon", '24.6.0-beta.1'
 end

--- a/MapboxSearchUI.podspec
+++ b/MapboxSearchUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearchUI'
-  s.version          = '2.2.0'
+  s.version          = '2.3.0-beta.1'
   s.summary          = 'Search UI for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.
@@ -23,5 +23,5 @@ Card style custom UI with full search functionality powered by Mapbox Search API
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency 'MapboxSearch', "2.2.0"
+  s.dependency 'MapboxSearch', "2.3.0-beta.1"
 end

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ Once you've installed the prerequisites, no additional steps are needed: Open th
 
 You can find the following documentation pages helpful:
 - [Search SDK for iOS guide](https://docs.mapbox.com/ios/search/guides/)
-- [MapboxSearch reference](https://docs.mapbox.com/ios/search/api/core/2.2.0/)
-- [MapboxSearchUI reference](https://docs.mapbox.com/ios/search/api/ui/2.2.0/)
+- [MapboxSearch reference](https://docs.mapbox.com/ios/search/api/core/2.3.0-beta.1/)
+- [MapboxSearchUI reference](https://docs.mapbox.com/ios/search/api/ui/2.3.0-beta.1/)
 
 ## Project structure overview
 
@@ -110,13 +110,13 @@ MapboxSearchDemoApplication provides a Demo app wih MapboxSearchUI.framework pre
 ##### MapboxSearch
 To integrate latest preview version of `MapboxSearch` into your Xcode project using CocoaPods, specify it in your `Podfile`:  
 ```
-pod 'MapboxSearch', ">= 2.2.0", "< 3.0"
+pod 'MapboxSearch', ">= 2.3.0-beta.1", "< 3.0"
 ```
 
 ##### MapboxSearchUI
 To integrate latest preview version of `MapboxSearchUI` into your Xcode project using CocoaPods, specify it in your `Podfile`:  
 ```
-pod 'MapboxSearchUI', ">= 2.2.0", "< 3.0"
+pod 'MapboxSearchUI', ">= 2.3.0-beta.1", "< 3.0"
 ```
 
 ### Swift Package Manager

--- a/Search Documentation.docc/Installation.md
+++ b/Search Documentation.docc/Installation.md
@@ -59,7 +59,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearchUI', ">= 2.2.0", "< 3.0"
+      pod 'MapboxSearchUI', ">= 2.3.0-beta.1", "< 3.0"
     end
     ```
 
@@ -68,7 +68,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearch', ">= 2.2.0", "< 3.0"
+      pod 'MapboxSearch', ">= 2.3.0-beta.1", "< 3.0"
     end
     ```
 


### PR DESCRIPTION
### Description

Update project for v2.3.0-beta.1 release

Compatible with:
- MapboxCommon v24.6.0-beta.1
- MapboxCoreSearch v2.3.0-rc.3

### Checklist
- [x] Update `CHANGELOG`
