### PR TITLE
Add RetrieveOptions parameter to select() (aka retrieve/) functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 - [SearchOptions] Remove SearchOptions.AttributeSets parameter.
 
+- [SearchEngine] Add RetrieveOptions(attributeSets:) parameter to `select()` functions. Use this to provide attribute set queries.
+
 **MapboxCommon**: v24.6.0
 **MapboxCoreSearch**: v2.3.0-rc.6
 

--- a/MapboxSearch.xcodeproj/project.pbxproj
+++ b/MapboxSearch.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		048823492B6B0A9D00C770AA /* category-hotel-search-along-route-jp.json in Resources */ = {isa = PBXBuildFile; fileRef = 04AB0B7C2B6B043C00FDE7D5 /* category-hotel-search-along-route-jp.json */; };
 		0488234A2B6B0A9E00C770AA /* category-hotel-search-along-route-jp.json in Resources */ = {isa = PBXBuildFile; fileRef = 04AB0B7C2B6B043C00FDE7D5 /* category-hotel-search-along-route-jp.json */; };
 		04970F8D2B7A97C900213763 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 04970F8C2B7A97C900213763 /* PrivacyInfo.xcprivacy */; };
+		049FE3A82C6A50BB00F54FB2 /* RetrieveOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 049FE3A72C6A50BB00F54FB2 /* RetrieveOptions.swift */; };
 		04AB0B4B2B6AADB700FDE7D5 /* mapbox.places.san.francisco.json in Resources */ = {isa = PBXBuildFile; fileRef = 04AB0B4A2B6AADB700FDE7D5 /* mapbox.places.san.francisco.json */; };
 		04AB0B4C2B6AADB700FDE7D5 /* mapbox.places.san.francisco.json in Resources */ = {isa = PBXBuildFile; fileRef = 04AB0B4A2B6AADB700FDE7D5 /* mapbox.places.san.francisco.json */; };
 		04AB0B4D2B6AADB700FDE7D5 /* mapbox.places.san.francisco.json in Resources */ = {isa = PBXBuildFile; fileRef = 04AB0B4A2B6AADB700FDE7D5 /* mapbox.places.san.francisco.json */; };
@@ -558,6 +559,7 @@
 		0477904C2B890F4E00A99528 /* search-box-retrieve-minsk.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "search-box-retrieve-minsk.json"; sourceTree = "<group>"; };
 		0484BCDE2BC4865C003CF408 /* OfflineIndexObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineIndexObserver.swift; sourceTree = "<group>"; };
 		04970F8C2B7A97C900213763 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		049FE3A72C6A50BB00F54FB2 /* RetrieveOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrieveOptions.swift; sourceTree = "<group>"; };
 		04AB0B4A2B6AADB700FDE7D5 /* mapbox.places.san.francisco.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = mapbox.places.san.francisco.json; sourceTree = "<group>"; };
 		04AB0B792B6AF37800FDE7D5 /* DiscoverIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverIntegrationTests.swift; sourceTree = "<group>"; };
 		04AB0B7C2B6B043C00FDE7D5 /* category-hotel-search-along-route-jp.json */ = {isa = PBXFileReference; explicitFileType = text.json; path = "category-hotel-search-along-route-jp.json"; sourceTree = "<group>"; };
@@ -1596,6 +1598,7 @@
 				FEEDD2E32508DFE400DC0A98 /* AbstractSearchEngine.swift */,
 				04C127542B62F6BC00884325 /* ApiType.swift */,
 				FEEDD2D82508DFE400DC0A98 /* SearchEngine.swift */,
+				049FE3A72C6A50BB00F54FB2 /* RetrieveOptions.swift */,
 				FEEDD2EB2508DFE400DC0A98 /* CategorySearchEngine.swift */,
 				04C0848C2B4C82F3002F9C69 /* SdkInformation.swift */,
 			);
