### PR TITLE
Add unit test for using UserRecord to add developer-defined results

### DIFF
--- a/MapboxSearch.xcodeproj/project.pbxproj
+++ b/MapboxSearch.xcodeproj/project.pbxproj
@@ -45,6 +45,8 @@
 		0488234A2B6B0A9E00C770AA /* category-hotel-search-along-route-jp.json in Resources */ = {isa = PBXBuildFile; fileRef = 04AB0B7C2B6B043C00FDE7D5 /* category-hotel-search-along-route-jp.json */; };
 		04970F8D2B7A97C900213763 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 04970F8C2B7A97C900213763 /* PrivacyInfo.xcprivacy */; };
 		049FE3A82C6A50BB00F54FB2 /* RetrieveOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 049FE3A72C6A50BB00F54FB2 /* RetrieveOptions.swift */; };
+		04A972C92C92431100C5F1A8 /* DataLayerProviderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEEDD38C2508E24900DC0A98 /* DataLayerProviderStub.swift */; };
+		04A972CC2C938B8800C5F1A8 /* UserRecordsLayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04A972C62C923C5300C5F1A8 /* UserRecordsLayerTests.swift */; };
 		04AB0B4B2B6AADB700FDE7D5 /* mapbox.places.san.francisco.json in Resources */ = {isa = PBXBuildFile; fileRef = 04AB0B4A2B6AADB700FDE7D5 /* mapbox.places.san.francisco.json */; };
 		04AB0B4C2B6AADB700FDE7D5 /* mapbox.places.san.francisco.json in Resources */ = {isa = PBXBuildFile; fileRef = 04AB0B4A2B6AADB700FDE7D5 /* mapbox.places.san.francisco.json */; };
 		04AB0B4D2B6AADB700FDE7D5 /* mapbox.places.san.francisco.json in Resources */ = {isa = PBXBuildFile; fileRef = 04AB0B4A2B6AADB700FDE7D5 /* mapbox.places.san.francisco.json */; };
@@ -561,6 +563,7 @@
 		0484BCDE2BC4865C003CF408 /* OfflineIndexObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineIndexObserver.swift; sourceTree = "<group>"; };
 		04970F8C2B7A97C900213763 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		049FE3A72C6A50BB00F54FB2 /* RetrieveOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrieveOptions.swift; sourceTree = "<group>"; };
+		04A972C62C923C5300C5F1A8 /* UserRecordsLayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRecordsLayerTests.swift; sourceTree = "<group>"; };
 		04AB0B4A2B6AADB700FDE7D5 /* mapbox.places.san.francisco.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = mapbox.places.san.francisco.json; sourceTree = "<group>"; };
 		04AB0B792B6AF37800FDE7D5 /* DiscoverIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverIntegrationTests.swift; sourceTree = "<group>"; };
 		04AB0B7C2B6B043C00FDE7D5 /* category-hotel-search-along-route-jp.json */ = {isa = PBXFileReference; explicitFileType = text.json; path = "category-hotel-search-along-route-jp.json"; sourceTree = "<group>"; };
