### PR TITLE
Update MapboxCoreSearch v2.5.1, Release v2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,13 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
+## 2.5.1
+
 - [Demo] Add example for forward(query:options:completion:) to Demo app using SwiftUI.
 - [Search] Add forward(query:options:completion:) function to search forward/ API endpoint.
+
+**MapboxCommon**: v24.7.0
+**MapboxCoreSearch**: v2.5.1
 
 ## 2.5.0
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.5.0
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.5.1
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.7.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.7.0"
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.5.0"
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.5.1"

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 ## License
 
-Mapbox Search for iOS version 2.5.0
+Mapbox Search for iOS version 2.5.1
 Mapbox Search iOS SDK
 
 Copyright © 2021 - 2024 Mapbox, Inc. All rights reserved.

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearch'
-  s.version          = '2.5.0'
+  s.version          = '2.5.1'
   s.summary          = 'Search SDK for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.
@@ -24,6 +24,6 @@ Some iOS platform specifics applies.
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency "MapboxCoreSearch", '2.5.0'
+  s.dependency "MapboxCoreSearch", '2.5.1'
   s.dependency "MapboxCommon", '24.7.0'
 end

--- a/MapboxSearchUI.podspec
+++ b/MapboxSearchUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearchUI'
-  s.version          = '2.5.0'
+  s.version          = '2.5.1'
   s.summary          = 'Search UI for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.
@@ -23,5 +23,5 @@ Card style custom UI with full search functionality powered by Mapbox Search API
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency 'MapboxSearch', "2.5.0"
+  s.dependency 'MapboxSearch', "2.5.1"
 end

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 import Foundation
 
-let (coreSearchVersion, coreSearchVersionHash) = ("2.5.1", "e17ccde3ff4ec389868cb3a512c3a018691e80337ae4868034a564c4fbad366c")
+let (coreSearchVersion, coreSearchVersionHash) = ("2.5.1", "f2b81b9ba4201f2de595913592aa947cae6e0e4b7bfe99fcb21e6b72e0a6cf72")
 
 let mapboxCommonSDKVersion = Version("24.7.0")
 

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 import Foundation
 
-let (coreSearchVersion, coreSearchVersionHash) = ("2.5.0", "e17ccde3ff4ec389868cb3a512c3a018691e80337ae4868034a564c4fbad366c")
+let (coreSearchVersion, coreSearchVersionHash) = ("2.5.1", "e17ccde3ff4ec389868cb3a512c3a018691e80337ae4868034a564c4fbad366c")
 
 let mapboxCommonSDKVersion = Version("24.7.0")
 

--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ dependencies: [
 ##### MapboxSearch
 To integrate latest pre-release version of `MapboxSearch` into your Xcode project using CocoaPods, specify it in your `Podfile`:
 ```
-pod 'MapboxSearch', ">= 2.5.0-rc.3", "0
+pod 'MapboxSearch', ">= 2.5.1", "< 3.0"
 ```
 
 ##### MapboxSearchUI
 To integrate latest pre-release version of `MapboxSearchUI` into your Xcode project using CocoaPods, specify it in your `Podfile`:
 ```
-pod 'MapboxSearchUI', ">= 2.5.0-rc.3", "0
+pod 'MapboxSearchUI', ">= 2.5.1", "< 3.0"
 ```
 
 ### Carthage
@@ -109,7 +109,7 @@ pod 'MapboxSearchUI', ">= 2.5.0-rc.3", "0
 2. Follow the [Carthage Quick Start](https://github.com/Carthage/Carthage?tab=readme-ov-file#quick-start) and specificy the MapboxSearch dependency in your `Cartfile`:
 
 ```
-github "Mapbox/mapbox-search-ios" ~> 2.5.0
+github "Mapbox/mapbox-search-ios" ~> 2.5.1
 ```
 
 ## Contributing

--- a/Search Documentation.docc/Installation.md
+++ b/Search Documentation.docc/Installation.md
@@ -59,7 +59,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearchUI', ">= 2.5.0", "< 3.0"
+      pod 'MapboxSearchUI', ">= 2.5.1", "< 3.0"
     end
     ```
 
@@ -68,7 +68,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearch', ">= 2.5.0", "< 3.0"
+      pod 'MapboxSearch', ">= 2.5.1", "< 3.0"
     end
     ```
 

--- a/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
+++ b/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
@@ -1,2 +1,2 @@
 /// Mapbox Search SDK version variable
-public let mapboxSearchSDKVersion = "2.5.0"
+public let mapboxSearchSDKVersion = "2.5.1"


### PR DESCRIPTION
### Description

- Update MapboxCoreSearch v2.5.1
- Prepare release for v2.5.1

### Checklist
- [x] Update `CHANGELOG`
