### PR TITLE
Release v2.6.0-beta.1, update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,14 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
+## 2.6.0-beta.1
+
 - [SearchResult] Mark `matchingName` field as deprecated and add note for absence of values in ApiType.searchBox results.
 - [SearchEngine] Add documentation and assertion that ApiType.searchBox does _not_ support batch requests.
+- [Core] Update dependencies
+
+**MapboxCommon**: v24.8.0-beta.1
+**MapboxCoreSearch**: v2.6.0-beta.2
 
 ## 2.5.1
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.5.1
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.7.0
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.6.0-beta.2
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.8.0-beta.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.7.0"
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.5.1"
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.8.0-beta.1"
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.6.0-beta.2"

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 ## License
 
-Mapbox Search for iOS version 2.5.1
+Mapbox Search for iOS version 2.6.0-beta.1
 Mapbox Search iOS SDK
 
 Copyright © 2021 - 2024 Mapbox, Inc. All rights reserved.

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearch'
-  s.version          = '2.5.1'
+  s.version          = '2.6.0-beta.1'
   s.summary          = 'Search SDK for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.
@@ -24,6 +24,6 @@ Some iOS platform specifics applies.
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency "MapboxCoreSearch", '2.5.1'
-  s.dependency "MapboxCommon", '24.7.0'
+  s.dependency "MapboxCoreSearch", '2.6.0-beta.2'
+  s.dependency "MapboxCommon", '24.8.0-beta.1'
 end

--- a/MapboxSearch.xcodeproj/project.pbxproj
+++ b/MapboxSearch.xcodeproj/project.pbxproj
@@ -3660,7 +3660,7 @@
 			repositoryURL = "https://github.com/mapbox/mapbox-common-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 24.7.0;
