### PR TITLE
Add brand nested search to UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
+- [Search] Add SearchSuggestType.brand
+- [SearchUI] Add display of Brand results
+- [SearchUI] Add ability to view nested results for a Brand (similar to Category results) when the query matches a brand name
 - [Offline] Change default tileset name to `mbx-gen2`
 - [Core] Update dependencies
 

--- a/MapboxSearch.xcodeproj/project.pbxproj
+++ b/MapboxSearch.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		043A3D4D2B30F38300DB681B /* CoreAddress+AddressComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043A3D4C2B30F38300DB681B /* CoreAddress+AddressComponents.swift */; };
 		044A6B732BA8933200A9F2A2 /* PreviewCategoriesFavoritesSegmentControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 044A6B722BA8933200A9F2A2 /* PreviewCategoriesFavoritesSegmentControl.swift */; };
 		0454FB942CA4AFEA00B1AFEA /* SearchBrandSuggestionImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0454FB932CA4AFEA00B1AFEA /* SearchBrandSuggestionImpl.swift */; };
+		0454FB962CA4B64D00B1AFEA /* BrandSuggestionsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0454FB952CA4B64D00B1AFEA /* BrandSuggestionsController.swift */; };
+		0454FB9A2CA4B86C00B1AFEA /* BrandSuggestionsController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0454FB972CA4B80300B1AFEA /* BrandSuggestionsController.xib */; };
 		045514C22B7D4B58000D88B9 /* CoreApiType+ToSDKType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045514C12B7D4B58000D88B9 /* CoreApiType+ToSDKType.swift */; };
 		045514C32B7D4B58000D88B9 /* CoreApiType+ToSDKType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045514C12B7D4B58000D88B9 /* CoreApiType+ToSDKType.swift */; };
 		045514C42B7D4B58000D88B9 /* CoreApiType+ToSDKType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045514C12B7D4B58000D88B9 /* CoreApiType+ToSDKType.swift */; };
@@ -553,6 +555,8 @@
 		043A3D4C2B30F38300DB681B /* CoreAddress+AddressComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CoreAddress+AddressComponents.swift"; sourceTree = "<group>"; };
 		044A6B722BA8933200A9F2A2 /* PreviewCategoriesFavoritesSegmentControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewCategoriesFavoritesSegmentControl.swift; sourceTree = "<group>"; };
 		0454FB932CA4AFEA00B1AFEA /* SearchBrandSuggestionImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBrandSuggestionImpl.swift; sourceTree = "<group>"; };
+		0454FB952CA4B64D00B1AFEA /* BrandSuggestionsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrandSuggestionsController.swift; sourceTree = "<group>"; };
+		0454FB972CA4B80300B1AFEA /* BrandSuggestionsController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = BrandSuggestionsController.xib; sourceTree = "<group>"; };
 		045514C12B7D4B58000D88B9 /* CoreApiType+ToSDKType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CoreApiType+ToSDKType.swift"; sourceTree = "<group>"; };
 		046818D32B87F2A70082B188 /* SearchBox_CategorySearchEngineIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBox_CategorySearchEngineIntegrationTests.swift; sourceTree = "<group>"; };
 		046818DA2B87FAB20082B188 /* search-box-category.json */ = {isa = PBXFileReference; explicitFileType = text.json; path = "search-box-category.json"; sourceTree = "<group>"; };
@@ -1897,6 +1901,8 @@
 				FE4F260525F8E8B700454BC5 /* AddToFavoritesCell.swift */,
 				FEEDD3472508E02700DC0A98 /* AddToFavoritesCell.xib */,
 				FEEDD3352508E02700DC0A98 /* Assets.xcassets */,
+				0454FB952CA4B64D00B1AFEA /* BrandSuggestionsController.swift */,
+				0454FB972CA4B80300B1AFEA /* BrandSuggestionsController.xib */,
 				FEEDD3412508E02700DC0A98 /* CategoriesFavoritesSegmentControl.swift */,
 				044A6B722BA8933200A9F2A2 /* PreviewCategoriesFavoritesSegmentControl.swift */,
 				FEEDD34C2508E02700DC0A98 /* CategoriesFavoritesSegmentControl.xib */,
@@ -2408,6 +2414,7 @@
 				FEBB7ADF2508F16100B331C3 /* HotCategoryButton.xib in Resources */,
 				FEBB7AE72508F16100B331C3 /* SearchTextField.xib in Resources */,
 				FEBB7AE82508F16100B331C3 /* UserFavoriteCell.xib in Resources */,
+				0454FB9A2CA4B86C00B1AFEA /* BrandSuggestionsController.xib in Resources */,
 				FE049928261B650100E575A2 /* Localizable.strings in Resources */,
 				FEBB7AE42508F16100B331C3 /* SearchErrorView.xib in Resources */,
 				FEBB7AE92508F19100B331C3 /* Assets.xcassets in Resources */,
