### PR TITLE
Refine distance field usage in SearchResult protocol conformances

### DIFF
--- a/Sources/MapboxSearch/PublicAPI/FavoriteRecord.swift
+++ b/Sources/MapboxSearch/PublicAPI/FavoriteRecord.swift
@@ -34,7 +34,7 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
     var coordinateCodable: CLLocationCoordinate2DCodable
 
     /// An approximate distance to the origin location, in meters.
-    public private(set) var distance: CLLocationDistance?
+    public var distance: CLLocationDistance?
 
     /// Result address.
     public var address: Address?

--- a/Sources/MapboxSearch/PublicAPI/FavoriteRecord.swift
+++ b/Sources/MapboxSearch/PublicAPI/FavoriteRecord.swift
@@ -33,7 +33,8 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
 
     var coordinateCodable: CLLocationCoordinate2DCodable
 
-    public var distance: CLLocationDistance?
+    /// An approximate distance to the origin location, in meters.
+    public private(set) var distance: CLLocationDistance?
 
     /// Result address.
     public var address: Address?
@@ -88,6 +89,7 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
         name: String,
         matchingName: String?,
         coordinate: CLLocationCoordinate2D,
+        distance: CLLocationDistance? = nil,
         address: Address?,
         makiIcon: Maki?,
         serverIndex: Int?,
@@ -103,6 +105,7 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
         self.name = name
         self.matchingName = matchingName
         self.coordinateCodable = .init(coordinate)
+        self.distance = distance
         self.address = address
         self.icon = makiIcon
         self.serverIndex = serverIndex
@@ -129,6 +132,7 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
             name: name,
             matchingName: searchResult.matchingName,
             coordinate: searchResult.coordinate,
+            distance: searchResult.distance,
             address: searchResult.address,
             makiIcon: searchResult.iconName.flatMap(Maki.init),
             serverIndex: searchResult.serverIndex,

--- a/Sources/MapboxSearch/PublicAPI/HistoryRecord.swift
+++ b/Sources/MapboxSearch/PublicAPI/HistoryRecord.swift
@@ -53,7 +53,8 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
 
     var coordinateCodable: CLLocationCoordinate2DCodable
 
-    public var distance: CLLocationDistance?
+    /// An approximate distance to the origin location, in meters.
+    public private(set) var distance: CLLocationDistance?
 
     /// The time when the record was created.
     public private(set) var timestamp: Date
@@ -107,6 +108,7 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
         serverIndex: Int?,
         accuracy: SearchResultAccuracy?,
         coordinate: CLLocationCoordinate2D,
+        distance: CLLocationDistance? = nil,
         timestamp: Date = Date(),
         historyType: HistoryRecord.HistoryType,
         type: SearchResultType,
@@ -123,6 +125,7 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
         self.serverIndex = serverIndex
         self.accuracy = accuracy
         self.coordinateCodable = .init(coordinate)
+        self.distance = distance
         self.timestamp = timestamp
         self.historyType = historyType
         self.type = type
@@ -150,6 +153,7 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
         self.serverIndex = searchResult.serverIndex
         self.accuracy = searchResult.accuracy
         self.coordinateCodable = .init(searchResult.coordinate)
+        self.distance = searchResult.distance
         self.timestamp = timestamp
         self.historyType = historyType
         self.type = searchResult.type

--- a/Sources/MapboxSearch/PublicAPI/HistoryRecord.swift
+++ b/Sources/MapboxSearch/PublicAPI/HistoryRecord.swift
@@ -54,7 +54,7 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
     var coordinateCodable: CLLocationCoordinate2DCodable
 
     /// An approximate distance to the origin location, in meters.
-    public private(set) var distance: CLLocationDistance?
+    public var distance: CLLocationDistance?
 
     /// The time when the record was created.
     public private(set) var timestamp: Date