+				version = "24.8.0-beta.1";
 			};
 		};
 		042BEB182C2DE30E0004CD7B /* XCRemoteSwiftPackageReference "mapbox-maps-ios" */ = {
@@ -3668,7 +3668,7 @@
 			repositoryURL = "https://github.com/mapbox/mapbox-maps-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 11.7.0;
+				version = "11.8.0-beta.1";
 			};
 		};
 		043339CB2C61295D001650FA /* XCRemoteSwiftPackageReference "atlantis" */ = {

--- a/MapboxSearchUI.podspec
+++ b/MapboxSearchUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearchUI'
-  s.version          = '2.5.1'
+  s.version          = '2.6.0-beta.1'
   s.summary          = 'Search UI for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.
@@ -23,5 +23,5 @@ Card style custom UI with full search functionality powered by Mapbox Search API
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency 'MapboxSearch', "2.5.1"
+  s.dependency 'MapboxSearch', "2.6.0-beta.1"
 end

--- a/Package.swift
+++ b/Package.swift
@@ -4,9 +4,9 @@
 import PackageDescription
 import Foundation
 
-let (coreSearchVersion, coreSearchVersionHash) = ("2.5.1", "f2b81b9ba4201f2de595913592aa947cae6e0e4b7bfe99fcb21e6b72e0a6cf72")
+let (coreSearchVersion, coreSearchVersionHash) = ("2.6.0-beta.2", "6acb85e76ff8028044c5d46004af4e3041899851ebb90aebb83be57e141560b6")
 
-let mapboxCommonSDKVersion = Version("24.7.0")
+let mapboxCommonSDKVersion = Version("24.8.0-beta.1")
 
 let package = Package(
     name: "MapboxSearch",

--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ dependencies: [
 ##### MapboxSearch
 To integrate latest pre-release version of `MapboxSearch` into your Xcode project using CocoaPods, specify it in your `Podfile`:
 ```
-pod 'MapboxSearch', ">= 2.5.1", "< 3.0"
+pod 'MapboxSearch', ">= 2.6.0-beta.1", "< 3.0"
 ```
 
 ##### MapboxSearchUI
 To integrate latest pre-release version of `MapboxSearchUI` into your Xcode project using CocoaPods, specify it in your `Podfile`:
 ```
-pod 'MapboxSearchUI', ">= 2.5.1", "< 3.0"
+pod 'MapboxSearchUI', ">= 2.6.0-beta.1", "< 3.0"
 ```
 
 ### Carthage
@@ -109,7 +109,7 @@ pod 'MapboxSearchUI', ">= 2.5.1", "< 3.0"
 2. Follow the [Carthage Quick Start](https://github.com/Carthage/Carthage?tab=readme-ov-file#quick-start) and specificy the MapboxSearch dependency in your `Cartfile`:
 
 ```
-github "Mapbox/mapbox-search-ios" ~> 2.5.1
+github "Mapbox/mapbox-search-ios" ~> 2.6.0-beta.1
 ```
 
 ## Contributing

--- a/Search Documentation.docc/Installation.md
+++ b/Search Documentation.docc/Installation.md
@@ -59,7 +59,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearchUI', ">= 2.5.1", "< 3.0"
+      pod 'MapboxSearchUI', ">= 2.6.0-beta.1", "< 3.0"
     end
     ```
 
@@ -68,7 +68,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearch', ">= 2.5.1", "< 3.0"
+      pod 'MapboxSearch', ">= 2.6.0-beta.1", "< 3.0"
     end
     ```
 

--- a/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
+++ b/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
@@ -1,2 +1,2 @@
 /// Mapbox Search SDK version variable
-public let mapboxSearchSDKVersion = "2.5.1"
+public let mapboxSearchSDKVersion = "2.6.0-beta.1"

--- a/Tests/MapboxSearchIntegrationTests/OfflineIntegrationTests.swift
+++ b/Tests/MapboxSearchIntegrationTests/OfflineIntegrationTests.swift
@@ -69,10 +69,19 @@ class OfflineIntegrationTests: MockServerIntegrationTestCase<SBSMockResponse> {
         clearData()
 
         // Set up index observer before the fetch starts to validate changes after it completes
-        let indexChangedExpectation = expectation(description: "Received offline index changed event")
+        let indexChanged_AddedExpectation = expectation(description: "Received offline index changed event, type=added")
+        let indexChanged_UpdatedExpectation =
+            expectation(description: "Received offline index changed event, type=updated")
         let offlineIndexObserver = OfflineIndexObserver(onIndexChangedBlock: { changeEvent in
             _Logger.searchSDK.info("Index changed: \(changeEvent)")
-            indexChangedExpectation.fulfill()
+            switch changeEvent.type {
+            case .added:
+                indexChanged_AddedExpectation.fulfill()
+            case .updated:
+                indexChanged_UpdatedExpectation.fulfill()
+            default:
+                return
+            }
         }, onErrorBlock: { error in
             _Logger.searchSDK.error("Encountered error in OfflineIndexObserver \(error)")
             XCTFail(error.debugDescription)
@@ -93,7 +102,7 @@ class OfflineIntegrationTests: MockServerIntegrationTestCase<SBSMockResponse> {
             loadDataExpectation.fulfill()
         }
         wait(
-            for: [loadDataExpectation, indexChangedExpectation],
+            for: [indexChanged_AddedExpectation, indexChanged_UpdatedExpectation, loadDataExpectation],
             timeout: 200,
             enforceOrder: true
         )
@@ -113,10 +122,19 @@ class OfflineIntegrationTests: MockServerIntegrationTestCase<SBSMockResponse> {
         clearData()
 
         // Set up index observer before the fetch starts to validate changes after it completes
-        let indexChangedExpectation = expectation(description: "Received offline index changed event")
+        let indexChanged_AddedExpectation = expectation(description: "Received offline index changed event, type=added")
+        let indexChanged_UpdatedExpectation =
+            expectation(description: "Received offline index changed event, type=updated")
         let offlineIndexObserver = OfflineIndexObserver(onIndexChangedBlock: { changeEvent in
             _Logger.searchSDK.info("Index changed: \(changeEvent)")
-            indexChangedExpectation.fulfill()
+            switch changeEvent.type {
+            case .added:
+                indexChanged_AddedExpectation.fulfill()
+            case .updated:
+                indexChanged_UpdatedExpectation.fulfill()
+            default:
+                return
+            }
         }, onErrorBlock: { error in
             _Logger.searchSDK.error("Encountered error in OfflineIndexObserver \(error)")
             XCTFail(error.debugDescription)
@@ -141,7 +159,7 @@ class OfflineIntegrationTests: MockServerIntegrationTestCase<SBSMockResponse> {
             loadDataExpectation.fulfill()
         }
         wait(
-            for: [loadDataExpectation, indexChangedExpectation],
+            for: [indexChanged_AddedExpectation, indexChanged_UpdatedExpectation, loadDataExpectation],
             timeout: 200,
             enforceOrder: true
         )
@@ -192,10 +210,19 @@ class OfflineIntegrationTests: MockServerIntegrationTestCase<SBSMockResponse> {
         clearData()
 
         // Set up index observer before the fetch starts to validate changes after it completes
-        let indexChangedExpectation = expectation(description: "Received offline index changed event")
+        let indexChanged_AddedExpectation = expectation(description: "Received offline index changed event, type=added")
+        let indexChanged_UpdatedExpectation =
+            expectation(description: "Received offline index changed event, type=updated")
         let offlineIndexObserver = OfflineIndexObserver(onIndexChangedBlock: { changeEvent in
             _Logger.searchSDK.info("Index changed: \(changeEvent)")
-            indexChangedExpectation.fulfill()
+            switch changeEvent.type {
+            case .added:
+                indexChanged_AddedExpectation.fulfill()
+            case .updated:
+                indexChanged_UpdatedExpectation.fulfill()
+            default:
+                return
+            }
         }, onErrorBlock: { error in
             _Logger.searchSDK.error("Encountered error in OfflineIndexObserver \(error)")
             XCTFail(error.debugDescription)
@@ -216,7 +243,7 @@ class OfflineIntegrationTests: MockServerIntegrationTestCase<SBSMockResponse> {
             loadDataExpectation.fulfill()
         }
         wait(
-            for: [loadDataExpectation, indexChangedExpectation],
+            for: [indexChanged_AddedExpectation, indexChanged_UpdatedExpectation, loadDataExpectation],
             timeout: 200,
             enforceOrder: true
         )

--- a/Tests/MapboxSearchTests/Legacy/UserRecordsLayerTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/UserRecordsLayerTests.swift
@@ -70,10 +70,19 @@ final class SearchBox_UserRecordsLayerTests: XCTestCase {
         wait(for: [setTileStoreExpectation], timeout: 10)
 
         // Set up index observer before the fetch starts to validate changes after it completes
-        let indexChangedExpectation = expectation(description: "Received offline index changed event")
+        let indexChanged_AddedExpectation = expectation(description: "Received offline index changed event, type=added")
+        let indexChanged_UpdatedExpectation =
+            expectation(description: "Received offline index changed event, type=updated")
         let offlineIndexObserver = OfflineIndexObserver(onIndexChangedBlock: { changeEvent in
             _Logger.searchSDK.info("Index changed: \(changeEvent)")
-            indexChangedExpectation.fulfill()
+            switch changeEvent.type {
+            case .added:
+                indexChanged_AddedExpectation.fulfill()
+            case .updated:
+                indexChanged_UpdatedExpectation.fulfill()
+            default:
+                return
+            }
         }, onErrorBlock: { error in
             _Logger.searchSDK.error("Encountered error in OfflineIndexObserver \(error)")
             XCTFail(error.debugDescription)
@@ -94,7 +103,7 @@ final class SearchBox_UserRecordsLayerTests: XCTestCase {
             loadDataExpectation.fulfill()
         }
         wait(
-            for: [loadDataExpectation, indexChangedExpectation],
+            for: [indexChanged_AddedExpectation, indexChanged_UpdatedExpectation, loadDataExpectation],
             timeout: 200,
             enforceOrder: true
         )


### PR DESCRIPTION
### Description

Release MapboxSearch and MapboxSearchUI v2.6.0-beta.1
- Update MapboxCommon v24.8.0-beta.1
- Update MapboxCoreSearch v2.6.0-beta.2

### Checklist
- [x] Update `CHANGELOG`
