### PR TITLE
Update MapboxCoreSearch v2.3.0-rc.6, MapboxCommon v24.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 - [UI] Enforce template mode on all Maki and SearchResult Types icons (always theme-able).
 
+- [SearchOptions] Remove SearchOptions.AttributeSets parameter.
+
+**MapboxCommon**: v24.6.0
+**MapboxCoreSearch**: v2.3.0-rc.6
+
 ## 2.3.0-rc.1
 
 - [SearchResultMetadata] Add `weekdayText` and `note` associated values to OpenHours.scheduled case.

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.3.0-rc.4
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.6.0-rc.1
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.3.0-rc.6
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.6.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.6.0-rc.1"
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.3.0-rc.4"
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.6.0"
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.3.0-rc.6"

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -24,6 +24,6 @@ Some iOS platform specifics applies.
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency "MapboxCoreSearch", '2.3.0-rc.4'
-  s.dependency "MapboxCommon", '24.6.0-rc.1'
+  s.dependency "MapboxCoreSearch", '2.3.0-rc.6'
+  s.dependency "MapboxCommon", '24.6.0'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -4,9 +4,9 @@
 import PackageDescription
 import Foundation
 
-let (coreSearchVersion, coreSearchVersionHash) = ("2.3.0-rc.4", "6afef0135dc459524d37470c38540b93aee11b21a943305f76bacb160187907c")
+let (coreSearchVersion, coreSearchVersionHash) = ("2.3.0-rc.6", "448abd1a80805078b3fda0840e8284cfe5a8d77350993bc855483aa5d3ed4a50")
 
-let mapboxCommonSDKVersion = Version("24.6.0-rc.1")
+let mapboxCommonSDKVersion = Version("24.6.0")
 
 let package = Package(
     name: "MapboxSearch",

--- a/Sources/MapboxSearch/PublicAPI/SearchOptions.swift
+++ b/Sources/MapboxSearch/PublicAPI/SearchOptions.swift
@@ -68,10 +68,6 @@ public struct SearchOptions {
     /// - Attention: May break engine entity functionality. Do not use without SDK developers agreement
     public var unsafeParameters: [String: String]?
 
-    /// Non-ordered array of attribute sets which describe the level of metadata that will be returned.
-    /// When attributeSets is absent the `.basic` value will be used.
-    public var attributeSets: [AttributeSet]?
-
     /**
       The locale in which results should be returned.
 
@@ -101,7 +97,6 @@ public struct SearchOptions {
     /// - Parameter ignoreIndexableRecords: Do not search external records in `IndexableDataProvider`s
     /// - Parameter indexableRecordsDistanceThreshold: Radius of circle around `proximity` to filter indexable records
     /// - Parameter unsafeParameters: Non-verified query parameters to the server API
-    /// - Parameter attributeSets: Options to describe the level of metadata that will be returned
     public init(
         countries: [String]? = nil,
         languages: [String]? = nil,
@@ -115,8 +110,7 @@ public struct SearchOptions {
         filterTypes: [SearchQueryType]? = nil,
         ignoreIndexableRecords: Bool = false,
         indexableRecordsDistanceThreshold: CLLocationDistance? = nil,
-        unsafeParameters: [String: String]? = nil,
-        attributeSets: [AttributeSet]? = nil
+        unsafeParameters: [String: String]? = nil
     ) {
         self.countries = countries
         self.languages = languages ?? Locale.defaultLanguages()
@@ -131,7 +125,6 @@ public struct SearchOptions {
         self.ignoreIndexableRecords = ignoreIndexableRecords
         self.indexableRecordsDistanceThreshold = indexableRecordsDistanceThreshold
         self.unsafeParameters = unsafeParameters
-        self.attributeSets = attributeSets
     }
 
     /// Search request options with custom proximity.
@@ -264,8 +257,7 @@ public struct SearchOptions {
             route: routeOptions?.route.coordinates.map(Coordinate2D.init(value:)),
             sarType: routeOptions?.deviation.sarType?.toCore(),
             timeDeviation: timeDeviation,
-            addonAPI: unsafeParameters,
-            attributeSets: attributeSets.map { $0.map { NSNumber(value: $0.coreValue.rawValue) } }
+            addonAPI: unsafeParameters
         )
     }
 
@@ -409,8 +401,7 @@ public struct SearchOptions {
             ignoreIndexableRecords: ignoreIndexableRecords,
             indexableRecordsDistanceThreshold: indexableRecordsDistanceThreshold ??
                 with.indexableRecordsDistanceThreshold,
-            unsafeParameters: unsafeParameters ?? with.unsafeParameters,
-            attributeSets: attributeSets ?? with.attributeSets
+            unsafeParameters: unsafeParameters ?? with.unsafeParameters
         )
     }
 }

--- a/Tests/MapboxSearchTests/Common/Data Samples/CoreSearchOptions+Samples.swift
+++ b/Tests/MapboxSearchTests/Common/Data Samples/CoreSearchOptions+Samples.swift
@@ -31,8 +31,7 @@ extension CoreSearchOptions {
         ],
         sarType: "isochrone",
         timeDeviation: 10,
-        addonAPI: nil,
-        attributeSets: nil
+        addonAPI: nil
     )
 
     static let sample2 = CoreSearchOptions(
@@ -67,7 +66,6 @@ extension CoreSearchOptions {
         ],
         sarType: "isochrone",
         timeDeviation: 10,
-        addonAPI: nil,
-        attributeSets: nil
+        addonAPI: nil
     )
 }


### PR DESCRIPTION
### Description

- Update MapboxCoreSearch v2.3.0-rc.6
- Update MapboxCommon v24.6.0
- Remove SearchOptions.attributeSets field for an updated approach

### Checklist
- [x] Update `CHANGELOG`
