### PR TITLE
Update MapboxCoreSearch to v2.6.0, MapboxCommon v24.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
+- [Core] Update dependencies
+
+**MapboxCommon**: v24.8.0
+**MapboxCoreSearch**: v2.6.0
+
 ## 2.6.0-rc.1
 
 - [Core] Update dependencies

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.6.0-rc.1
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.8.0-rc.1
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.6.0
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.8.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.8.0-rc.1"
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.6.0-rc.1"
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.8.0"
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.6.0"

--- a/MapboxSearch.xcodeproj/project.pbxproj
+++ b/MapboxSearch.xcodeproj/project.pbxproj
@@ -3660,7 +3660,7 @@
 			repositoryURL = "https://github.com/mapbox/mapbox-common-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = "24.8.0-rc.1";
+				version = 24.8.0;
 			};
 		};
 		042BEB182C2DE30E0004CD7B /* XCRemoteSwiftPackageReference "mapbox-maps-ios" */ = {
@@ -3668,7 +3668,7 @@
 			repositoryURL = "https://github.com/mapbox/mapbox-maps-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = "11.8.0-rc.1";
+				version = 11.8.0;
 			};
 		};
 		043339CB2C61295D001650FA /* XCRemoteSwiftPackageReference "atlantis" */ = {

--- a/Package.swift
+++ b/Package.swift
@@ -4,9 +4,9 @@
 import PackageDescription
 import Foundation
 
-let (coreSearchVersion, coreSearchVersionHash) = ("2.6.0-rc.1", "c59170343520ecbb3ff104e1a85b8d242c8e5784219e569137ea6812c713e077")
+let (coreSearchVersion, coreSearchVersionHash) = ("2.6.0", "44c8215e1b0e33b5ea6ce1f2147dd918f2d53a908992f5eed80c4577b36faf00")
 
-let mapboxCommonSDKVersion = Version("24.8.0-rc.1")
+let mapboxCommonSDKVersion = Version("24.8.0")
 
 let package = Package(
     name: "MapboxSearch",


### PR DESCRIPTION
### Description

- Update MapboxCoreSearch v2.6.0
- Update MapboxCommon v24.8.0

### Checklist
- [x] Update `CHANGELOG`