@@ -2927,6 +2934,7 @@
 			files = (
 				FEEDD36C2508E02700DC0A98 /* FavoritesTableViewSource.swift in Sources */,
 				F9CFCE1B2743E65C00072027 /* Array+Extensions.swift in Sources */,
+				0454FB962CA4B64D00B1AFEA /* BrandSuggestionsController.swift in Sources */,
 				FEEDD3532508E02700DC0A98 /* Strings.swift in Sources */,
 				FEEDD3762508E02700DC0A98 /* SearchSuggestionsTableSource.swift in Sources */,
 				FEEDD35D2508E02700DC0A98 /* FavoriteDetailsController.swift in Sources */,

--- a/MapboxSearch.xcodeproj/project.pbxproj
+++ b/MapboxSearch.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		04340D202C6BD06500B4F242 /* ResultChildMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04340D1F2C6BD06500B4F242 /* ResultChildMetadata.swift */; };
 		043A3D4D2B30F38300DB681B /* CoreAddress+AddressComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043A3D4C2B30F38300DB681B /* CoreAddress+AddressComponents.swift */; };
 		044A6B732BA8933200A9F2A2 /* PreviewCategoriesFavoritesSegmentControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 044A6B722BA8933200A9F2A2 /* PreviewCategoriesFavoritesSegmentControl.swift */; };
+		0454FB942CA4AFEA00B1AFEA /* SearchBrandSuggestionImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0454FB932CA4AFEA00B1AFEA /* SearchBrandSuggestionImpl.swift */; };
 		045514C22B7D4B58000D88B9 /* CoreApiType+ToSDKType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045514C12B7D4B58000D88B9 /* CoreApiType+ToSDKType.swift */; };
 		045514C32B7D4B58000D88B9 /* CoreApiType+ToSDKType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045514C12B7D4B58000D88B9 /* CoreApiType+ToSDKType.swift */; };
 		045514C42B7D4B58000D88B9 /* CoreApiType+ToSDKType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045514C12B7D4B58000D88B9 /* CoreApiType+ToSDKType.swift */; };
@@ -551,6 +552,7 @@
 		04340D1F2C6BD06500B4F242 /* ResultChildMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultChildMetadata.swift; sourceTree = "<group>"; };
 		043A3D4C2B30F38300DB681B /* CoreAddress+AddressComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CoreAddress+AddressComponents.swift"; sourceTree = "<group>"; };
 		044A6B722BA8933200A9F2A2 /* PreviewCategoriesFavoritesSegmentControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewCategoriesFavoritesSegmentControl.swift; sourceTree = "<group>"; };
+		0454FB932CA4AFEA00B1AFEA /* SearchBrandSuggestionImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBrandSuggestionImpl.swift; sourceTree = "<group>"; };
 		045514C12B7D4B58000D88B9 /* CoreApiType+ToSDKType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CoreApiType+ToSDKType.swift"; sourceTree = "<group>"; };
 		046818D32B87F2A70082B188 /* SearchBox_CategorySearchEngineIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBox_CategorySearchEngineIntegrationTests.swift; sourceTree = "<group>"; };
 		046818DA2B87FAB20082B188 /* search-box-category.json */ = {isa = PBXFileReference; explicitFileType = text.json; path = "search-box-category.json"; sourceTree = "<group>"; };
@@ -1880,6 +1882,7 @@
 				FEEDD2E72508DFE400DC0A98 /* SearchSuggestion.swift */,
 				FEEDD2E82508DFE400DC0A98 /* ServerSearchResult.swift */,
 				04340D1F2C6BD06500B4F242 /* ResultChildMetadata.swift */,
+				0454FB932CA4AFEA00B1AFEA /* SearchBrandSuggestionImpl.swift */,
 			);
 			path = "Search Results";
 			sourceTree = "<group>";
@@ -2689,6 +2692,7 @@
 				140D1BDC286DB479001A51C2 /* SearchResultAccuracy.swift in Sources */,
 				141789E7287C05060000AE79 /* AddressAutofill.Suggestion+SearchResult.swift in Sources */,
 				1488F78329A7AD5800CF373B /* CoreUserActivityReporter.swift in Sources */,
+				0454FB942CA4AFEA00B1AFEA /* SearchBrandSuggestionImpl.swift in Sources */,
 				144F32F5298D21E70082B2D5 /* AddressComponents.swift in Sources */,
 				FEEDD3122508DFE400DC0A98 /* SearchResultSuggestion.swift in Sources */,
 				148DE671285777180085684D /* NSLocking+Extensions.swift in Sources */,