@@ -2701,6 +2704,7 @@
 				0484BCDF2BC4865C003CF408 /* OfflineIndexObserver.swift in Sources */,
 				FE260A6725C063880037B725 /* ReverseGeocodingOptions.swift in Sources */,
 				FECA461026D3F81800BC7B18 /* MapboxSearchUserAgent.swift in Sources */,
+				049FE3A82C6A50BB00F54FB2 /* RetrieveOptions.swift in Sources */,
 				04764E682C5AB93E0040A7FE /* AttributeSet.swift in Sources */,
 				FEEDD2F32508DFE400DC0A98 /* CoreBoundingBox.swift in Sources */,
 				148DE66A285756C20085684D /* NonEmptyArray.swift in Sources */,

--- a/Sources/MapboxSearch/InternalAPI/CoreAliases.swift
+++ b/Sources/MapboxSearch/InternalAPI/CoreAliases.swift
@@ -10,6 +10,7 @@ typealias CoreSearchOptions = MapboxCoreSearch.SearchOptions
 typealias CoreBoundingBox = MapboxCoreSearch.LonLatBBox
 typealias CoreSearchResult = MapboxCoreSearch.SearchResult
 typealias CoreAttributeSet = MapboxCoreSearch.AttributeSet
+typealias CoreRetrieveOptions = MapboxCoreSearch.RetrieveOptions
 typealias CoreRoutablePoint = MapboxCoreSearch.RoutablePoint
 typealias CoreResultMetadata = MapboxCoreSearch.ResultMetadata
 typealias CoreRequestOptions = MapboxCoreSearch.RequestOptions

