### PR TITLE
Add AttributeSets enum and parameter to SearchOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
+- [SearchOptions] Add support for AttributeSets parameter to change the level of metadata that is returned.
 - [Core] Update dependencies
 
 **MapboxCommon**: v24.6.0-rc.1

--- a/MapboxSearch.xcodeproj/project.pbxproj
+++ b/MapboxSearch.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		046818E12B87FF5C0082B188 /* search-box-suggestions-minsk.json in Resources */ = {isa = PBXBuildFile; fileRef = 046818E02B87FF5C0082B188 /* search-box-suggestions-minsk.json */; };
 		046818E22B87FF5C0082B188 /* search-box-suggestions-minsk.json in Resources */ = {isa = PBXBuildFile; fileRef = 046818E02B87FF5C0082B188 /* search-box-suggestions-minsk.json */; };
 		046818E32B87FF5C0082B188 /* search-box-suggestions-minsk.json in Resources */ = {isa = PBXBuildFile; fileRef = 046818E02B87FF5C0082B188 /* search-box-suggestions-minsk.json */; };
+		04764E682C5AB93E0040A7FE /* AttributeSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04764E672C5AB93E0040A7FE /* AttributeSet.swift */; };
 		047790492B890A8500A99528 /* search-box-recursion.json in Resources */ = {isa = PBXBuildFile; fileRef = 047790482B890A8500A99528 /* search-box-recursion.json */; };
 		0477904A2B890A8500A99528 /* search-box-recursion.json in Resources */ = {isa = PBXBuildFile; fileRef = 047790482B890A8500A99528 /* search-box-recursion.json */; };
 		0477904B2B890A8500A99528 /* search-box-recursion.json in Resources */ = {isa = PBXBuildFile; fileRef = 047790482B890A8500A99528 /* search-box-recursion.json */; };
@@ -549,6 +550,7 @@
 		046818DA2B87FAB20082B188 /* search-box-category.json */ = {isa = PBXFileReference; explicitFileType = text.json; path = "search-box-category.json"; sourceTree = "<group>"; };
 		046818DE2B87FDC00082B188 /* SearchBox_SearchEngineIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBox_SearchEngineIntegrationTests.swift; sourceTree = "<group>"; };
 		046818E02B87FF5C0082B188 /* search-box-suggestions-minsk.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "search-box-suggestions-minsk.json"; sourceTree = "<group>"; };
+		04764E672C5AB93E0040A7FE /* AttributeSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributeSet.swift; sourceTree = "<group>"; };
 		047790482B890A8500A99528 /* search-box-recursion.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "search-box-recursion.json"; sourceTree = "<group>"; };
 		0477904C2B890F4E00A99528 /* search-box-retrieve-minsk.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "search-box-retrieve-minsk.json"; sourceTree = "<group>"; };
 		0484BCDE2BC4865C003CF408 /* OfflineIndexObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineIndexObserver.swift; sourceTree = "<group>"; };
@@ -1820,6 +1822,7 @@
 				F9274FE92732B64C00708F37 /* Engine */,
 				FEEDD2E42508DFE400DC0A98 /* Search Results */,
 				FE097B77264EAA1A001EAC2F /* Errors */,
+				04764E672C5AB93E0040A7FE /* AttributeSet.swift */,
 				FEEDD2DB2508DFE400DC0A98 /* CodablePersistentService.swift */,
 				FEEDD2E12508DFE400DC0A98 /* DefaultLocationProvider.swift */,
 				FEEDD2ED2508DFE400DC0A98 /* FavoriteRecord.swift */,
@@ -2690,6 +2693,7 @@
 				0484BCDF2BC4865C003CF408 /* OfflineIndexObserver.swift in Sources */,
 				FE260A6725C063880037B725 /* ReverseGeocodingOptions.swift in Sources */,
 				FECA461026D3F81800BC7B18 /* MapboxSearchUserAgent.swift in Sources */,
+				04764E682C5AB93E0040A7FE /* AttributeSet.swift in Sources */,
 				FEEDD2F32508DFE400DC0A98 /* CoreBoundingBox.swift in Sources */,
 				148DE66A285756C20085684D /* NonEmptyArray.swift in Sources */,
 				F97FA24025C95ACD0085A311 /* EventAppMetadata.swift in Sources */,

--- a/Sources/MapboxSearch/InternalAPI/CoreAliases.swift
+++ b/Sources/MapboxSearch/InternalAPI/CoreAliases.swift
@@ -9,6 +9,7 @@ typealias CoreSearchResponse = MapboxCoreSearch_Private.SearchResponse
 typealias CoreSearchOptions = MapboxCoreSearch.SearchOptions
 typealias CoreBoundingBox = MapboxCoreSearch.LonLatBBox
 typealias CoreSearchResult = MapboxCoreSearch.SearchResult
