### PR TITLE
Update MapboxCommon to 24.7.0, MapboxCoreSearch v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Guide: https://keepachangelog.com/en/1.0.0/
 - [Offline] Change default tileset name to `mbx-gen2`
 - [Core] Update dependencies
 
-**MapboxCommon**: v24.7.0-rc.2
+**MapboxCommon**: v24.7.0
 **MapboxCoreSearch**: v2.5.0-rc.4
 
 ## 2.5.0-rc.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Guide: https://keepachangelog.com/en/1.0.0/
 - [Core] Update dependencies
 
 **MapboxCommon**: v24.7.0
-**MapboxCoreSearch**: v2.5.0-rc.4
+**MapboxCoreSearch**: v2.5.0
 
 ## 2.5.0-rc.3
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.5.0-rc.4
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.7.0-rc.2
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.7.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.5.0-rc.4
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.5.0
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.7.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.7.0"
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.5.0-rc.4"
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.5.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.7.0-rc.2"
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.7.0"
 binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.5.0-rc.4"

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -25,5 +25,5 @@ Some iOS platform specifics applies.
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
   s.dependency "MapboxCoreSearch", '2.5.0-rc.3'
-  s.dependency "MapboxCommon", '24.7.0-rc.2'
+  s.dependency "MapboxCommon", '24.7.0'
 end

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -24,6 +24,6 @@ Some iOS platform specifics applies.
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency "MapboxCoreSearch", '2.5.0-rc.3'
+  s.dependency "MapboxCoreSearch", '2.5.0'
   s.dependency "MapboxCommon", '24.7.0'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import Foundation
 
 let (coreSearchVersion, coreSearchVersionHash) = ("2.5.0-rc.4", "4ec3ba525d24136dca5c9058a251fb06368dce707675289631b1366949ae6270")
 
-let mapboxCommonSDKVersion = Version("24.7.0-rc.2")
+let mapboxCommonSDKVersion = Version("24.7.0")
 
 let package = Package(
     name: "MapboxSearch",

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 import Foundation
 
-let (coreSearchVersion, coreSearchVersionHash) = ("2.5.0-rc.4", "4ec3ba525d24136dca5c9058a251fb06368dce707675289631b1366949ae6270")
+let (coreSearchVersion, coreSearchVersionHash) = ("2.5.0", "e17ccde3ff4ec389868cb3a512c3a018691e80337ae4868034a564c4fbad366c")
 
 let mapboxCommonSDKVersion = Version("24.7.0")
 


### PR DESCRIPTION
### Description

- Update MapboxCommon to 24.7.0
- Update MapboxCoreSearch to 2.5.0

### Checklist
- [x] Update `CHANGELOG`
