### PR TITLE
Expose init for ResultChildMetadata with field values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
+- [ResultChildMetadata] Add ResultChildMetadata.init(category:coordinate:mapboxId:name)
+
 ## 2.6.0-rc.1
 
 - [Core] Update dependencies

--- a/Sources/MapboxSearch/PublicAPI/Search Results/ResultChildMetadata.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/ResultChildMetadata.swift
@@ -28,13 +28,13 @@ public struct ResultChildMetadata: Codable, Hashable {
     /// and a required `mapboxId`.
     ///
     /// - Parameters:
+    ///   - mapboxId: A required `String` that uniquely identifies the Mapbox object. This is a required
+    ///     parameter and must be provided during initialization.
+    ///   - name: An optional `String` representing the name of the result.
     ///   - category: An optional `String` representing the category of the result.
     ///   - coordinate: An optional `CLLocationCoordinate2D` representing the geographical location
     ///     associated with the result. If provided, it is transformed to a `CLLocationCoordinate2DCodable`
     ///     instance for storage.
-    ///   - mapboxId: A required `String` that uniquely identifies the Mapbox object. This is a required
-    ///     parameter and must be provided during initialization.
-    ///   - name: An optional `String` representing the name of the result.
     public init(
         mapboxId: String,
         name: String? = nil,

--- a/Sources/MapboxSearch/PublicAPI/Search Results/ResultChildMetadata.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/ResultChildMetadata.swift
@@ -24,11 +24,22 @@ public struct ResultChildMetadata: Codable, Hashable {
         self.name = resultChildMetadata.name
     }
 
+    /// Initializes a new instance of `ResultChildMetadata` with optional category, coordinates, and name,
+    /// and a required `mapboxId`.
+    ///
+    /// - Parameters:
+    ///   - category: An optional `String` representing the category of the result.
+    ///   - coordinate: An optional `CLLocationCoordinate2D` representing the geographical location
+    ///     associated with the result. If provided, it is transformed to a `CLLocationCoordinate2DCodable`
+    ///     instance for storage.
+    ///   - mapboxId: A required `String` that uniquely identifies the Mapbox object. This is a required
+    ///     parameter and must be provided during initialization.
+    ///   - name: An optional `String` representing the name of the result.
     public init(
-        category: String? = nil,
-        coordinate: CLLocationCoordinate2D? = nil,
         mapboxId: String,
-        name: String? = nil
+        name: String? = nil,
+        category: String? = nil,
+        coordinate: CLLocationCoordinate2D? = nil
     ) {
         self.category = category
         self.coordinatesCodable = coordinate.map(CLLocationCoordinate2DCodable.init)

--- a/Sources/MapboxSearch/PublicAPI/Search Results/ResultChildMetadata.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/ResultChildMetadata.swift
@@ -23,4 +23,16 @@ public struct ResultChildMetadata: Codable, Hashable {
         }
         self.name = resultChildMetadata.name
     }
+
+    public init(
+        category: String? = nil,
+        coordinate: CLLocationCoordinate2D? = nil,
+        mapboxId: String,
+        name: String? = nil
+    ) {
+        self.category = category
+        self.coordinatesCodable = coordinate.map(CLLocationCoordinate2DCodable.init)
+        self.mapboxId = mapboxId
+        self.name = name
+    }
 }


### PR DESCRIPTION
### Description

This PR expose `ResultChildMetadata/init(category:coordinate:mapboxId:name)`, that is needed for https://github.com/mapbox/navigation/pull/7195

### Checklist
- [ ] Update `CHANGELOG`
