### PR TITLE
Add forward endpoint support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
+- [Search] Add forward(query:options:completion:) function to search forward/ API endpoint.
+
 ## 2.5.0
 
 - [Search] Add SearchSuggestType.brand

--- a/MapboxSearch.xcodeproj/project.pbxproj
+++ b/MapboxSearch.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		04CECA142C3EFAB9007117E4 /* MapsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04CECA102C3EFAB9007117E4 /* MapsViewController.swift */; };
 		04CECA152C3EFAB9007117E4 /* TextViewLoggerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04CECA112C3EFAB9007117E4 /* TextViewLoggerViewController.swift */; };
 		04CECA162C3EFAB9007117E4 /* ExamplesListing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04CECA122C3EFAB9007117E4 /* ExamplesListing.swift */; };
+		04D690CE2CADC5A600AB0E16 /* SearchEngine+ForwardIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D690CD2CADC5A600AB0E16 /* SearchEngine+ForwardIntegrationTests.swift */; };
 		04DAF7582BDAAB4C002719E2 /* OfflineDemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04DAF7572BDAAB4C002719E2 /* OfflineDemoViewController.swift */; };
 		04DFB40C2B8CF1ED00231830 /* search-box-suggestions-categories.json in Resources */ = {isa = PBXBuildFile; fileRef = 04DFB40B2B8CF1ED00231830 /* search-box-suggestions-categories.json */; };
 		04DFB40D2B8CF1ED00231830 /* search-box-suggestions-categories.json in Resources */ = {isa = PBXBuildFile; fileRef = 04DFB40B2B8CF1ED00231830 /* search-box-suggestions-categories.json */; };
@@ -587,6 +588,7 @@
 		04CECA102C3EFAB9007117E4 /* MapsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MapsViewController.swift; path = Sources/Demo/Examples/MapsViewController.swift; sourceTree = SOURCE_ROOT; };
 		04CECA112C3EFAB9007117E4 /* TextViewLoggerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TextViewLoggerViewController.swift; path = Sources/Demo/Examples/TextViewLoggerViewController.swift; sourceTree = SOURCE_ROOT; };
 		04CECA122C3EFAB9007117E4 /* ExamplesListing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ExamplesListing.swift; path = Sources/Demo/Examples/ExamplesListing.swift; sourceTree = SOURCE_ROOT; };
+		04D690CD2CADC5A600AB0E16 /* SearchEngine+ForwardIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchEngine+ForwardIntegrationTests.swift"; sourceTree = "<group>"; };
 		04DAF7572BDAAB4C002719E2 /* OfflineDemoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineDemoViewController.swift; sourceTree = "<group>"; };
 		04DFB40B2B8CF1ED00231830 /* search-box-suggestions-categories.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "search-box-suggestions-categories.json"; sourceTree = "<group>"; };
 		04DFB40F2B8CF46D00231830 /* search-box-retrieve-categories.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "search-box-retrieve-categories.json"; sourceTree = "<group>"; };
@@ -1704,6 +1706,7 @@
 				F9ACA6162642C18200F50CD4 /* SearchEngineIntegrationTests.swift */,
 				042477C12B7290E700D870D5 /* SearchEngineGeocodingIntegrationTests.swift */,
 				F99190422645ABE6009927A6 /* CategorySearchEngineIntegrationTests.swift */,
+				04D690CD2CADC5A600AB0E16 /* SearchEngine+ForwardIntegrationTests.swift */,
 				046818D22B87F2810082B188 /* search-box */,
 				04AB0B792B6AF37800FDE7D5 /* DiscoverIntegrationTests.swift */,
 				F9C5572C2670C88E00BE8B94 /* Info.plist */,
@@ -2749,6 +2752,7 @@
 				FE1F320925680E4B004DCB6D /* SearchResponseTests.swift in Sources */,
 				FECB510025541A170026302E /* ExternalRecordPlaceholderTests.swift in Sources */,
 				FE7C739A25667FDE0047CA20 /* RecordsProviderInteractorNativeCoreTests.swift in Sources */,