--- a/Sources/MapboxSearch/InternalAPI/CoreSearchEngineProtocol.swift
+++ b/Sources/MapboxSearch/InternalAPI/CoreSearchEngineProtocol.swift
@@ -32,6 +32,7 @@ protocol CoreSearchEngineProtocol {
     func nextSearch(
         for result: CoreSearchResultProtocol,
         with originalRequest: CoreRequestOptions,
+        options retrieveOptions: CoreRetrieveOptions,
         callback: @escaping (CoreSearchResponseProtocol?) -> Void
     )
 
@@ -155,10 +156,11 @@ extension CoreSearchEngine: CoreSearchEngineProtocol {
     func nextSearch(
         for result: CoreSearchResultProtocol,
         with originalRequest: CoreRequestOptions,
+        options retrieveOptions: CoreRetrieveOptions,
         callback: @escaping (CoreSearchResponseProtocol?) -> Void
     ) {
         if let coreResult = result as? CoreSearchResult {
-            retrieve(forRequest: originalRequest, result: coreResult) { response in
+            retrieve(forRequest: originalRequest, result: coreResult, retrieveOptions: retrieveOptions) { response in
                 DispatchQueue.main.async {
                     callback(response)
                 }
@@ -166,7 +168,7 @@ extension CoreSearchEngine: CoreSearchEngineProtocol {
         } else {
             // swiftlint:disable:next line_length
             assertionFailure(
-                "Unexpected type of CoreSearchResultProtocol. Engine doesn't support nothing but CoreSearchResult"
+                "Unexpected type of CoreSearchResultProtocol. Engine only supports result: CoreSearchResult input."
             )
             DispatchQueue.main.async {
                 callback(nil)
@@ -198,7 +200,7 @@ extension CoreSearchEngine: CoreSearchEngineProtocol {
         } else {
             // swiftlint:disable:next line_length
             assertionFailure(
-                "Unexpected type of CoreSearchResultProtocol. Engine doesn't support nothing but CoreSearchResult"
+                "Unexpected type of CoreSearchResultProtocol. Engine only supports result: CoreSearchResult input."
             )
         }
     }

--- a/Sources/MapboxSearch/PublicAPI/AttributeSet.swift
+++ b/Sources/MapboxSearch/PublicAPI/AttributeSet.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-public enum AttributeSet: Codable, Hashable, Sendable {
+public enum AttributeSet: CaseIterable, Codable, Hashable, Sendable {
     /** Essential information about a location such as name, address and coordinates. This is the default value for attribute_sets parameter, and will be provided when attribute_sets is not provided in the request. */
     case basic
 

--- a/Sources/MapboxSearch/PublicAPI/Engine/AbstractSearchEngine.swift
+++ b/Sources/MapboxSearch/PublicAPI/Engine/AbstractSearchEngine.swift
@@ -147,6 +147,7 @@ public class AbstractSearchEngine: FeedbackManagerDelegate {
 
     func resolve(
         suggestion: SearchResultSuggestion,
+        retrieveOptions: RetrieveOptions?,
         completionQueue: DispatchQueue = .main,
         completion: @escaping (Result<SearchResult, SearchError>) -> Void
     ) {
@@ -156,7 +157,7 @@ public class AbstractSearchEngine: FeedbackManagerDelegate {
             return
         }
 
-        resolver.resolve(suggestion: suggestion) { resolvedResult in
+        resolver.resolve(suggestion: suggestion, retrieveOptions: retrieveOptions) { resolvedResult in
             completionQueue.async {
                 if let resolvedResult {
                     completion(.success(resolvedResult))

--- a/Sources/MapboxSearch/PublicAPI/Engine/RetrieveOptions.swift
+++ b/Sources/MapboxSearch/PublicAPI/Engine/RetrieveOptions.swift
@@ -1,0 +1,22 @@
+// Copyright © 2024 Mapbox. All rights reserved.
+
+import Foundation
+
+public struct RetrieveOptions: Sendable {
+    /// Besides the basic metadata attributes, developers can request additional
+    /// attributes by setting attribute_sets parameter with attribute set values,
+    /// for example &attribute_sets=basic,photos,visit.
+    /// The requested metadata will be provided in metadata object in the response.
+    public var attributeSets: [AttributeSet]?
+
+    public init(attributeSets: [AttributeSet]?) {
+        self.attributeSets = attributeSets
+    }
+
+    func toCore() -> CoreRetrieveOptions {
+        CoreRetrieveOptions(
+            attributeSets:
+            attributeSets.map { $0.map { NSNumber(value: $0.coreValue.rawValue) } }
+        )
+    }
+}

--- a/Sources/MapboxSearch/PublicAPI/Engine/SearchEngine.swift
+++ b/Sources/MapboxSearch/PublicAPI/Engine/SearchEngine.swift
@@ -206,7 +206,10 @@ public class SearchEngine: AbstractSearchEngine {
         offlineMode == .disabled ? engine.reverseGeocoding : engine.reverseGeocodingOffline
     }
 
-    func retrieve(suggestion: SearchSuggestion) {
+    func retrieve(
+        suggestion: SearchSuggestion,
+        retrieveOptions: RetrieveOptions?
+    ) {
         guard let responseProvider = suggestion as? CoreResponseProvider else {
             assertionFailure()
             return
@@ -214,9 +217,11 @@ public class SearchEngine: AbstractSearchEngine {
 
         assert(offlineMode == .disabled)
 
+        let retrieveOptions = retrieveOptions ?? RetrieveOptions(attributeSets: nil)
         engine.nextSearch(
             for: responseProvider.originalResponse.coreResult,
-            with: responseProvider.originalResponse.requestOptions
+            with: responseProvider.originalResponse.requestOptions,
+            options: retrieveOptions.toCore()
         ) { [weak self] serverResponse in
             self?.processResponse(serverResponse, suggestion: suggestion)
         }
@@ -292,7 +297,7 @@ public class SearchEngine: AbstractSearchEngine {
         return SearchResponse(coreResponse: coreResponse)
     }
 
-    /// Process core search response and update delegate.
+    /// Process core search response and update delegate when a suggested category returns more suggestions.
     /// - Parameters:
     ///   - coreResponse: coreResponse to process
     ///   - suggestion: original suggestion
@@ -373,7 +378,7 @@ extension SearchEngine {
     /// Select one of the provided `SearchSuggestion`'s.
     /// Search flow would continue if category suggestion was selected.
     /// - Parameter suggestion: Suggestion to continue the search and retrieve resolved `SearchResult` via delegate.
-    public func select(suggestion: SearchSuggestion) {
+    public func select(suggestion: SearchSuggestion, options retrieveOptions: RetrieveOptions? = nil) {
         userActivityReporter.reportActivity(forComponent: "search-engine-forward-geocoding-selection")
 
         // Call `onSelected` for only supported types
@@ -387,11 +392,20 @@ extension SearchEngine {
 
         switch suggestion {
         case let categorySuggestion as SearchCategorySuggestion:
-            retrieve(suggestion: categorySuggestion)
+            retrieve(
+                suggestion: categorySuggestion,
+                retrieveOptions: retrieveOptions
+            )
         case let querySuggestion as SearchQuerySuggestion:
-            retrieve(suggestion: querySuggestion)
+            retrieve(
+                suggestion: querySuggestion,
+                retrieveOptions: retrieveOptions
+            )
         case let resultSuggestion as SearchResultSuggestion:
-            resolve(suggestion: resultSuggestion) { [weak self] (result: Result<SearchResult, SearchError>) in
+            resolve(
+                suggestion: resultSuggestion,
+                retrieveOptions: retrieveOptions
+            ) { [weak self] (result: Result<SearchResult, SearchError>) in
                 guard let self else {
                     assertionFailure("Owning object was deallocated")
                     return
@@ -510,19 +524,37 @@ extension SearchEngine: IndexableDataResolver {
     ///   - suggestion: suggestion to resolve
     ///   - completion: completion closure
     public func resolve(suggestion: SearchResultSuggestion, completion: @escaping (SearchResult?) -> Void) {
+        resolve(suggestion: suggestion, retrieveOptions: nil, completion: completion)
+    }
+
+    /// Resolves ``SearchResultSuggestion`` into ``SearchResult`` through Mapbox API.
+    /// Should never be called directly.
+    ///
+    /// - Parameters:
+    ///   - suggestion: suggestion to resolve
+    ///   - retrieveOptions: Define attribute sets to request additional metadata attributes
+    ///   - completion: completion closure
+    public func resolve(
+        suggestion: SearchResultSuggestion,
+        retrieveOptions: RetrieveOptions?,
+        completion: @escaping (SearchResult?) -> Void
+    ) {
         assert(suggestion.dataLayerIdentifier == Self.providerIdentifier)
 
         switch suggestion {
         case let suggestion as SearchResultSuggestionImpl:
+            let retrieveOptions = retrieveOptions ?? RetrieveOptions(attributeSets: nil)
             engine.nextSearch(
                 for: suggestion.originalResponse.coreResult,
-                with: suggestion.originalResponse.requestOptions
+                with: suggestion.originalResponse.requestOptions,
+                options: retrieveOptions.toCore()
             ) { coreSearchResponse in
                 // Processing search response for Suggestion with type Query may return multiple suggestions or results.
                 // For other types we are expecting single result.
                 let searchResult = self.resolveServerRetrieveResponse(coreSearchResponse)
                 completion(searchResult)
             }
+
         case let suggestion as SearchResult:
             completion(suggestion)
 

--- a/Sources/MapboxSearch/PublicAPI/IndexableDataResolver.swift
+++ b/Sources/MapboxSearch/PublicAPI/IndexableDataResolver.swift
@@ -8,4 +8,15 @@ public protocol IndexableDataResolver {
     ///   - suggestion: suggestion to resolve
     ///   - completion: completion closure
     func resolve(suggestion: SearchResultSuggestion, completion: @escaping (SearchResult?) -> Void)
+
+    /// Resolves ``SearchResultSuggestion`` into ``SearchResult`` if possible
+    /// - Parameters:
+    ///   - suggestion: suggestion to resolve
+    ///   - retrieveOptions: Define attribute sets to request additional metadata attributes
+    ///   - completion: completion closure
+    func resolve(
+        suggestion: SearchResultSuggestion,
+        retrieveOptions: RetrieveOptions?,
+        completion: @escaping (SearchResult?) -> Void
+    )
 }

--- a/Sources/MapboxSearch/PublicAPI/LocalDataProviders.swift
+++ b/Sources/MapboxSearch/PublicAPI/LocalDataProviders.swift
@@ -63,6 +63,20 @@ public class LocalDataProvider<Record: Codable & SearchResult & IndexableRecord>
         completion(resolvedResult)
     }
 
+    /// Resolves ``SearchResultSuggestion`` into ``SearchResult`` locally.
+    /// - Parameters:
+    ///   - suggestion: suggestion to resolve
+    ///   - retrieveOptions: Define attribute sets to request additional metadata attributes
+    ///   - completion: completion closure
+    public func resolve(
+        suggestion: any SearchResultSuggestion,
+        retrieveOptions: RetrieveOptions?,
+        completion: @escaping ((any SearchResult)?) -> Void
+    ) {
+        let resolvedResult = recordsMap[suggestion.id]
+        completion(resolvedResult)
+    }
+
     func saveData() {
         let notification = Notification(name: Self.updateNotificationName)
         NotificationQueue.default.enqueue(notification, postingStyle: .asap)

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Address Autofill/AddressAutofill.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Address Autofill/AddressAutofill.swift
@@ -117,14 +117,16 @@ extension AddressAutofill {
 
         switch suggestion.underlying {
         case .suggestion(let coreSearch, let coreOptions):
-            searchEngine.nextSearch(for: coreSearch, with: coreOptions) { [weak self] coreResponse in
-                guard let self else {
-                    completion(.failure(SearchError.owningObjectDeallocated))
-                    return
-                }
+            let retrieveOptions = CoreRetrieveOptions(attributeSets: nil)
+            searchEngine
+                .nextSearch(for: coreSearch, with: coreOptions, options: retrieveOptions) { [weak self] coreResponse in
+                    guard let self else {
+                        completion(.failure(SearchError.owningObjectDeallocated))
+                        return
+                    }
 
-                self.manage(response: coreResponse, completion: completion)
-            }
+                    manage(response: coreResponse, completion: completion)
+                }
         case .result:
             guard let coordinate = suggestion.coordinate else {
                 completion(.failure(SearchError.responseProcessingFailed))
@@ -196,7 +198,7 @@ extension AddressAutofill {
                 return
             }
 
-            self.manage(response: response, for: query, completion: completion)
+            manage(response: response, for: query, completion: completion)
         }
     }
 

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/PlaceAutocomplete.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/PlaceAutocomplete.swift
@@ -203,7 +203,7 @@ extension PlaceAutocomplete {
                 return
             }
 
-            self.manage(response: response, for: query, completion: completion)
+            manage(response: response, for: query, completion: completion)
         }
     }
 
@@ -247,7 +247,8 @@ extension PlaceAutocomplete {
         with options: CoreRequestOptions,
         completion: @escaping (Swift.Result<Suggestion, Error>) -> Void
     ) {
-        searchEngine.nextSearch(for: suggestion, with: options) { response in
+        let retrieveOptions = CoreRetrieveOptions(attributeSets: nil)
+        searchEngine.nextSearch(for: suggestion, with: options, options: retrieveOptions) { response in
             guard let coreResponse = response else {
                 assertionFailure("Response should never be nil")
                 completion(.failure(SearchError.responseProcessingFailed))

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/CoreSearchEngineStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/CoreSearchEngineStub.swift
@@ -113,6 +113,7 @@ extension CoreSearchEngineStub: CoreSearchEngineProtocol {
     func nextSearch(
         for result: CoreSearchResultProtocol,
         with originalRequest: CoreRequestOptions,
+        options: CoreRetrieveOptions,
         callback: @escaping (CoreSearchResponseProtocol?) -> Void
     ) {
         nextSearchCalled = true
@@ -185,9 +186,10 @@ extension CoreSearchEngineStub: CoreSearchEngineProtocol {
     func retrieveOffline(
         for result: CoreSearchResultProtocol,
         with originalRequest: CoreRequestOptions,
+        options retrieveOptions: CoreRetrieveOptions,
         callback: @escaping (CoreSearchResponseProtocol?) -> Void
     ) {
-        nextSearch(for: result, with: originalRequest, callback: callback)
+        nextSearch(for: result, with: originalRequest, options: retrieveOptions, callback: callback)
     }
 
     func reverseGeocodingOffline(

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/DataLayerProviderStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/DataLayerProviderStub.swift
@@ -18,4 +18,13 @@ class DataLayerProviderStub: IndexableDataProvider {
         let resolved = records.first { $0.id == suggestion.id } as? IndexableRecordStub
         completion(resolved?.asResolved)
     }
+
+    func resolve(
+        suggestion: any MapboxSearch.SearchResultSuggestion,
+        retrieveOptions: MapboxSearch.RetrieveOptions?,
+        completion: @escaping ((any MapboxSearch.SearchResult)?) -> Void
+    ) {
+        let resolved = records.first { $0.id == suggestion.id } as? IndexableRecordStub
+        completion(resolved?.asResolved)
+    }
 }

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/SearchEngineDelegateStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/SearchEngineDelegateStub.swift
@@ -2,6 +2,7 @@
 import XCTest
 
 class SearchEngineDelegateStub: SearchEngineDelegate {
+    var resolvedSuggestions: [SearchSuggestion]?
     var resolvedResult: SearchResult?
     var resolvedResults: [SearchResult] = []
     var error: SearchError?
@@ -40,6 +41,7 @@ class SearchEngineDelegateStub: SearchEngineDelegate {
     }
 
     func suggestionsUpdated(suggestions: [SearchSuggestion], searchEngine: SearchEngine) {
+        resolvedSuggestions = suggestions
         NotificationCenter.default.post(name: updateNotificationName, object: self)
     }
 

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/TestDataProvider.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/TestDataProvider.swift
@@ -16,4 +16,13 @@ class TestDataProvider: IndexableDataProvider {
         let record = records.first { $0.id == suggestion.id }
         completion(record)
     }
+
+    func resolve(
+        suggestion: any SearchResultSuggestion,
+        retrieveOptions: RetrieveOptions?,
+        completion: @escaping ((any SearchResult)?) -> Void
+    ) {
+        let record = records.first { $0.id == suggestion.id }
+        completion(record)
+    }
 }

--- a/Tests/MapboxSearchTests/Legacy/SearchEngineTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/SearchEngineTests.swift
@@ -552,7 +552,7 @@ class SearchEngineTests: XCTestCase {
                 XCTAssertNil(metadata.otherImages)
                 XCTAssertNil(metadata.phone)
                 XCTAssertNil(metadata.website)
-                XCTAssertNil(metadata.reviewCount)
+                XCTAssertNotNil(metadata.reviewCount)
                 XCTAssertNil(metadata.averageRating)
                 XCTAssertNil(metadata.openHours)
             case .visit:

--- a/Tests/MapboxSearchTests/Legacy/SearchEngineTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/SearchEngineTests.swift
@@ -485,4 +485,87 @@ class SearchEngineTests: XCTestCase {
         searchEngine.query = "random-query"
         XCTAssertEqual(searchEngine.query, "random-query")
     }
+
+    /// NOTE: Although this test uses separate fetches for each attribute set this is purely for testing coverage
+    /// purposes. It is recommended to request as many attribute sets as desired in one RequestOptions array.
+    /// Ex: You should use RetrieveOptions(attributeSets: [.visit, .photos]) in one select() call rather than two calls.
+    func testRetrieveDetailsFunction() throws {
+        let searchEngine = SearchEngine(apiType: .searchBox)
+        let delegate = SearchEngineDelegateStub()
+        searchEngine.delegate = delegate
+        let updateExpectation = delegate.updateExpectation
+
+        let searchOptions = SearchOptions(
+            limit: 100,
+            origin: CLLocationCoordinate2D(latitude: 38.902309, longitude: -77.029129),
+            filterTypes: [.poi]
+        )
+
+        searchEngine.search(query: "planet word", options: searchOptions)
+        wait(for: [updateExpectation], timeout: 200)
+        let suggestion = try XCTUnwrap(delegate.resolvedSuggestions?.first)
+
+        func fetchResult(for: SearchSuggestion, options: RetrieveOptions) throws -> SearchResult {
+            let successExpectation = delegate.successExpectation
+            searchEngine.select(suggestion: suggestion, options: options)
+            wait(for: [successExpectation], timeout: 200)
+            return try XCTUnwrap(delegate.resolvedResult)
+        }
+
+        let attributes = [
+            AttributeSet.basic,
+            .photos,
+            .venue,
+            .visit,
+        ]
+
+        let resultsByAttribute = try attributes.map { attributeSet in
+            let result = try fetchResult(for: suggestion, options: RetrieveOptions(attributeSets: [attributeSet]))
+
+            XCTAssertNotNil(result.metadata, "\(attributeSet) metadata should not be nil")
+
+            return (attributeSet, result)
+        }
+
+        XCTAssertNotNil(resultsByAttribute)
+        for (attribute, result) in resultsByAttribute {
+            let metadata = try XCTUnwrap(result.metadata)
+            switch attribute {
+            case .basic:
+                XCTAssertNotNil(metadata.primaryImage)
+                XCTAssertNil(metadata.otherImages)
+                XCTAssertNil(metadata.phone)
+                XCTAssertNil(metadata.website)
+                XCTAssertNil(metadata.reviewCount)
+                XCTAssertNil(metadata.averageRating)
+                XCTAssertNil(metadata.openHours)
+            case .photos:
+                XCTAssertNotNil(metadata.primaryImage)
+                XCTAssertNotNil(metadata.otherImages)
+                XCTAssertNil(metadata.phone)
+                XCTAssertNil(metadata.website)
+                XCTAssertNil(metadata.reviewCount)
+                XCTAssertNil(metadata.averageRating)
+                XCTAssertNil(metadata.openHours)
+            case .venue:
+                XCTAssertNotNil(metadata.primaryImage)
+                XCTAssertNil(metadata.otherImages)
+                XCTAssertNil(metadata.phone)
+                XCTAssertNil(metadata.website)
+                XCTAssertNil(metadata.reviewCount)
+                XCTAssertNil(metadata.averageRating)
+                XCTAssertNil(metadata.openHours)
+            case .visit:
+                XCTAssertNotNil(metadata.primaryImage)
+                XCTAssertNil(metadata.otherImages)
+                XCTAssertNotNil(metadata.phone)
+                XCTAssertNotNil(metadata.website)
+                XCTAssertNil(metadata.reviewCount)
+                XCTAssertNil(metadata.averageRating)
+                XCTAssertNotNil(metadata.openHours)
+            }
+        }
+
+        XCTAssertNil(delegate.error)
+    }
 }


### PR DESCRIPTION
### Description

- Add RetrieveOptions struct and typealias for CoreRetrieveOptions
- Add retrieveOptions parameter to retrieve() function calls (by way of SearchEngine.select() functions)
- Rewrite error messages
- Add CaseIterable to AttributeSet

### Checklist
- [x] Update `CHANGELOG`