+typealias CoreAttributeSet = MapboxCoreSearch.AttributeSet
 typealias CoreRoutablePoint = MapboxCoreSearch.RoutablePoint
 typealias CoreResultMetadata = MapboxCoreSearch.ResultMetadata
 typealias CoreRequestOptions = MapboxCoreSearch.RequestOptions

--- a/Sources/MapboxSearch/PublicAPI/AttributeSet.swift
+++ b/Sources/MapboxSearch/PublicAPI/AttributeSet.swift
@@ -1,0 +1,45 @@
+// Copyright © 2024 Mapbox. All rights reserved.
+
+import Foundation
+
+public enum AttributeSet: Codable, Hashable, Sendable {
+    /** Essential information about a location such as name, address and coordinates. This is the default value for attribute_sets parameter, and will be provided when attribute_sets is not provided in the request. */
+    case basic
+
+    /** A collection of photos related to the location. */
+    case photos
+
+    /** Specific information about the location including a detailed description text, user reviews, price level and popularity. */
+    case venue
+
+    /** Visiting information for the location like website, phone number and social media handles. */
+    case visit
+
+    var coreValue: CoreAttributeSet {
+        switch self {
+        case .basic:
+            .basic
+        case .photos:
+            .photos
+        case .venue:
+            .venue
+        case .visit:
+            .visit
+        }
+    }
+
+    static func fromCoreValue(_ value: CoreAttributeSet) -> Self? {
+        switch value {
+        case .basic:
+            return .basic
+        case .photos:
+            return .photos
+        case .venue:
+            return .venue
+        case .visit:
+            return .visit
+        @unknown default:
+            return nil
+        }
+    }
+}

--- a/Sources/MapboxSearch/PublicAPI/SearchOptions.swift
+++ b/Sources/MapboxSearch/PublicAPI/SearchOptions.swift
@@ -68,6 +68,10 @@ public struct SearchOptions {
     /// - Attention: May break engine entity functionality. Do not use without SDK developers agreement
     public var unsafeParameters: [String: String]?
 
+    /// Non-ordered array of attribute sets which describe the level of metadata that will be returned.
+    /// When attributeSets is absent the `.basic` value will be used.
+    public var attributeSets: [AttributeSet]?
+
     /**
       The locale in which results should be returned.
 
@@ -93,10 +97,11 @@ public struct SearchOptions {
     /// fields
     /// - Parameter navigationOptions: Navigation options used for proper calculation of ETA and results ranking
     /// - Parameter routeOptions: Options to filter search results along the route
-    /// - Parameter unsafeParameters: Non-verified query parameters to the server API
     /// - Parameter filterTypes: Filter results by types. `CategorySearchEngine` doesn't support that option.
     /// - Parameter ignoreIndexableRecords: Do not search external records in `IndexableDataProvider`s
     /// - Parameter indexableRecordsDistanceThreshold: Radius of circle around `proximity` to filter indexable records
+    /// - Parameter unsafeParameters: Non-verified query parameters to the server API
+    /// - Parameter attributeSets: Options to describe the level of metadata that will be returned
     public init(
         countries: [String]? = nil,
         languages: [String]? = nil,
@@ -110,7 +115,8 @@ public struct SearchOptions {
         filterTypes: [SearchQueryType]? = nil,
         ignoreIndexableRecords: Bool = false,
         indexableRecordsDistanceThreshold: CLLocationDistance? = nil,
-        unsafeParameters: [String: String]? = nil
+        unsafeParameters: [String: String]? = nil,
+        attributeSets: [AttributeSet]? = nil
     ) {
         self.countries = countries
         self.languages = languages ?? Locale.defaultLanguages()
@@ -125,6 +131,7 @@ public struct SearchOptions {
         self.ignoreIndexableRecords = ignoreIndexableRecords
         self.indexableRecordsDistanceThreshold = indexableRecordsDistanceThreshold
         self.unsafeParameters = unsafeParameters
+        self.attributeSets = attributeSets
     }
 
     /// Search request options with custom proximity.
@@ -258,7 +265,7 @@ public struct SearchOptions {
             sarType: routeOptions?.deviation.sarType?.toCore(),
             timeDeviation: timeDeviation,
             addonAPI: unsafeParameters,
-            attributeSets: nil
+            attributeSets: attributeSets.map { $0.map { NSNumber(value: $0.coreValue.rawValue) } }
         )
     }
 
@@ -402,7 +409,8 @@ public struct SearchOptions {
             ignoreIndexableRecords: ignoreIndexableRecords,
             indexableRecordsDistanceThreshold: indexableRecordsDistanceThreshold ??
                 with.indexableRecordsDistanceThreshold,
-            unsafeParameters: unsafeParameters ?? with.unsafeParameters
+            unsafeParameters: unsafeParameters ?? with.unsafeParameters,
+            attributeSets: attributeSets ?? with.attributeSets
         )
     }
 }


### PR DESCRIPTION
### Description

- Add support for AttributeSets parameter to change the level of metadata that is returned.

### Checklist
- [x] Update `CHANGELOG`
