### PR TITLE
Change averageRating deprecation to a documentation comment

### DIFF
--- a/Sources/MapboxSearch/InternalAPI/CoreResultMetadataProtocol.swift
+++ b/Sources/MapboxSearch/InternalAPI/CoreResultMetadataProtocol.swift
@@ -18,8 +18,8 @@ protocol CoreResultMetadataProtocol {
     /** Long form detailed description for POI. */
     var description: String? { get }
 
-    /** The average rating of the location, on a scale from 1 to 5. */
-    @available(*, deprecated, renamed: "rating", message: "Please use the rating field for this value")
+    /** The average rating of the location, on a scale from 1 to 5.
+     **Deprecated**: Please use the ``rating`` field for this value. */
     var averageRating: NSNumber? { get }
 
     /** The average rating of the location, on a scale from 1 to 5. */

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchCategorySuggestionImpl.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchCategorySuggestionImpl.swift
@@ -49,8 +49,6 @@ class SearchCategorySuggestionImpl: SearchCategorySuggestion, CoreResponseProvid
         self.batchResolveSupported = coreResult.action?.multiRetrievable ?? false
         self.categories = coreResult.categories
         self.categoryIDs = coreResult.categoryIDs
-        NSLog("@@ categories is \(coreResult.categories)")
-        NSLog("@@ category IDs is \(coreResult.categoryIDs)")
 
         self.descriptionText = coreResult.addressDescription
         self.estimatedTime = coreResult.estimatedTime

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchResultMetadata.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchResultMetadata.swift
@@ -29,7 +29,7 @@ public struct SearchResultMetadata: Codable, Hashable {
     public var rating: Double?
 
     /// The average rating of the location, on a scale from 1 to 5.
-    @available(*, deprecated, renamed: "rating", message: "Please use the rating field for this value")
+    /// **Deprecated**: Please use the ``rating`` field for this value.
     public var averageRating: Double?
 
     /// Business opening hours


### PR DESCRIPTION
### Description

- Compiler flag to treat warnings as errors is active so we cannot make use of this without incurring an error

### Checklist
- [NA] Update `CHANGELOG`
