### PR TITLE
Fix docs for ServiceProvider customBaseURL

### DIFF
--- a/Sources/MapboxSearch/PublicAPI/ServiceProvider.swift
+++ b/Sources/MapboxSearch/PublicAPI/ServiceProvider.swift
@@ -41,7 +41,8 @@ public class ServiceProvider: ServiceProviderProtocol {
     /// Customize API host URL with a value from the Info.plist
     /// Also supports reading a process argument when in non-Release UITest builds
     /// Read-only property.
-    /// To change the customBaseURL for an engine programmatically, use the ``createEngine`` function.
+    /// To change the customBaseURL for an engine programmatically, use the
+    /// `ServiceProvider.createEngine(apiType:accessToken:locationProvider:customBaseURL:)` function.
     public static var customBaseURL: String? {
 #if !RELEASE
         if ProcessInfo.processInfo.arguments.contains(where: { $0 == "--uitesting" }) {


### PR DESCRIPTION
### Description

- Fully specify createEngine function in docs and remove public symbol because function is not marked public
- Fixes DocC project compatibility 

### Checklist
- [NA] Update `CHANGELOG`