--- a/Sources/MapboxSearch/PublicAPI/Search Results/ServerSearchResult.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/ServerSearchResult.swift
@@ -2,8 +2,6 @@ import CoreLocation
 import Foundation
 
 class ServerSearchResult: SearchResult, SearchResultSuggestion, CoreResponseProvider {
-    var distance: CLLocationDistance?
-
     var originalResponse: CoreSearchResultResponse
 
     var coordinate: CLLocationCoordinate2D {
@@ -26,6 +24,8 @@ class ServerSearchResult: SearchResult, SearchResultSuggestion, CoreResponseProv
     var coordinateCodable: CLLocationCoordinate2DCodable
 
     var address: Address?
+
+    var distance: CLLocationDistance?
 
     var categories: [String]?
 

--- a/Tests/MapboxSearchIntegrationTests/SearchEngineIntegrationTests.swift
+++ b/Tests/MapboxSearchIntegrationTests/SearchEngineIntegrationTests.swift
@@ -94,6 +94,7 @@ class SBS_SearchEngineIntegrationTests: MockServerIntegrationTestCase<SBSMockRes
         let resolvedResult = try XCTUnwrap(delegate.resolvedResult)
 
         XCTAssertEqual(resolvedResult.name, selectedResult.name)
+        XCTAssertEqual(resolvedResult.distance, 5000000)
     }
 
     func testResolvedSearchResultWhenQueryChanged() throws {

--- a/Tests/MapboxSearchTests/Common/Data Samples/SearchResultStub+Samples.swift
+++ b/Tests/MapboxSearchTests/Common/Data Samples/SearchResultStub+Samples.swift
@@ -12,7 +12,7 @@ extension SearchResultStub {
         resultType: .POI,
         routablePoints: [.routablePointForSample1],
         coordinate: .sample1,
-        distance: nil,
+        distance: 100.0,
         address: .fullAddress,
         metadata: .pizzaMetadata,
         dataLayerIdentifier: "sample-data-layer-identifier"

--- a/Tests/MapboxSearchTests/Common/Models/Search Result/ServerSearchResultTests.swift
+++ b/Tests/MapboxSearchTests/Common/Models/Search Result/ServerSearchResultTests.swift
@@ -79,4 +79,16 @@ class ServerSearchResultTests: XCTestCase {
         ))
         XCTAssertEqual(result.suggestionType, .address(subtypes: [.address]))
     }
+
+    func testServerSearchResultDistanceField() throws {
+        let coreResult = CoreSearchResultStub(id: UUID().uuidString, mapboxId: "", type: .address)
+        let result = try XCTUnwrap(ServerSearchResult(
+            coreResult: coreResult,
+            response: CoreSearchResponseStub.failureSample
+        ))
+
+        // ServerSearchResult will perform its own distance computation locally if nil from server
+        XCTAssertNotNil(result.distance)
+        XCTAssertEqual(result.distance, 0.0)
+    }
 }

--- a/Tests/MapboxSearchTests/Legacy/FavoriteRecordTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/FavoriteRecordTests.swift
@@ -15,6 +15,7 @@ class FavoriteRecordTests: XCTestCase {
         XCTAssertEqual(record.coordinate, resultStub.coordinate)
         XCTAssertEqual(record.icon, .bar)
         XCTAssertEqual(record.type, resultStub.type)
+        XCTAssertEqual(record.distance, 100.0)
 
         XCTAssertNil(record.additionalTokens)
     }

--- a/Tests/MapboxSearchTests/Legacy/HistoryRecordTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/HistoryRecordTests.swift
@@ -77,5 +77,6 @@ class HistoryRecordTests: XCTestCase {
         XCTAssertEqual(record.address, result.address)
         XCTAssertEqual(record.metadata, result.metadata)
         XCTAssertEqual(record.routablePoints, result.routablePoints)
+        XCTAssertEqual(record.distance, 100.0)
     }
 }


### PR DESCRIPTION
### Description

- Add documentation comments to IndexableRecord instances (FavoriteRecord, HistoryRecord)
- Add initializer fields where needed
- Re-arrange fields in ServerSearchResult 
- Add test behavior to check value in distance field
- Follow-up to https://github.com/mapbox/mapbox-search-ios/pull/286

### Checklist
- [NA] Update `CHANGELOG`
