### PR TITLE
Correct archive errors introduced by swiftformat changes

### DIFF
--- a/Sources/MapboxSearch/InternalAPI/CoreSearchEngineStatics.swift
+++ b/Sources/MapboxSearch/InternalAPI/CoreSearchEngineStatics.swift
@@ -46,7 +46,7 @@ enum CoreSearchEngineStatics {
 
 enum ISOLanguages {
     static func contains(language: String) -> Bool {
-        var validLanguage: Bool = if #available(iOS 16, *) {
+        if #available(iOS 16, *) {
             Locale.LanguageCode.isoLanguageCodes
                 .map(\.identifier)
                 .contains(language)
@@ -54,6 +54,5 @@ enum ISOLanguages {
             Locale.isoLanguageCodes
                 .contains(language)
         }
-        return validLanguage
     }
 }

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Discover/Models/Discover+Result.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Discover/Models/Discover+Result.swift
@@ -28,7 +28,7 @@ extension Discover {
 
 extension Discover.Result {
     static func from(_ searchResult: SearchResult) -> Self {
-        var routablePointsArray: NonEmptyArray<RoutablePoint>? = if let routablePoints = searchResult.routablePoints,
+        let routablePointsArray: NonEmptyArray<RoutablePoint>? = if let routablePoints = searchResult.routablePoints,
                                                                     let first = searchResult.routablePoints?.first
         {
             .init(first: first, others: Array(routablePoints.dropFirst()))


### PR DESCRIPTION
### Description

- Fix errors when archiving MapboxSearch and MapboxSearchUI through Demo app for Generic/Any iOS Device caused by swiftformat changes
- Also occurred when archiving MapboxSearch and MapboxSearchUI through `make ios`

### Checklist
- [NA] Update `CHANGELOG`