--- a/Sources/MapboxSearch/InternalAPI/SearchResponse.swift
+++ b/Sources/MapboxSearch/InternalAPI/SearchResponse.swift
@@ -42,6 +42,9 @@ extension SearchResponse {
             case [.userRecord]:
                 suggestion = ExternalRecordPlaceholder(coreResult: coreResult, response: coreResponse)
 
+            case [.brand]:
+                suggestion = SearchBrandSuggestionImpl(coreResult: coreResult, response: coreResponse)
+
             case _ where coreResult.resultTypes.contains(.unknown):
                 suggestion = nil
 

--- a/Sources/MapboxSearch/PublicAPI/Engine/SearchEngine.swift
+++ b/Sources/MapboxSearch/PublicAPI/Engine/SearchEngine.swift
@@ -163,12 +163,15 @@ public class SearchEngine: AbstractSearchEngine {
     private enum Query: ExpressibleByStringLiteral {
         case string(String)
         case category(String)
+        case brand(String)
 
         var stringQuery: String? {
             switch self {
             case .string(let query):
                 return query
             case .category:
+                return nil
+            case .brand:
                 return nil
             }
         }
@@ -275,6 +278,11 @@ public class SearchEngine: AbstractSearchEngine {
             }
         case .category:
             // CoreSDK currently doesn't support arguments for category suggestions
+            if !coreResponse.request.query.isEmpty {
+                return nil
+            }
+        case .brand:
+            // CoreSDK currently doesn't support arguments for brand suggestions
             if !coreResponse.request.query.isEmpty {
                 return nil
             }

--- a/Sources/MapboxSearch/PublicAPI/Engine/SearchEngine.swift
+++ b/Sources/MapboxSearch/PublicAPI/Engine/SearchEngine.swift
@@ -390,8 +390,9 @@ extension SearchEngine {
         userActivityReporter.reportActivity(forComponent: "search-engine-forward-geocoding-selection")
 
         // Call `onSelected` for only supported types
-        // but avoid it for category suggestions (like Cafe category)
-        if let responseProvider = suggestion as? CoreResponseProvider, !(suggestion is SearchCategorySuggestion) {
+        // but avoid it for nested suggestions (like category and brand searches)
+        let shouldSelect = !(suggestion is SearchCategorySuggestion) && !(suggestion is SearchBrandSuggestion)
+        if let responseProvider = suggestion as? CoreResponseProvider, shouldSelect {
             engine.onSelected(
                 forRequest: responseProvider.originalResponse.requestOptions,
                 result: responseProvider.originalResponse.coreResult

--- a/Sources/MapboxSearch/PublicAPI/Engine/SearchEngine.swift
+++ b/Sources/MapboxSearch/PublicAPI/Engine/SearchEngine.swift
@@ -409,6 +409,11 @@ extension SearchEngine {
                 suggestion: querySuggestion,
                 retrieveOptions: retrieveOptions
             )
+        case let brandSuggestion as SearchBrandSuggestion:
+            retrieve(
+                suggestion: brandSuggestion,
+                retrieveOptions: retrieveOptions
+            )
         case let resultSuggestion as SearchResultSuggestion:
             resolve(
                 suggestion: resultSuggestion,

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchBrandSuggestionImpl.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchBrandSuggestionImpl.swift
@@ -1,0 +1,70 @@
+// Copyright © 2024 Mapbox. All rights reserved.
+
+import CoreLocation
+import Foundation
+
+protocol SearchBrandSuggestion: SearchSuggestion {
+    var externalIDs: [String: String]? { get }
+}
+
+class SearchBrandSuggestionImpl: SearchBrandSuggestion, CoreResponseProvider {
+    var originalResponse: CoreSearchResultResponse
+
+    var id: String
+
+    var mapboxId: String?
+
+    var name: String
+
+    var address: Address?
+
+    var descriptionText: String?
+
+    var iconName: String?
+
+    var serverIndex: Int?
+
+    var suggestionType: SearchSuggestType
+
+    var categories: [String]?
+
+    var categoryIDs: [String]?
+
+    var distance: CLLocationDistance?
+
+    let batchResolveSupported: Bool
+
+    var estimatedTime: Measurement<UnitDuration>?
+
+    var brand: [String]?
+
+    var brandID: String?
+
+    var externalIDs: [String: String]?
+
+    init?(coreResult: CoreSearchResultProtocol, response: CoreSearchResponseProtocol) {
+        assert(coreResult.centerLocation == nil)
+
+        guard coreResult.resultTypes == [.category] else { return nil }
+
+        self.id = coreResult.id
+        self.mapboxId = coreResult.mapboxId
+        self.suggestionType = .category
+        self.name = coreResult.names[0]
+        self.address = coreResult.addresses?.first.map(Address.init)
+        self.iconName = nil // Categories should use it's special icon
+        self.serverIndex = coreResult.serverIndex?.intValue
+        self.originalResponse = CoreSearchResultResponse(coreResult: coreResult, response: response)
+        self.distance = coreResult.distanceToProximity
+        self.batchResolveSupported = coreResult.action?.multiRetrievable ?? false
+        self.categories = coreResult.categories
+        self.categoryIDs = coreResult.categoryIDs
+
+        self.descriptionText = coreResult.addressDescription
+        self.estimatedTime = coreResult.estimatedTime
+
+        self.brand = coreResult.brand
+        self.brandID = coreResult.brandID
+        self.externalIDs = coreResult.externalIds
+    }
+}

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchBrandSuggestionImpl.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchBrandSuggestionImpl.swift
@@ -43,16 +43,14 @@ class SearchBrandSuggestionImpl: SearchBrandSuggestion, CoreResponseProvider {
     var externalIDs: [String: String]?
 
     init?(coreResult: CoreSearchResultProtocol, response: CoreSearchResponseProtocol) {
-        assert(coreResult.centerLocation == nil)
-
-        guard coreResult.resultTypes == [.category] else { return nil }
+        guard coreResult.resultTypes == [.brand] else { return nil }
 
         self.id = coreResult.id
         self.mapboxId = coreResult.mapboxId
-        self.suggestionType = .category
+        self.suggestionType = .brand
         self.name = coreResult.names[0]
         self.address = coreResult.addresses?.first.map(Address.init)
-        self.iconName = nil // Categories should use it's special icon
+        self.iconName = coreResult.icon
         self.serverIndex = coreResult.serverIndex?.intValue
         self.originalResponse = CoreSearchResultResponse(coreResult: coreResult, response: response)
         self.distance = coreResult.distanceToProximity

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchSuggestType.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchSuggestType.swift
@@ -20,6 +20,7 @@ public enum SearchSuggestType: Codable, Hashable {
     /// It might be used for query corrections.
     case query
 
+    /// Suggestion represents further query searches for a particular brand.
     case brand
 
     /// Access to `subtypes` of `address` type. Do not available for `.POI` type.

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchSuggestType.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchSuggestType.swift
@@ -20,18 +20,20 @@ public enum SearchSuggestType: Codable, Hashable {
     /// It might be used for query corrections.
     case query
 
+    case brand
+
     /// Access to `subtypes` of `address` type. Do not available for `.POI` type.
     public var addressSubtypes: [SearchAddressType]? {
         switch self {
         case .address(let subtypes):
             return subtypes
-        case .POI, .category, .query:
+        case .POI, .category, .query, .brand:
             return nil
         }
     }
 
     enum CodingKeys: CodingKey {
-        case poi, address, category, query
+        case poi, address, category, query, brand
     }
 
     /// Initializer for custom Decoder
@@ -49,6 +51,8 @@ public enum SearchSuggestType: Codable, Hashable {
             self = .category
         case .query:
             self = .query
+        case .brand:
+            self = .brand
         case nil:
             var path = container.codingPath
             if let firstKey = container.allKeys.first {
@@ -86,6 +90,8 @@ public enum SearchSuggestType: Codable, Hashable {
             try container.encode(true, forKey: .category)
         case .query:
             try container.encode(true, forKey: .query)
+        case .brand:
+            try container.encode(true, forKey: .brand)
         }
     }
 }

--- a/Sources/MapboxSearchUI/BrandSuggestionsController.swift
+++ b/Sources/MapboxSearchUI/BrandSuggestionsController.swift
@@ -1,0 +1,217 @@
+// Copyright © 2024 Mapbox. All rights reserved.
+
+import MapboxSearch
+import UIKit
+
+protocol BrandSuggestionsControllerDelegate: AnyObject {
+    func brandSuggestionsSelected(searchSuggestion: SearchSuggestion)
+    func brandSuggestionsCancelled()
+    func brandSuggestionsFeedbackRequested(searchSuggestion: SearchSuggestion)
+}
+
+class BrandSuggestionsController: UIViewController {
+    @IBOutlet private var tableView: UITableView!
+    @IBOutlet private var activityIndicator: UIActivityIndicatorView!
+    @IBOutlet private var titleLabel: UILabel!
+    @IBOutlet private var titleImageView: UIImageView!
+    @IBOutlet private var noSuggestionsLabel: UILabel!
+    @IBOutlet private var titleView: UIView!
+
+    let cellIdentifier = "SearchSuggestionCell"
+
+    var navigationBarInitiallyHidden = true
+    var allowsFeedbackUI = true
+    weak var delegate: BrandSuggestionsControllerDelegate?
+
+    var brandSuggestion: SearchSuggestion? {
+        didSet {
+            updateTitle()
+        }
+    }
+
+    var results: [SearchSuggestion]? {
+        didSet {
+            presentResults()
+        }
+    }
+
+    var configuration: Configuration {
+        didSet {
+            updateUI()
+        }
+    }
+
+    init(configuration: Configuration) {
+        self.configuration = configuration
+        super.init(nibName: nil, bundle: .mapboxSearchUI)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setVisible(view: tableView, visible: false, animated: false)
+        setVisible(view: noSuggestionsLabel, visible: false, animated: false)
+        tableView.register(
+            UINib(nibName: cellIdentifier, bundle: .mapboxSearchUI),
+            forCellReuseIdentifier: cellIdentifier
+        )
+
+        updateTitle()
+        presentResults()
+        setupNavigationItem()
+        setupForTesting()
+        updateUI()
+    }
+
+    func updateUI() {
+        tableView.reloadData()
+
+        titleLabel.textColor = configuration.style.primaryTextColor
+        titleLabel.font = Fonts.default(style: .title3, traits: traitCollection)
+        titleLabel.adjustsFontForContentSizeCategory = true
+        view.backgroundColor = configuration.style.primaryBackgroundColor
+        titleView.backgroundColor = configuration.style.primaryBackgroundColor
+        tableView.backgroundColor = configuration.style.primaryBackgroundColor
+        titleImageView.tintColor = configuration.style.primaryInactiveElementColor
+        titleImageView.adjustsImageSizeForAccessibilityContentSizeCategory = true
+        navigationController?.navigationBar.barTintColor = configuration.style.primaryBackgroundColor
+        navigationController?.navigationBar.tintColor = configuration.style.primaryAccentColor
+    }
+
+    func updateTitle() {
+        guard isViewLoaded else { return }
+        navigationItem.titleView = titleView
+        titleLabel.text = brandSuggestion?.name
+        titleImageView.image = brandSuggestion?.suggestionType.icon?.withRenderingMode(.alwaysTemplate)
+    }
+
+    func presentResults() {
+        guard isViewLoaded, let results else { return }
+
+        if results.isEmpty {
+            setVisible(view: noSuggestionsLabel, visible: true)
+        } else {
+            setVisible(view: tableView, visible: true)
+            tableView.reloadData()
+        }
+        activityIndicator.stopAnimating()
+    }
+
+    func setVisible(view: UIView, visible: Bool, animated: Bool = true) {
+        let alpha: CGFloat = visible ? 1.0 : 0.0
+        UIView.animate(
+            withDuration: animated ? 0.2 : 0.0,
+            delay: 0,
+            options: [.beginFromCurrentState, .allowUserInteraction]
+        ) {
+            view.alpha = alpha
+        }
+    }
+
+    @objc
+    func cancelAction() {
+        delegate?.brandSuggestionsCancelled()
+    }
+
+    func setupNavigationItem() {
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            image: Images.cancelIcon,
+            style: .plain,
+            target: self,
+            action: #selector(cancelAction)
+        )
+    }
+
+    func setupForTesting() {
+        tableView.accessibilityIdentifier = "BrandSuggestionsController.tableView"
+        navigationItem.rightBarButtonItem?.accessibilityIdentifier = "BrandSuggestionsController.cancel"
+    }
+}
+
+extension BrandSuggestionsController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        results?.count ?? 0
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let searchSuggestion = results?[indexPath.row] else {
+            assertionFailure("No suggestion found for this cell")
+            return UITableViewCell()
+        }
+
+        let cell = tableView.dequeueReusableCell(
+            withIdentifier: cellIdentifier,
+            for: indexPath
+        ) as! SearchSuggestionCell
+        // swiftlint:disable:previous force_cast
+
+        cell.configure(suggestion: searchSuggestion, hideQueryHighlights: true, configuration: configuration)
+        cell.populateButtonEnabled = false
+
+        return cell
+    }
+}
+
+extension BrandSuggestionsController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        let searchSuggestion = results?[indexPath.row]
+        delegate?.brandSuggestionsSelected(searchSuggestion: searchSuggestion!)
+    }
+
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        nil
+    }
+
+    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        nil
+    }
+
+    func tableView(
+        _ tableView: UITableView,
+        trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath
+    ) -> UISwipeActionsConfiguration? {
+        guard allowsFeedbackUI, let suggestion = results?[indexPath.row] else { return nil }
+
+        let sendFeedback = UIContextualAction(
+            style: .normal,
+            title: Strings.Feedback.report
+        ) { [weak self] _, _, completion in
+            self?.delegate?.brandSuggestionsFeedbackRequested(searchSuggestion: suggestion)
+            completion(true)
+        }
+        sendFeedback.backgroundColor = Colors.tableAction
+        return UISwipeActionsConfiguration(actions: [sendFeedback])
+    }
+}
+
+// MARK: - Navigation bar logic
+
+extension BrandSuggestionsController {
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        guard let navigation = navigationController else { return }
+
+        navigationBarInitiallyHidden = navigation.isNavigationBarHidden
+        navigation.setNavigationBarHidden(false, animated: animated)
+
+        navigation.navigationBar.isTranslucent = false
+
+        // This will hide navigation bar underline
+        navigation.navigationBar.setBackgroundImage(UIImage(), for: .default)
+        navigation.navigationBar.shadowImage = UIImage()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        let navigationBarHidden = navigationBarInitiallyHidden
+        navigationController?.setNavigationBarHidden(navigationBarHidden, animated: animated)
+    }
+}

--- a/Sources/MapboxSearchUI/BrandSuggestionsController.xib
+++ b/Sources/MapboxSearchUI/BrandSuggestionsController.xib
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="BrandSuggestionsController" customModule="MapboxSearchUI">
+            <connections>
+                <outlet property="activityIndicator" destination="hIz-G2-Mis" id="i1n-4V-mHW"/>
+                <outlet property="noSuggestionsLabel" destination="dlL-LV-rB7" id="dMP-mt-Ku1"/>
+                <outlet property="tableView" destination="q7J-0z-KIs" id="35g-km-f2f"/>
+                <outlet property="titleImageView" destination="71E-Ly-etM" id="g1E-IB-okx"/>
+                <outlet property="titleLabel" destination="ApD-hC-RXo" id="vsr-g3-7h8"/>
+                <outlet property="titleView" destination="sHf-ac-ZIi" id="iNc-yv-7y9"/>
+                <outlet property="view" destination="bk3-DS-wiJ" id="QWY-v6-h5k"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="bk3-DS-wiJ">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" animating="YES" style="white" translatesAutoresizingMaskIntoConstraints="NO" id="hIz-G2-Mis">
+                    <rect key="frame" x="197" y="88" width="20" height="20"/>
+                    <color key="color" name="mapbox icon tint"/>
+                </activityIndicatorView>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NO CATEGORY SUGGESTIONS FOUND" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dlL-LV-rB7" userLabel="NO BRAND SUGGESTIONS FOUND">
+                    <rect key="frame" x="20" y="78" width="374" height="40"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="40" id="iJD-F2-SnF"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" name="AvenirNext-Bold" family="Avenir Next" pointSize="13"/>
+                    <color key="textColor" red="0.73725490199999999" green="0.73725490199999999" blue="0.74901960779999999" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="singleLineEtched" rowHeight="68" estimatedRowHeight="-1" sectionHeaderHeight="1" sectionFooterHeight="1" translatesAutoresizingMaskIntoConstraints="NO" id="q7J-0z-KIs">
+                    <rect key="frame" x="0.0" y="48" width="414" height="814"/>
+                    <color key="backgroundColor" name="mapbox background"/>
+                    <color key="separatorColor" red="0.80784313730000001" green="0.80784313730000001" blue="0.80784313730000001" alpha="0.55765732020000003" colorSpace="calibratedRGB"/>
+                    <inset key="separatorInset" minX="22" minY="0.0" maxX="22" maxY="0.0"/>
+                    <connections>
+                        <outlet property="dataSource" destination="-1" id="yS0-14-ReU"/>
+                        <outlet property="delegate" destination="-1" id="6Dx-MS-CTv"/>
+                    </connections>
+                </tableView>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="ra6-2t-5PN"/>
+            <color key="backgroundColor" name="mapbox background"/>
+            <constraints>
+                <constraint firstItem="q7J-0z-KIs" firstAttribute="leading" secondItem="ra6-2t-5PN" secondAttribute="leading" id="93S-hE-liA"/>
+                <constraint firstItem="hIz-G2-Mis" firstAttribute="centerX" secondItem="bk3-DS-wiJ" secondAttribute="centerX" id="IPR-Oq-cvi"/>
+                <constraint firstItem="q7J-0z-KIs" firstAttribute="top" secondItem="ra6-2t-5PN" secondAttribute="top" id="Zsf-TE-MCU"/>
+                <constraint firstItem="ra6-2t-5PN" firstAttribute="trailing" secondItem="dlL-LV-rB7" secondAttribute="trailing" constant="20" id="cB6-v2-xxe"/>
+                <constraint firstItem="ra6-2t-5PN" firstAttribute="trailing" secondItem="q7J-0z-KIs" secondAttribute="trailing" id="fQZ-zT-Zms"/>
+                <constraint firstItem="dlL-LV-rB7" firstAttribute="leading" secondItem="ra6-2t-5PN" secondAttribute="leading" constant="20" id="jYG-wF-CvM"/>
+                <constraint firstItem="ra6-2t-5PN" firstAttribute="bottom" secondItem="q7J-0z-KIs" secondAttribute="bottom" id="n7L-lz-W1w"/>
+                <constraint firstItem="hIz-G2-Mis" firstAttribute="top" secondItem="ra6-2t-5PN" secondAttribute="top" constant="40" id="pIy-wv-jyS"/>
+                <constraint firstItem="dlL-LV-rB7" firstAttribute="centerY" secondItem="hIz-G2-Mis" secondAttribute="centerY" id="rBH-Cw-jst"/>
+                <constraint firstItem="dlL-LV-rB7" firstAttribute="centerX" secondItem="hIz-G2-Mis" secondAttribute="centerX" id="yNg-wo-vmd"/>
+            </constraints>
+            <point key="canvasLocation" x="137.68115942028987" y="100.44642857142857"/>
+        </view>
+        <view contentMode="scaleToFill" id="sHf-ac-ZIi">
+            <rect key="frame" x="0.0" y="0.0" width="133" height="85"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <subviews>
+                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="71E-Ly-etM">
+                    <rect key="frame" x="2" y="2" width="72.5" height="47"/>
+                    <color key="tintColor" name="mapbox inactive segment text"/>
+                </imageView>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ApD-hC-RXo">
+                    <rect key="frame" x="80.5" y="2" width="50.5" height="81"/>
+                    <fontDescription key="fontDescription" name="AvenirNext-Medium" family="Avenir Next" pointSize="20"/>
+                    <color key="textColor" name="mapbox text"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="140-xR-gUY"/>
+            <color key="backgroundColor" name="mapbox background"/>
+            <constraints>
+                <constraint firstItem="140-xR-gUY" firstAttribute="bottom" secondItem="71E-Ly-etM" secondAttribute="bottom" constant="2" id="1Zv-l1-6N4"/>
+                <constraint firstItem="71E-Ly-etM" firstAttribute="centerY" secondItem="sHf-ac-ZIi" secondAttribute="centerY" id="7hW-nK-dng"/>
+                <constraint firstAttribute="bottom" secondItem="ApD-hC-RXo" secondAttribute="bottom" constant="2" id="BOd-3s-AOw"/>
+                <constraint firstItem="ApD-hC-RXo" firstAttribute="leading" secondItem="71E-Ly-etM" secondAttribute="trailing" constant="6" id="P8B-dS-jJh"/>
+                <constraint firstAttribute="trailing" secondItem="ApD-hC-RXo" secondAttribute="trailing" constant="2" id="PPm-B5-ndE"/>
+                <constraint firstItem="71E-Ly-etM" firstAttribute="leading" secondItem="sHf-ac-ZIi" secondAttribute="leading" constant="2" id="iyA-ea-dPr"/>
+                <constraint firstItem="71E-Ly-etM" firstAttribute="top" secondItem="sHf-ac-ZIi" secondAttribute="top" constant="2" id="q9i-5Y-mkE"/>
+                <constraint firstItem="ApD-hC-RXo" firstAttribute="top" secondItem="sHf-ac-ZIi" secondAttribute="top" constant="2" id="xmy-Jo-n80"/>
+            </constraints>
+            <nil key="simulatedTopBarMetrics"/>
+            <nil key="simulatedBottomBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="-745.6521739130435" y="-36.495535714285715"/>
+        </view>
+    </objects>
+    <resources>
+        <namedColor name="mapbox background">
+            <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="mapbox icon tint">
+            <color red="0.20392156862745098" green="0.20392156862745098" blue="0.20392156862745098" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="mapbox inactive segment text">
+            <color red="0.73725490196078436" green="0.73725490196078436" blue="0.74901960784313726" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="mapbox text">
+            <color red="0.20392156862745098" green="0.20392156862745098" blue="0.20392156862745098" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
+</document>

--- a/Sources/MapboxSearchUI/MapboxSearchController.swift
+++ b/Sources/MapboxSearchUI/MapboxSearchController.swift
@@ -495,7 +495,7 @@ extension MapboxSearchController: SearchEngineDelegate {
         if searchEngine.responseInfo?.suggestion?.suggestionType == .category {
             categorySuggestionController?.results = suggestions
             return
-        } else if searchEngine.responseInfo?.suggestion?.brandID != nil {
+        } else if searchEngine.responseInfo?.suggestion?.suggestionType == .brand {
             brandSuggestionController?.results = suggestions
             return
         }

--- a/Sources/MapboxSearchUI/MapboxSearchController.swift
+++ b/Sources/MapboxSearchUI/MapboxSearchController.swift
@@ -72,7 +72,7 @@ public class MapboxSearchController: UIViewController {
     private weak var categorySuggestionController: CategorySuggestionsController?
 
     /// Brand results can be viewed in a child controller
-    private weak var brandSuggestionController: UIViewController?
+    private weak var brandSuggestionController: BrandSuggestionsController?
 
     private weak var feedbackController: SendFeedbackController?
 
@@ -417,14 +417,12 @@ public class MapboxSearchController: UIViewController {
     func navigateToBrandSuggestionList(suggestion: SearchSuggestion) {
         searchBar.endEditing(true)
 
-        // TODO: Implement
-        let controller = UIViewController()
-        controller.view.backgroundColor = .red
-//        categorySuggestionController = controller
-//
-//        controller.categorySuggestion = suggestion
-//        controller.delegate = self
-//        controller.allowsFeedbackUI = configuration.allowsFeedbackUI
+        let controller = BrandSuggestionsController(configuration: configuration)
+        brandSuggestionController = controller
+
+        controller.brandSuggestion = suggestion
+        controller.delegate = self
+        controller.allowsFeedbackUI = configuration.allowsFeedbackUI
         mapboxPanelController?.push(viewController: controller, animated: true)
     }
 
@@ -498,7 +496,7 @@ extension MapboxSearchController: SearchEngineDelegate {
             categorySuggestionController?.results = suggestions
             return
         } else if searchEngine.responseInfo?.suggestion?.brandID != nil {
-//            brandSuggestionController.results = suggestions
+            brandSuggestionController?.results = suggestions
             return
         }
         searchSuggestionsSource.suggestions = suggestions
@@ -586,7 +584,7 @@ extension MapboxSearchController: SearchResultsTableSourceDelegate {
         // Present other controller for suggestions with category type
         if searchSuggestion.suggestionType == .category {
             navigateToCategorySuggestionList(suggestion: searchSuggestion)
-        } else if searchSuggestion.brandID != nil { // TODO: Should suggestionType have a brand case?
+        } else if searchSuggestion.suggestionType == .brand {
             navigateToBrandSuggestionList(suggestion: searchSuggestion)
         }
         searchEngine.select(suggestion: searchSuggestion)
@@ -609,6 +607,22 @@ extension MapboxSearchController: CategorySuggestionsControllerDelegate {
     }
 
     func categorySuggestionsCancelled() {
+        resetSearchUI(animated: true)
+    }
+}
+
+// MARK: - Brand Suggestions Delegate
+
+extension MapboxSearchController: BrandSuggestionsControllerDelegate {
+    func brandSuggestionsFeedbackRequested(searchSuggestion: SearchSuggestion) {
+        navigateToSendFeedbackController(suggestion: searchSuggestion)
+    }
+
+    func brandSuggestionsSelected(searchSuggestion: SearchSuggestion) {
+        searchEngine.select(suggestion: searchSuggestion)
+    }
+
+    func brandSuggestionsCancelled() {
         resetSearchUI(animated: true)
     }
 }

--- a/Sources/MapboxSearchUI/MapboxSearchController.swift
+++ b/Sources/MapboxSearchUI/MapboxSearchController.swift
@@ -68,7 +68,11 @@ public class MapboxSearchController: UIViewController {
 
     private weak var favoriteDetailsController: FavoriteDetailsController?
 
+    /// Category results can be viewed in a child controller
     private weak var categorySuggestionController: CategorySuggestionsController?
+
+    /// Brand results can be viewed in a child controller
+    private weak var brandSuggestionController: UIViewController?
 
     private weak var feedbackController: SendFeedbackController?
 
@@ -410,6 +414,20 @@ public class MapboxSearchController: UIViewController {
         mapboxPanelController?.push(viewController: controller, animated: true)
     }
 
+    func navigateToBrandSuggestionList(suggestion: SearchSuggestion) {
+        searchBar.endEditing(true)
+
+        // TODO: Implement
+        let controller = UIViewController()
+        controller.view.backgroundColor = .red
+//        categorySuggestionController = controller
+//
+//        controller.categorySuggestion = suggestion
+//        controller.delegate = self
+//        controller.allowsFeedbackUI = configuration.allowsFeedbackUI
+        mapboxPanelController?.push(viewController: controller, animated: true)
+    }
+
     func navigateToSendFeedbackController(suggestion: SearchSuggestion?) {
         searchBar.endEditing(true)
         let controller = SendFeedbackController(configuration: configuration)
@@ -475,9 +493,12 @@ extension MapboxSearchController: SearchEngineDelegate {
         let responseQuery = Query(string: searchEngine.query)
         guard responseQuery == query || responseQuery == .none else { return }
 
-        // This search results should be ignored and consumed by CategorySuggestionsController(if exists)
+        // This search result should be ignored and consumed by CategorySuggestionsController(if exists)
         if searchEngine.responseInfo?.suggestion?.suggestionType == .category {
             categorySuggestionController?.results = suggestions
+            return
+        } else if searchEngine.responseInfo?.suggestion?.brandID != nil {
+//            brandSuggestionController.results = suggestions
             return
         }
         searchSuggestionsSource.suggestions = suggestions
@@ -565,6 +586,8 @@ extension MapboxSearchController: SearchResultsTableSourceDelegate {
         // Present other controller for suggestions with category type
         if searchSuggestion.suggestionType == .category {
             navigateToCategorySuggestionList(suggestion: searchSuggestion)
+        } else if searchSuggestion.brandID != nil { // TODO: Should suggestionType have a brand case?
+            navigateToBrandSuggestionList(suggestion: searchSuggestion)
         }
         searchEngine.select(suggestion: searchSuggestion)
     }

--- a/Sources/MapboxSearchUI/SearchSuggestionCell.swift
+++ b/Sources/MapboxSearchUI/SearchSuggestionCell.swift
@@ -135,11 +135,11 @@ extension SearchSuggestType {
         case .POI:
             return Images.poiIcon
         case .category:
-            return Images.cancelIcon
+            return Images.poiIcon
         case .query:
             return Images.poiIcon
-//        case .brand:
-//            return Images.favoritesIcon
+        case .brand:
+            return Maki.shop.icon
         @unknown default:
             return Images.poiIcon
         }

--- a/Sources/MapboxSearchUI/SearchSuggestionCell.swift
+++ b/Sources/MapboxSearchUI/SearchSuggestionCell.swift
@@ -114,6 +114,8 @@ class SearchSuggestionCell: UITableViewCell {
         // Show templated image for 'Category' type
         if suggestion.suggestionType == .category {
             iconImageView.tintColor = configuration.style.primaryAccentColor
+        } else if suggestion.brand != nil {
+            iconImageView.tintColor = configuration.style.primaryAccentColor
         } else {
             iconImageView.tintColor = configuration.style.iconTintColor
         }
@@ -133,9 +135,11 @@ extension SearchSuggestType {
         case .POI:
             return Images.poiIcon
         case .category:
-            return Images.poiIcon
+            return Images.cancelIcon
         case .query:
             return Images.poiIcon
+//        case .brand:
+//            return Images.favoritesIcon
         @unknown default:
             return Images.poiIcon
         }


### PR DESCRIPTION
### Description
Fixes SSDK-1123

- Add nested brand search
- Fetch and display `retrieve/` results for a brand selected from the SearchUI 

| Screenshot gif | Screenshot gif |
| -- | -- |
| ![Simulator Screen Recording - iPhone 15 - 2024-09-26 at 11 50 17](https://github.com/user-attachments/assets/63b337c2-0c4b-457e-ae3b-11d903c2a8f8) | ![Simulator Screen Recording - iPhone 15 - 2024-09-26 at 15 30 50](https://github.com/user-attachments/assets/0bab318f-f6da-4f77-bffb-f3c1cc01f28c) |

### Checklist
- [x] Update `CHANGELOG`