+				04D690CE2CADC5A600AB0E16 /* SearchEngine+ForwardIntegrationTests.swift in Sources */,
 				1420F31D29A2800500D4A511 /* CoreSearchResultStub+Samples.swift in Sources */,
 				FE1122B92567BE5B0064FD53 /* ArrayExtensionsTests.swift in Sources */,
 				14FBBBAF2881673E00721935 /* AddressAutofill.Query+Tests.swift in Sources */,

--- a/Sources/MapboxSearch/InternalAPI/CoreSearchEngineProtocol.swift
+++ b/Sources/MapboxSearch/InternalAPI/CoreSearchEngineProtocol.swift
@@ -79,6 +79,13 @@ protocol CoreSearchEngineProtocol {
         completion: @escaping (CoreSearchResponseProtocol?) -> Void
     )
 
+    @discardableResult
+    func forward(
+        query: String,
+        options: CoreSearchOptions,
+        completion: @escaping (CoreSearchResponseProtocol?) -> Void
+    ) -> UInt64
+
     func setTileStore(_ tileStore: MapboxCommon.TileStore, completion: (() -> Void)?)
 
     func setTileStore(_ tileStore: MapboxCommon.TileStore)
@@ -260,6 +267,19 @@ extension CoreSearchEngine: CoreSearchEngineProtocol {
         completion: @escaping (CoreSearchResponseProtocol?) -> Void
     ) {
         reverseGeocodingOffline(for: options, callback: { response in
+            DispatchQueue.main.async {
+                completion(response)
+            }
+        })
+    }
+
+    @discardableResult
+    func forward(
+        query: String,
+        options: CoreSearchOptions,
+        completion: @escaping (CoreSearchResponseProtocol?) -> Void
+    ) -> UInt64 {
+        forward(forQuery: query, options: options, callback: { response in
             DispatchQueue.main.async {
                 completion(response)
             }

--- a/Sources/MapboxSearch/PublicAPI/Engine/SearchEngine.swift
+++ b/Sources/MapboxSearch/PublicAPI/Engine/SearchEngine.swift
@@ -528,6 +528,7 @@ extension SearchEngine {
 
     /// Search non-interactively to receive search results with coordinates and metadata.
     /// This function will not return type-ahead suggestions (such as brand or category nested results).
+    /// Forward is only compatible with ``ApiType/searchBox``.
     /// Documentation at https://docs.mapbox.com/api/search/search-box/#search-request
     /// - Parameters:
     ///   - query: The search text.
@@ -535,12 +536,14 @@ extension SearchEngine {
     ///   - completion: A block to execute when results or errors are received.
     public func forward(
         query: String,
-        options: SearchOptions,
+        options: SearchOptions? = nil,
         completion: @escaping (Result<[SearchResult], SearchError>) -> Void
     ) {
         assert(Thread.isMainThread)
+        assert(apiType == .searchBox)
 
         // Request identifier is ignored
+        let options = options ?? SearchOptions()
         _ = engine.forward(query: query, options: options.toCore()) { [weak self] response in
             guard let self else {
                 assertionFailure("Owning object was deallocated")

--- a/Sources/MapboxSearch/PublicAPI/Engine/SearchEngine.swift
+++ b/Sources/MapboxSearch/PublicAPI/Engine/SearchEngine.swift
@@ -523,6 +523,52 @@ extension SearchEngine {
             }
         }
     }
+
+    // MARK: Forward
+
+    /// Search non-interactively to receive search results with coordinates and metadata.
+    /// This function will not return type-ahead suggestions (such as brand or category nested results).
+    /// Documentation at https://docs.mapbox.com/api/search/search-box/#search-request
+    /// - Parameters:
+    ///   - query: The search text.
+    ///   - options: SearchOptions object to filter or narrow results. Recommended to customize for your specialization.
+    ///   - completion: A block to execute when results or errors are received.
+    public func forward(
+        query: String,
+        options: SearchOptions,
+        completion: @escaping (Result<[SearchResult], SearchError>) -> Void
+    ) {
+        assert(Thread.isMainThread)
+
+        // Request identifier is ignored
+        _ = engine.forward(query: query, options: options.toCore()) { [weak self] response in
+            guard let self else {
+                assertionFailure("Owning object was deallocated")
+                return
+            }
+
+            guard let response else {
+                eventsManager.reportError(.responseProcessingFailed)
+                completion(.failure(.responseProcessingFailed))
+                assertionFailure("Response should never be nil")
+                return
+            }
+
+            switch response.result {
+            case .success(let results):
+                completion(
+                    .success(
+                        results.compactMap { ServerSearchResult(coreResult: $0, response: response) }
+                    )
+                )
+
+            case .failure(let responseError):
+                let wrappedError = SearchError.searchRequestFailed(reason: responseError)
+
+                completion(.failure(wrappedError))
+            }
+        }
+    }
 }
 
 // MARK: - IndexableDataResolver

--- a/Tests/MapboxSearchIntegrationTests/SearchEngine+ForwardIntegrationTests.swift
+++ b/Tests/MapboxSearchIntegrationTests/SearchEngine+ForwardIntegrationTests.swift
@@ -1,0 +1,38 @@
+// Copyright © 2024 Mapbox. All rights reserved.
+
+import CoreLocation
+@testable import MapboxSearch
+import XCTest
+
+class SearchEngineForwardIntegrationTests: XCTestCase {
+    let delegate = SearchEngineDelegateStub()
+    var searchEngine: SearchEngine!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        searchEngine = SearchEngine(
+            serviceProvider: ServiceProvider.shared,
+            locationProvider: DefaultLocationProvider(),
+            apiType: .searchBox
+        )
+
+        searchEngine.delegate = delegate
+    }
+
+    // Note that Forward is only compatible with ApiType.searchBox
+    func testForwardSearch() throws {
+        let completionExpectation = XCTestExpectation()
+        searchEngine.forward(query: "coffee shop") { response in
+            switch response {
+            case .success(let success):
+                XCTAssertTrue(!success.isEmpty)
+
+            case .failure(let failure):
+                XCTFail(failure.localizedDescription)
+            }
+            completionExpectation.fulfill()
+        }
+        wait(for: [completionExpectation], timeout: 10)
+    }
+}

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/CoreSearchEngineStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/CoreSearchEngineStub.swift
@@ -198,4 +198,14 @@ extension CoreSearchEngineStub: CoreSearchEngineProtocol {
     ) {
         reverseGeocoding(for: options, completion: completion)
     }
+
+    @discardableResult
+    func forward(
+        query: String,
+        options: CoreSearchOptions,
+        completion: @escaping (CoreSearchResponseProtocol?) -> Void
+    ) -> UInt64 {
+        // TODO:
+        return UInt64.max
+    }
 }


### PR DESCRIPTION
### Description
Fixes SSDK-921

> Search Box API enables developers to send one-off search requests and get relevant results. Developers can create search requests with the `/forward` endpoint and get a list of search results with coordinates and metadata. In contrast to Interactive Search, the `/forward` endpoint will not provide type-ahead suggestions, e.g., brand and category suggestions, but will only provide relevant search results.

— Network API documentation available at https://docs.mapbox.com/api/search/search-box/#search-request

Add `SearchEngine.forward(query:options:completion:)` function to use network `forward/` API endpoint. This function provides a non-interactive search to find complete results in one step. Results and errors are returned in the completion block. 

Please note this function is only compatible with engines created using `SearchEngine(apiType: .searchBox)`. SBS and geocoding network APIs do not support this endpoint.

### Checklist
- [x] Update `CHANGELOG`
