### PR TITLE
Add SearchResult.distance field to protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
+- [SearchResult] Add `distance` field to SearchResult protocol
+
 ## 2.3.0-rc.1
 
 - [SearchResultMetadata] Add `weekdayText` and `note` associated values to OpenHours.scheduled case.

--- a/Sources/Demo/ResultDetailViewController.swift
+++ b/Sources/Demo/ResultDetailViewController.swift
@@ -144,6 +144,12 @@ extension SearchResult {
             )
         }
 
+        if let distance {
+            components.append(
+                (name: "Distance", value: distance.description)
+            )
+        }
+
         return components
     }
 }

--- a/Sources/MapboxSearch/PublicAPI/FavoriteRecord.swift
+++ b/Sources/MapboxSearch/PublicAPI/FavoriteRecord.swift
@@ -33,6 +33,8 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
 
     var coordinateCodable: CLLocationCoordinate2DCodable
 
+    public var distance: CLLocationDistance?
+
     /// Result address.
     public var address: Address?
 

--- a/Sources/MapboxSearch/PublicAPI/HistoryRecord.swift
+++ b/Sources/MapboxSearch/PublicAPI/HistoryRecord.swift
@@ -53,6 +53,8 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
 
     var coordinateCodable: CLLocationCoordinate2DCodable
 
+    public var distance: CLLocationDistance?
+
     /// The time when the record was created.
     public private(set) var timestamp: Date
 

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchResult.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchResult.swift
@@ -48,6 +48,9 @@ public protocol SearchResult {
     /// MapKit placemark
     var placemark: MKPlacemark { get }
 
+    /// An approximate distance to the origin location, in meters.
+    var distance: CLLocationDistance? { get }
+
     /// Estimated time of arrival (in minutes) based on specified origin point and `NavigationOptions`.
     /// Those can be specified via `SearchOptions`
     var estimatedTime: Measurement<UnitDuration>? { get }

--- a/Tests/MapboxSearchTests/Common/Data Samples/SearchResultStub+Samples.swift
+++ b/Tests/MapboxSearchTests/Common/Data Samples/SearchResultStub+Samples.swift
@@ -12,6 +12,7 @@ extension SearchResultStub {
         resultType: .POI,
         routablePoints: [.routablePointForSample1],
         coordinate: .sample1,
+        distance: nil,
         address: .fullAddress,
         metadata: .pizzaMetadata,
         dataLayerIdentifier: "sample-data-layer-identifier"

--- a/Tests/MapboxSearchTests/Common/Models/Search Result/SearchResultTests.swift
+++ b/Tests/MapboxSearchTests/Common/Models/Search Result/SearchResultTests.swift
@@ -11,6 +11,7 @@ class SearchResultTests: XCTestCase {
             serverIndex: nil,
             resultType: .POI,
             coordinate: .init(latitude: 12, longitude: -35),
+            distance: nil,
             metadata: .pizzaMetadata
         )
 

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/IndexableRecordStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/IndexableRecordStub.swift
@@ -28,6 +28,7 @@ struct IndexableRecordStub: IndexableRecord {
             iconName: nil,
             resultType: .address(subtypes: [.address]),
             coordinate: .init(coordinate),
+            distance: nil,
             address: address,
             metadata: nil
         )

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/SearchResultStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/SearchResultStub.swift
@@ -14,6 +14,7 @@ class SearchResultStub: SearchResult {
         resultType: SearchResultType,
         routablePoints: [RoutablePoint]? = nil,
         coordinate: CLLocationCoordinate2DCodable,
+        distance: CLLocationDistance?,
         address: Address? = nil,
         metadata: SearchResultMetadata?,
         searchRequest: SearchRequestOptions = .init(query: "Sample", proximity: nil),
@@ -30,6 +31,7 @@ class SearchResultStub: SearchResult {
         self.type = resultType
         self.routablePoints = routablePoints
         self.coordinateCodable = coordinate
+        self.distance = distance
         self.address = address
         self.metadata = metadata
         self.dataLayerIdentifier = dataLayerIdentifier
@@ -60,6 +62,7 @@ class SearchResultStub: SearchResult {
     }
 
     var coordinateCodable: CLLocationCoordinate2DCodable
+    var distance: CLLocationDistance?
     var address: Address?
     var descriptionText: String?
     var searchRequest: SearchRequestOptions
@@ -77,6 +80,7 @@ extension SearchResultStub {
             serverIndex: nil,
             resultType: .POI,
             coordinate: .init(latitude: 12, longitude: -35),
+            distance: nil,
             metadata: nil
         )
     }

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/TestDataProviderRecord.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/TestDataProviderRecord.swift
@@ -13,6 +13,7 @@ struct TestDataProviderRecord: IndexableRecord, SearchResult {
     var iconName: String?
     var categories: [String]?
     var routablePoints: [RoutablePoint]?
+    var distance: CLLocationDistance?
     var address: Address?
     var additionalTokens: Set<String>?
     var estimatedTime: Measurement<UnitDuration>?


### PR DESCRIPTION
### Description

Fixes SSDK-1024

- Add `distance: CLLocationDistance?` value in meters to SearchResult protocol for conformance in ServerSearchResult (also used offline), FavoriteRecord, and HistoryRecord.
- Display this value in Demo app > SearchUI > tap on a search result on the map

##### Demo

![Simulator Screen Recording - iPhone 15 - 2024-08-05 at 12 28 52](https://github.com/user-attachments/assets/55f049c4-49b4-49d5-806b-3ded316b71b3)

### Checklist
- [x] Update `CHANGELOG`