@@ -1222,6 +1225,7 @@
 		141789EF287C30260000AE79 /* Legacy */ = {
 			isa = PBXGroup;
 			children = (
+				04A972C62C923C5300C5F1A8 /* UserRecordsLayerTests.swift */,
 				FE66C65625E3F42E006A74FC /* ValidateResources.swift */,
 				FE1122B82567BE5B0064FD53 /* ArrayExtensionsTests.swift */,
 				FEEDD3972508E24900DC0A98 /* BoundingBoxTests.swift */,
@@ -2750,6 +2754,7 @@
 				2CD6C03C29F1982100D865D1 /* EventsManagerTests.swift in Sources */,
 				FEEDD3AB2508E24900DC0A98 /* BoundingBoxTests.swift in Sources */,
 				FE5A41EC2551694600A076BF /* SearchResultTests.swift in Sources */,
+				04A972CC2C938B8800C5F1A8 /* UserRecordsLayerTests.swift in Sources */,
 				FEEDD39D2508E24900DC0A98 /* ServiceProviderStub.swift in Sources */,
 				FE1F31DC2567FA6D004DCB6D /* WrapperLocationProviderTests.swift in Sources */,
 				FE5E0BC82576867F002260C9 /* BoundingBox+Samples.swift in Sources */,
@@ -2868,6 +2873,7 @@
 				F9C557C02670CD5E00BE8B94 /* Address+Samples.swift in Sources */,
 				F914EE652743E4F400D4F173 /* CoreAliases.swift in Sources */,
 				046818DF2B87FDC00082B188 /* SearchBox_SearchEngineIntegrationTests.swift in Sources */,
+				04A972C92C92431100C5F1A8 /* DataLayerProviderStub.swift in Sources */,
 				F9C557B42670CB4000BE8B94 /* SearchEngineIntegrationTests.swift in Sources */,
 				046818D42B87F2A70082B188 /* SearchBox_CategorySearchEngineIntegrationTests.swift in Sources */,
 				F9274FF5273AA79700708F37 /* OfflineIntegrationTests.swift in Sources */,

--- a/MapboxSearch.xcodeproj/project.pbxproj
+++ b/MapboxSearch.xcodeproj/project.pbxproj
@@ -45,7 +45,6 @@
 		0488234A2B6B0A9E00C770AA /* category-hotel-search-along-route-jp.json in Resources */ = {isa = PBXBuildFile; fileRef = 04AB0B7C2B6B043C00FDE7D5 /* category-hotel-search-along-route-jp.json */; };
 		04970F8D2B7A97C900213763 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 04970F8C2B7A97C900213763 /* PrivacyInfo.xcprivacy */; };
 		049FE3A82C6A50BB00F54FB2 /* RetrieveOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 049FE3A72C6A50BB00F54FB2 /* RetrieveOptions.swift */; };
-		04A972C92C92431100C5F1A8 /* DataLayerProviderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEEDD38C2508E24900DC0A98 /* DataLayerProviderStub.swift */; };
 		04A972CC2C938B8800C5F1A8 /* UserRecordsLayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04A972C62C923C5300C5F1A8 /* UserRecordsLayerTests.swift */; };
 		04AB0B4B2B6AADB700FDE7D5 /* mapbox.places.san.francisco.json in Resources */ = {isa = PBXBuildFile; fileRef = 04AB0B4A2B6AADB700FDE7D5 /* mapbox.places.san.francisco.json */; };
 		04AB0B4C2B6AADB700FDE7D5 /* mapbox.places.san.francisco.json in Resources */ = {isa = PBXBuildFile; fileRef = 04AB0B4A2B6AADB700FDE7D5 /* mapbox.places.san.francisco.json */; };
@@ -2873,7 +2872,6 @@
 				F9C557C02670CD5E00BE8B94 /* Address+Samples.swift in Sources */,
 				F914EE652743E4F400D4F173 /* CoreAliases.swift in Sources */,
 				046818DF2B87FDC00082B188 /* SearchBox_SearchEngineIntegrationTests.swift in Sources */,
-				04A972C92C92431100C5F1A8 /* DataLayerProviderStub.swift in Sources */,
 				F9C557B42670CB4000BE8B94 /* SearchEngineIntegrationTests.swift in Sources */,
 				046818D42B87F2A70082B188 /* SearchBox_CategorySearchEngineIntegrationTests.swift in Sources */,
 				F9274FF5273AA79700708F37 /* OfflineIntegrationTests.swift in Sources */,

--- a/Sources/MapboxSearch/PublicAPI/Common/Models/Result Types/SearchAddressType.swift
+++ b/Sources/MapboxSearch/PublicAPI/Common/Models/Result Types/SearchAddressType.swift
@@ -82,4 +82,29 @@ public enum SearchAddressType: String, Hashable, Codable {
             return nil
         }
     }
+
+    func toCore() -> CoreResultType {
+        return switch self {
+        case .address:
+            .address
+        case .place:
+            .place
+        case .street:
+            .street
+        case .postcode:
+            .postcode
+        case .country:
+            .country
+        case .region:
+            .region
+        case .district:
+            .district
+        case .locality:
+            .locality
+        case .neighborhood:
+            .neighborhood
+        case .block:
+            .block
+        }
+    }
 }

--- a/Sources/MapboxSearch/PublicAPI/FavoriteRecord.swift
+++ b/Sources/MapboxSearch/PublicAPI/FavoriteRecord.swift
@@ -51,6 +51,10 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
     /// Maki icon name. Use ``icon`` when possible.
     public var iconName: String?
 
+    public var makiIcon: String? {
+        icon?.name
+    }
+
     /// Result categories types.
     public var categories: [String]?
 

--- a/Sources/MapboxSearch/PublicAPI/HistoryRecord.swift
+++ b/Sources/MapboxSearch/PublicAPI/HistoryRecord.swift
@@ -5,6 +5,8 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
     /// "history icon" by default
     public var iconName: String? = "history icon"
 
