### PR TITLE
SSDK-1070: Change default tileset name to mbx-gen2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
+- [Offline] Change default tileset name to `mbx-gen2`
+
 ## 2.5.0-rc.3
 
 - [Core] Update dependencies

--- a/Search Documentation.docc/GettingStarted.md
+++ b/Search Documentation.docc/GettingStarted.md
@@ -56,7 +56,7 @@ extension LocationFinderController: SearchEngineDelegate {
 
 #### User choose location suggestion
 
-As soon as user will choose one of displayed suggestions, we have to pass it into ``SearchEngine/select(suggestion:)`` to fetch suggestion details.
+As soon as user will choose one of displayed suggestions, we have to pass it into ``SearchEngine/select(suggestion:options:)`` to fetch suggestion details.
 
 ```swift
 searchEngine.select(suggestion: userSelectedSuggestion)

--- a/Sources/MapboxSearch/PublicAPI/Offline/SearchOfflineManager.swift
+++ b/Sources/MapboxSearch/PublicAPI/Offline/SearchOfflineManager.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// OfflineManager handles `TileStore`s and responsible for creating Search `TilsetDescriptor`s
 public class SearchOfflineManager {
-    static let defaultDatasetName = "mbx-main"
+    static let defaultDatasetName = "mbx-gen2"
 
     var engine: CoreSearchEngineProtocol
 

--- a/Tests/MapboxSearchIntegrationTests/OfflineIntegrationTests.swift
+++ b/Tests/MapboxSearchIntegrationTests/OfflineIntegrationTests.swift
@@ -125,7 +125,7 @@ class OfflineIntegrationTests: MockServerIntegrationTestCase<SBSMockResponse> {
 
         // Perform the offline fetch
         let spanishTileset = SearchOfflineManager.createTilesetDescriptor(
-            dataset: "mbx-main",
+            dataset: "mbx-gen2",
             language: "es"
         )
         let loadDataExpectation = expectation(description: "Load Data")


### PR DESCRIPTION
### Description
Fixes SSDK-1070

- Required with the current CoreSearch version.
- Bonus: fix a docs typo.

### Checklist
- [x] Update `CHANGELOG`
