### PR TITLE
[release] Prepare v2.3.0-rc.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
+## 2.3.0-rc.1
+
 - [SearchResultMetadata] Add `weekdayText` and `note` associated values to OpenHours.scheduled case.
 - [OpenHours] Change OpenHours decoding to work regardless of key-ordering.
 - [SearchOptions] Add support for AttributeSets parameter to change the level of metadata that is returned.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 ## License
 
-Mapbox Search for iOS version 2.0.1
+Mapbox Search for iOS version 2.3.0-rc.1
 Mapbox Search iOS SDK
 
 Copyright © 2021 - 2024 Mapbox, Inc. All rights reserved.

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearch'
-  s.version          = '2.3.0-beta.1'
+  s.version          = '2.3.0-rc.1'
   s.summary          = 'Search SDK for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.

--- a/MapboxSearchUI.podspec
+++ b/MapboxSearchUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearchUI'
-  s.version          = '2.3.0-beta.1'
+  s.version          = '2.3.0-rc.1'
   s.summary          = 'Search UI for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.
@@ -23,5 +23,5 @@ Card style custom UI with full search functionality powered by Mapbox Search API
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency 'MapboxSearch', "2.3.0-beta.1"
+  s.dependency 'MapboxSearch', "2.3.0-rc.1"
 end

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ Once you've installed the prerequisites, no additional steps are needed: Open th
 
 You can find the following documentation pages helpful:
 - [Search SDK for iOS guide](https://docs.mapbox.com/ios/search/guides/)
-- [MapboxSearch reference](https://docs.mapbox.com/ios/search/api/core/2.3.0-beta.1/)
-- [MapboxSearchUI reference](https://docs.mapbox.com/ios/search/api/ui/2.3.0-beta.1/)
+- [MapboxSearch reference](https://docs.mapbox.com/ios/search/api/core/2.3.0-rc.1/)
+- [MapboxSearchUI reference](https://docs.mapbox.com/ios/search/api/ui/2.3.0-rc.1/)
 
 ## Project structure overview
 
@@ -110,13 +110,13 @@ MapboxSearchDemoApplication provides a Demo app wih MapboxSearchUI.framework pre
 ##### MapboxSearch
 To integrate latest preview version of `MapboxSearch` into your Xcode project using CocoaPods, specify it in your `Podfile`:  
 ```
-pod 'MapboxSearch', ">= 2.3.0-beta.1", "< 3.0"
+pod 'MapboxSearch', ">= 2.3.0-rc.1", "< 3.0"
 ```
 
 ##### MapboxSearchUI
 To integrate latest preview version of `MapboxSearchUI` into your Xcode project using CocoaPods, specify it in your `Podfile`:  
 ```
-pod 'MapboxSearchUI', ">= 2.3.0-beta.1", "< 3.0"
+pod 'MapboxSearchUI', ">= 2.3.0-rc.1", "< 3.0"
 ```
 
 ### Swift Package Manager

--- a/Search Documentation.docc/Installation.md
+++ b/Search Documentation.docc/Installation.md
@@ -59,7 +59,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearchUI', ">= 2.3.0-beta.1", "< 3.0"
+      pod 'MapboxSearchUI', ">= 2.3.0-rc.1", "< 3.0"
     end
     ```
 
@@ -68,7 +68,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearch', ">= 2.3.0-beta.1", "< 3.0"
+      pod 'MapboxSearch', ">= 2.3.0-rc.1", "< 3.0"
     end
     ```
 

--- a/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
+++ b/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
@@ -1,2 +1,2 @@
 /// Mapbox Search SDK version variable
-public let mapboxSearchSDKVersion = "2.3.0-beta.1"
+public let mapboxSearchSDKVersion = "2.3.0-rc.1"


### PR DESCRIPTION
### Description
Fixes SSDK-1010

Prepare v2.3.0-rc.1 release compatible with MapboxCoreSearch v2.3.0-rc.4 and MapboxCommon v24.6.0-rc.1.

### Checklist
- [x] Update `CHANGELOG`