+    public var makiIcon: String? { iconName }
+
     /// Type of stored history record
     public enum HistoryType: Int, Codable {
         /// History record was build based on search result

--- a/Sources/MapboxSearch/PublicAPI/IndexableRecord.swift
+++ b/Sources/MapboxSearch/PublicAPI/IndexableRecord.swift
@@ -2,17 +2,39 @@ import CoreLocation
 
 /// Defines data for index to represent external data to be included in search functionality
 public protocol IndexableRecord {
-    /// Record unique identifier
+    // MARK: Required Fields
+
+    /// Record unique identifier.
     var id: String { get }
 
-    /// Record name
+    /// Record name.
     var name: String { get }
 
-    /// Record coordinates
+    /// Record coordinates.
     var coordinate: CLLocationCoordinate2D { get }
 
-    /// Record address
+    /// Type of the search result represented by the record.
+    var type: SearchResultType { get }
+
+    // MARK: Optional Fields
+
+    /// Additional description for this record.
+    var descriptionText: String? { get }
+
+    /// Record address.
     var address: Address? { get }
+
+    /// List of points near `coordinate`, that represent entries to the associated building.
+    var routablePoints: [RoutablePoint]? { get }
+
+    /// Record categories.
+    var categories: [String]? { get }
+
+    /// Mapbox Maki icon ID.
+    var makiIcon: String? { get }
+
+    /// Search result metadata containing this place's detailed information if available.
+    var metadata: SearchResultMetadata? { get }
 
     /// Additional string literals that should be included in object index. For example, you may provide non-official
     /// names to force `SearchEngine` match them.
@@ -26,13 +48,22 @@ extension IndexableRecord {
             .compactMap { $0 }
             .forEach { tokens.insert($0) }
 
+        /// Fallback value for a nil result type is CoreResultType.unknown
+        let coreType: CoreResultType? = switch type {
+        case .POI:
+            CoreResultType.poi
+        case .address(let subtypes):
+            subtypes.first?.toCore()
+        }
+
         return CoreUserRecord(
             id: id,
             name: name,
             center: Coordinate2D(value: coordinate),
             address: address?.coreAddress(),
             categories: nil,
-            indexTokens: Array(tokens)
+            indexTokens: Array(tokens),
+            from: coreType ?? .unknown
         )
     }
 }

--- a/Tests/MapboxSearchIntegrationTests/OfflineIntegrationTests.swift
+++ b/Tests/MapboxSearchIntegrationTests/OfflineIntegrationTests.swift
@@ -21,7 +21,7 @@ class OfflineIntegrationTests: MockServerIntegrationTestCase<SBSMockResponse> {
 
         searchEngine.delegate = delegate
 
-        let enableOfflineExpectation = expectation(description: "TileStore setup completion")
+        let enableOfflineExpectation = expectation(description: "Offline mode enabled")
         searchEngine.setOfflineMode(.enabled) {
             enableOfflineExpectation.fulfill()
         }

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/IndexableRecordStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/IndexableRecordStub.swift
@@ -16,6 +16,12 @@ struct IndexableRecordStub: IndexableRecord {
     var coordinateCodable: CLLocationCoordinate2DCodable
     var address: Address?
     var additionalTokens: Set<String>?
+    var descriptionText: String?
+    var routablePoints: [RoutablePoint]?
+    var categories: [String]?
+    var makiIcon: String?
+    var metadata: SearchResultMetadata?
+    var type: SearchResultType
 
     var asResolved: SearchResult {
         SearchResultStub(
@@ -39,13 +45,15 @@ struct IndexableRecordStub: IndexableRecord {
         name: String,
         coordinate: CLLocationCoordinate2DCodable,
         address: Address? = nil,
-        additionalTokens: Set<String>? = nil
+        additionalTokens: Set<String>? = nil,
+        type: SearchResultType = .POI
     ) {
         self.id = id
         self.name = name
         self.coordinateCodable = coordinate
         self.address = address
         self.additionalTokens = additionalTokens
+        self.type = type
     }
 
     init() {

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/TestDataProviderRecord.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/TestDataProviderRecord.swift
@@ -20,6 +20,7 @@ struct TestDataProviderRecord: IndexableRecord, SearchResult {
     var metadata: SearchResultMetadata?
     var descriptionText: String?
     var searchRequest: SearchRequestOptions = .init(query: "Sample", proximity: nil)
+    var makiIcon: String? { iconName }
 
     static func testData(count: Int) -> [TestDataProviderRecord] {
         var results = [TestDataProviderRecord]()

--- a/Tests/MapboxSearchTests/Legacy/UserRecordsLayerTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/UserRecordsLayerTests.swift
@@ -5,6 +5,9 @@ final class SearchBox_UserRecordsLayerTests: XCTestCase {
     let delegate = SearchEngineDelegateStub()
     var searchEngine: SearchEngine!
 
+    let dcLocation = CLLocationCoordinate2D(latitude: 38.89992081005698, longitude: -77.03399849939174)
+    let regionId = "dc"
+
     override func setUpWithError() throws {
         try super.setUpWithError()
 
@@ -17,9 +20,12 @@ final class SearchBox_UserRecordsLayerTests: XCTestCase {
     }
 
     /// Set the ignoreUR flag to FALSE to opt-in to to user records layer
-    var searchOptionsWithUserRecords: SearchOptions = .init(ignoreIndexableRecords: false)
+    var searchOptionsWithUserRecords: SearchOptions = .init(
+        ignoreIndexableRecords: false,
+        indexableRecordsDistanceThreshold: nil
+    )
 
-    func testWritingUserRecordsLayer() throws {
+    func testWritingUserRecordsLayer_Online() throws {
         let mockRecordProvider = DataLayerProviderStub(records: [])
 
         let recordsInteractor = try searchEngine.register(dataProvider: mockRecordProvider, priority: 1)
@@ -33,7 +39,7 @@ final class SearchBox_UserRecordsLayerTests: XCTestCase {
 
         XCTAssertNotNil(recordsInteractor)
 
-        recordsInteractor.update(record: IndexableRecordStub.sample1)
+        recordsInteractor.update(record: IndexableRecordStub.sample1_online)
 
         let secondUpdateExpectation = delegate.updateExpectation
         searchEngine.search(query: "obelisk")
@@ -42,10 +48,105 @@ final class SearchBox_UserRecordsLayerTests: XCTestCase {
         let nameResultsAfterAddingUserRecord = searchEngine.suggestions.map(\.name)
         XCTAssertTrue(nameResultsAfterAddingUserRecord.contains(where: { $0 == "Washington Monument" }))
     }
+
+    func testWritingUserRecordsLayer_Offline() throws {
+        let mockRecordProvider = DataLayerProviderStub(records: [])
+
+        let recordsInteractor = try searchEngine.register(dataProvider: mockRecordProvider, priority: 1)
+
+        // Set up Offline
+        let enableOfflineExpectation = expectation(description: "TileStore setup completion")
+        searchEngine.setOfflineMode(.enabled) {
+            enableOfflineExpectation.fulfill()
+        }
+        wait(for: [enableOfflineExpectation], timeout: 10)
+
+        // TestTileStore builds tileStores with unique path allowing runs tests in parallel
+        let tileStore = TestTileStore.build()
+        let setTileStoreExpectation = expectation(description: "TileStore setup completion")
+        searchEngine.offlineManager.setTileStore(tileStore) {
+            setTileStoreExpectation.fulfill()
+        }
+        wait(for: [setTileStoreExpectation], timeout: 10)
+
+        // Set up index observer before the fetch starts to validate changes after it completes
+        let indexChangedExpectation = expectation(description: "Received offline index changed event")
+        let offlineIndexObserver = OfflineIndexObserver(onIndexChangedBlock: { changeEvent in
+            _Logger.searchSDK.info("Index changed: \(changeEvent)")
+            indexChangedExpectation.fulfill()
+        }, onErrorBlock: { error in
+            _Logger.searchSDK.error("Encountered error in OfflineIndexObserver \(error)")
+            XCTFail(error.debugDescription)
+        })
+        searchEngine.offlineManager.engine.addOfflineIndexObserver(for: offlineIndexObserver)
+
+        // Perform the offline fetch
+        let loadDataExpectation = expectation(description: "Load Data")
+        _ = loadData { result in
+            switch result {
+            case .success(let region):
+                XCTAssert(region.id == self.regionId)
+                XCTAssert(region.completedResourceCount > 0)
+                XCTAssertEqual(region.requiredResourceCount, region.completedResourceCount)
+            case .failure(let error):
+                XCTFail("Unable to load Region, \(error.localizedDescription)")
+            }
+            loadDataExpectation.fulfill()
+        }
+        wait(
+            for: [loadDataExpectation, indexChangedExpectation],
+            timeout: 200,
+            enforceOrder: true
+        )
+
+        // Perform the first search without any user records
+        let updateExpectation = delegate.offlineUpdateExpectation
+        searchEngine.search(query: "user record location")
+        wait(for: [updateExpectation], timeout: 300)
+        XCTAssertFalse(searchEngine.suggestions.isEmpty)
+        let nameResultsBeforeUserRecord = searchEngine.suggestions.map { ($0.name, $0.distance) }
+        XCTAssertFalse(nameResultsBeforeUserRecord.contains(where: { $0.0 == "User Record Location" }))
+
+        XCTAssertNotNil(recordsInteractor)
+
+        recordsInteractor.update(record: IndexableRecordStub.sample2_offline)
+
+        let secondUpdateExpectation = delegate.updateExpectation
+        searchEngine.search(query: "user record location")
+        wait(for: [secondUpdateExpectation], timeout: 10)
+        XCTAssertFalse(searchEngine.suggestions.isEmpty)
+        let nameResultsAfterAddingUserRecord = searchEngine.suggestions.map { ($0.name, $0.distance) }
+        XCTAssertTrue(nameResultsAfterAddingUserRecord.contains(where: { $0.0 == "User Record Location" }))
+    }
+
+    // MARK: Helpers
+
+    private func loadData(
+        tilesetDescriptor: TilesetDescriptor? = nil,
+        completion: @escaping (Result<MapboxCommon.TileRegion, MapboxSearch.TileRegionError>) -> Void
+    )
+    -> SearchCancelable {
+        /// A nil tilesetDescriptor parameter will fallback to the default dataset defined at
+        /// ``SearchOfflineManager.defaultDatasetName``
+        let descriptor = tilesetDescriptor ?? SearchOfflineManager.createDefaultTilesetDescriptor()
+
+        let dcLocationValue = NSValue(mkCoordinate: dcLocation)
+        let options = MapboxCommon.TileRegionLoadOptions.build(
+            geometry: Geometry(point: dcLocationValue),
+            descriptors: [descriptor],
+            acceptExpired: true
+        )!
+
+        let cancelable = searchEngine.offlineManager.tileStore.loadTileRegion(id: regionId, options: options) { _ in
+        } completion: { result in
+            completion(result)
+        }
+        return cancelable
+    }
 }
 
 extension IndexableRecordStub {
-    static var sample1 = IndexableRecordStub(
+    static var sample1_online = IndexableRecordStub(
         id: "1234",
         name: "Washington Monument",
         coordinate: CLLocationCoordinate2DCodable(latitude: 38.889462, longitude: -77.03524),
@@ -63,6 +164,27 @@ extension IndexableRecordStub {
             searchAddressCountry: nil // skipped for brevity
         ),
         additionalTokens: ["Monument", "Obelisk"],
+        type: .POI
+    )
+
+    static var sample2_offline = IndexableRecordStub(
+        id: "1234",
+        name: "User Record POI",
+        coordinate: CLLocationCoordinate2DCodable(latitude: 38.889462, longitude: -77.03524),
+        address: Address(
+            houseNumber: "2",
+            street: "15th St NW",
+            neighborhood: "National Mall",
+            locality: nil,
+            postcode: "20024",
+            place: "Washington",
+            district: nil,
+            region: "District of Columbia",
+            searchAddressRegion: nil, // skipped for brevity
+            country: "US",
+            searchAddressCountry: nil // skipped for brevity
+        ),
+        additionalTokens: ["User Record Location"],
         type: .POI
     )
 }

--- a/Tests/MapboxSearchTests/Legacy/UserRecordsLayerTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/UserRecordsLayerTests.swift
@@ -103,20 +103,23 @@ final class SearchBox_UserRecordsLayerTests: XCTestCase {
         let updateExpectation = delegate.offlineUpdateExpectation
         searchEngine.search(query: "user record location")
         wait(for: [updateExpectation], timeout: 300)
-        XCTAssertFalse(searchEngine.suggestions.isEmpty)
+        XCTAssertTrue(searchEngine.suggestions.isEmpty)
+        XCTAssertTrue(delegate.resolvedResults.isEmpty)
         let nameResultsBeforeUserRecord = searchEngine.suggestions.map { ($0.name, $0.distance) }
         XCTAssertFalse(nameResultsBeforeUserRecord.contains(where: { $0.0 == "User Record Location" }))
 
         XCTAssertNotNil(recordsInteractor)
-
         recordsInteractor.update(record: IndexableRecordStub.sample2_offline)
 
-        let secondUpdateExpectation = delegate.updateExpectation
-        searchEngine.search(query: "user record location")
-        wait(for: [secondUpdateExpectation], timeout: 10)
+        let secondUpdateExpectation = delegate.offlineUpdateExpectation
+        searchEngine.search(query: "user record poi")
+        wait(for: [secondUpdateExpectation], timeout: 600)
         XCTAssertFalse(searchEngine.suggestions.isEmpty)
         let nameResultsAfterAddingUserRecord = searchEngine.suggestions.map { ($0.name, $0.distance) }
-        XCTAssertTrue(nameResultsAfterAddingUserRecord.contains(where: { $0.0 == "User Record Location" }))
+        XCTAssertTrue(
+            nameResultsAfterAddingUserRecord
+                .contains(where: { $0.0 == IndexableRecordStub.sample2_offline.name })
+        )
     }
 
     // MARK: Helpers

--- a/Tests/MapboxSearchTests/Legacy/UserRecordsLayerTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/UserRecordsLayerTests.swift
@@ -1,0 +1,68 @@
+@testable import MapboxSearch
+import XCTest
+
+final class SearchBox_UserRecordsLayerTests: XCTestCase {
+    let delegate = SearchEngineDelegateStub()
+    var searchEngine: SearchEngine!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        searchEngine = SearchEngine(
+            locationProvider: DefaultLocationProvider(),
+            defaultSearchOptions: searchOptionsWithUserRecords
+        )
+
+        searchEngine.delegate = delegate
+    }
+
+    /// Set the ignoreUR flag to FALSE to opt-in to to user records layer
+    var searchOptionsWithUserRecords: SearchOptions = .init(ignoreIndexableRecords: false)
+
+    func testWritingUserRecordsLayer() throws {
+        let mockRecordProvider = DataLayerProviderStub(records: [])
+
+        let recordsInteractor = try searchEngine.register(dataProvider: mockRecordProvider, priority: 1)
+
+        let updateExpectation = delegate.updateExpectation
+        searchEngine.search(query: "obelisk")
+        wait(for: [updateExpectation], timeout: 10)
+        XCTAssertFalse(searchEngine.suggestions.isEmpty)
+        let nameResultsBeforeUserRecord = searchEngine.suggestions.map(\.name)
+        XCTAssertFalse(nameResultsBeforeUserRecord.contains(where: { $0 == "Washington Monument" }))
+
+        XCTAssertNotNil(recordsInteractor)
+
+        recordsInteractor.update(record: IndexableRecordStub.sample1)
+
+        let secondUpdateExpectation = delegate.updateExpectation
+        searchEngine.search(query: "obelisk")
+        wait(for: [secondUpdateExpectation], timeout: 10)
+        XCTAssertFalse(searchEngine.suggestions.isEmpty)
+        let nameResultsAfterAddingUserRecord = searchEngine.suggestions.map(\.name)
+        XCTAssertTrue(nameResultsAfterAddingUserRecord.contains(where: { $0 == "Washington Monument" }))
+    }
+}
+
+extension IndexableRecordStub {
+    static var sample1 = IndexableRecordStub(
+        id: "1234",
+        name: "Washington Monument",
+        coordinate: CLLocationCoordinate2DCodable(latitude: 38.889462, longitude: -77.03524),
+        address: Address(
+            houseNumber: "2",
+            street: "15th St NW",
+            neighborhood: "National Mall",
+            locality: nil,
+            postcode: "20024",
+            place: "Washington",
+            district: nil,
+            region: "District of Columbia",
+            searchAddressRegion: nil, // skipped for brevity
+            country: "US",
+            searchAddressCountry: nil // skipped for brevity
+        ),
+        additionalTokens: ["Monument", "Obelisk"],
+        type: .POI
+    )
+}


### PR DESCRIPTION
### Description
Fixes SSDK-1083

- such as an alias for the Washington Monument = Obelisk
- User Records are provided by your own development integration either dynamically by an end-user or provided from your development (such as adding your own custom locations statically for all end-users).
- Initialize `SearchOptions(ignoreIndexableRecords: Bool, indexableRecordsDistanceThreshold: CLLocationDistance?)` and provide this to your SearchEngine or search function to opt-in to user records search

### Checklist
- [x] Update `CHANGELOG`
