### PR TITLE
Add weekdayText and note fields to OpenHours.scheduled enum values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
-- [Core] Update dependencies
+- [Core] Update dependencies.
+- [SearchResultMetadata] Add `weekdayText` and `note` associated values to OpenHours.scheduled case.
+- [OpenHours] Change OpenHours decoding to work regardless of key-ordering.
 
 **MapboxCommon**: v24.6.0-rc.1
 **MapboxCoreSearch**: v2.3.0-rc.4

--- a/Sources/MapboxSearch/PublicAPI/OpenHours.swift
+++ b/Sources/MapboxSearch/PublicAPI/OpenHours.swift
@@ -60,7 +60,7 @@ public enum OpenHours: Codable, Hashable {
                   try container.decode(Bool.self, forKey: .permanentlyClosed) == true
         {
             self = .permanentlyClosed
-        } else if container.contains(.scheduled) == true {
+        } else if container.contains(.scheduled) {
             let periods = try container.decode([OpenPeriod].self, forKey: .scheduled)
             // This type annotation
             let weekdayText: WeekdayText? = try container.decodeIfPresent(WeekdayText.self, forKey: .weekdayText)

--- a/Tests/MapboxSearchTests/Common/Models/Metadata/OpenHoursTests.swift
+++ b/Tests/MapboxSearchTests/Common/Models/Metadata/OpenHoursTests.swift
@@ -85,10 +85,10 @@ extension OpenHours.WeekdayText {
     public static func fullWeekdayTextSample() -> Self {
         [
             "Monday 08:35am - 8:18pm",
-            "Monday 08:35am - 8:18pm",
-            "Monday 08:35am - 8:18pm",
-            "Monday 08:35am - 8:18pm",
-            "Monday 08:35am - 8:18pm",
+            "Tuesday 08:35am - 8:18pm",
+            "Wednesday 08:35am - 8:18pm",
+            "Thursday 08:35am - 8:18pm",
+            "Friday 08:35am - 8:18pm",
             "Saturday 10:00am - 7:00pm",
             "Sunday 10:00am - 7:00pm",
         ]

--- a/Tests/MapboxSearchTests/Common/Models/Metadata/OpenHoursTests.swift
+++ b/Tests/MapboxSearchTests/Common/Models/Metadata/OpenHoursTests.swift
@@ -27,7 +27,7 @@ class OpenHoursTests: XCTestCase {
         let coreHours = CoreOpenHours(mode: .scheduled, periods: .coreOpenHourPeriods(), weekdayText: nil, note: nil)
         let hours = OpenHours(coreHours)
 
-        if case .scheduled(let periods) = hours {
+        if case .scheduled(let periods, _, _) = hours {
             XCTAssertEqual(periods.count, 7)
         } else {
             XCTFail("Expected `.scheduled` case")
@@ -44,16 +44,53 @@ class OpenHoursTests: XCTestCase {
         XCTAssertEqual(hours, .permanentlyClosed)
     }
 
-    func testScheduledCaseCodableSupport() throws {
+    /// Test Scheduled Case returned from SBS API
+    func testScheduledCaseSBSCodableSupport() throws {
         let scheduled = OpenHours.scheduled(periods: .fullWeekPeriodsSample())
 
         let data = try jsonEncoder.encode(scheduled)
         let decodedScheduled = try jsonDecoder.decode(OpenHours.self, from: data)
 
-        if case .scheduled(let periods) = decodedScheduled {
+        XCTAssertEqual(decodedScheduled, scheduled)
+        if case .scheduled(let periods, _, _) = decodedScheduled {
             XCTAssertEqual(periods, .fullWeekPeriodsSample())
         } else {
             XCTFail("Expected `.scheduled` case")
         }
+    }
+
+    /// Test Scheduled Case returned from SearchBox API
+    func testScheduledCaseSearchBoxCodableSupport() throws {
+        let scheduled = OpenHours.scheduled(
+            periods: .fullWeekPeriodsSample(),
+            weekdayText: .fullWeekdayTextSample(),
+            note: "Value present"
+        )
+
+        let data = try jsonEncoder.encode(scheduled)
+        let decodedScheduled = try jsonDecoder.decode(OpenHours.self, from: data)
+
+        XCTAssertEqual(decodedScheduled, scheduled)
+        if case .scheduled(let periods, let weekdayText, let note) = decodedScheduled {
+            XCTAssertEqual(periods, .fullWeekPeriodsSample())
+            XCTAssertEqual(weekdayText, .fullWeekdayTextSample())
+            XCTAssertEqual("Value present", note)
+        } else {
+            XCTFail("Expected `.scheduled` case")
+        }
+    }
+}
+
+extension OpenHours.WeekdayText {
+    public static func fullWeekdayTextSample() -> Self {
+        [
+            "Monday 08:35am - 8:18pm",
+            "Monday 08:35am - 8:18pm",
+            "Monday 08:35am - 8:18pm",
+            "Monday 08:35am - 8:18pm",
+            "Monday 08:35am - 8:18pm",
+            "Saturday 10:00am - 7:00pm",
+            "Sunday 10:00am - 7:00pm",
+        ]
     }
 }


### PR DESCRIPTION
### Description
Fixes SSDK-935

- Add associated values to OpenHours.scheduled enum case for `weekdayText` and `notes` fields
- Add default values (nil) for any scenarios where these are absent (SBS)
- Fix OpenHours decoding from a "first key found in non-sorted array" approach to intentionally check for keys matching each of the four known modes and then proceeding. 

### Checklist
- [x] Update `CHANGELOG`
