### PR TITLE
Update dependencies for 2.6.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 ## 2.6.1
 
+- [Core] Fix the OpenHours parsing logic for SearchBox.
+- [Core] Fix the issue with setting OpenHours mode when there is only one open hour period.
 - [ResultChildMetadata] Add ResultChildMetadata.init(category:coordinate:mapboxId:name)
 - [Core] Update dependencies
 
-**MapboxCoreSearch**: v2.6.1
+**MapboxCoreSearch**: v2.6.2
 
 ## 2.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 <!-- Add changes for active work here -->
 
+## 2.6.1
+
 - [ResultChildMetadata] Add ResultChildMetadata.init(category:coordinate:mapboxId:name)
+- [Core] Update dependencies
+
+**MapboxCoreSearch**: v2.6.1
 
 ## 2.6.0
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.6.1
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.6.2
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.8.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.6.0
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.6.1
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.8.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.8.0"
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.6.1"
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.6.2"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.8.0"
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.6.0"
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.6.1"

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 ## License
 
-Mapbox Search for iOS version 2.6.0
+Mapbox Search for iOS version 2.6.1
 Mapbox Search iOS SDK
 
 Copyright © 2021 - 2024 Mapbox, Inc. All rights reserved.

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -24,6 +24,6 @@ Some iOS platform specifics applies.
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency "MapboxCoreSearch", '2.6.1'
+  s.dependency "MapboxCoreSearch", '2.6.2'
   s.dependency "MapboxCommon", '24.8.0'
 end

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearch'
-  s.version          = '2.6.0'
+  s.version          = '2.6.1'
   s.summary          = 'Search SDK for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.
@@ -24,6 +24,6 @@ Some iOS platform specifics applies.
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency "MapboxCoreSearch", '2.6.0'
+  s.dependency "MapboxCoreSearch", '2.6.1'
   s.dependency "MapboxCommon", '24.8.0'
 end

--- a/MapboxSearchUI.podspec
+++ b/MapboxSearchUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearchUI'
-  s.version          = '2.6.0'
+  s.version          = '2.6.1'
   s.summary          = 'Search UI for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.
@@ -23,5 +23,5 @@ Card style custom UI with full search functionality powered by Mapbox Search API
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency 'MapboxSearch', "2.6.0"
+  s.dependency 'MapboxSearch', "2.6.1"
 end

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 import Foundation
 
-let (coreSearchVersion, coreSearchVersionHash) = ("2.6.1", "bcb2e718ab46e36d8b1d7ed2d93bccf0dbf13354591fafd7c9ffc49f275218c6")
+let (coreSearchVersion, coreSearchVersionHash) = ("2.6.2", "6957c3b8ae16f7a3f85f55a97eeb3dbeb663aa02bc041577236ec3a725eb31df")
 
 let mapboxCommonSDKVersion = Version("24.8.0")
 

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 import Foundation
 
-let (coreSearchVersion, coreSearchVersionHash) = ("2.6.0", "44c8215e1b0e33b5ea6ce1f2147dd918f2d53a908992f5eed80c4577b36faf00")
+let (coreSearchVersion, coreSearchVersionHash) = ("2.6.1", "bcb2e718ab46e36d8b1d7ed2d93bccf0dbf13354591fafd7c9ffc49f275218c6")
 
 let mapboxCommonSDKVersion = Version("24.8.0")
 

--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ dependencies: [
 ##### MapboxSearch
 To integrate latest pre-release version of `MapboxSearch` into your Xcode project using CocoaPods, specify it in your `Podfile`:
 ```
-pod 'MapboxSearch', ">= 2.6.0", "< 3.0"
+pod 'MapboxSearch', ">= 2.6.1", "< 3.0"
 ```
 
 ##### MapboxSearchUI
 To integrate latest pre-release version of `MapboxSearchUI` into your Xcode project using CocoaPods, specify it in your `Podfile`:
 ```
-pod 'MapboxSearchUI', ">= 2.6.0", "< 3.0"
+pod 'MapboxSearchUI', ">= 2.6.1", "< 3.0"
 ```
 
 ### Carthage
@@ -109,7 +109,7 @@ pod 'MapboxSearchUI', ">= 2.6.0", "< 3.0"
 2. Follow the [Carthage Quick Start](https://github.com/Carthage/Carthage?tab=readme-ov-file#quick-start) and specificy the MapboxSearch dependency in your `Cartfile`:
 
 ```
-github "Mapbox/mapbox-search-ios" ~> 2.6.0
+github "Mapbox/mapbox-search-ios" ~> 2.6.1
 ```
 
 ## Contributing

--- a/Search Documentation.docc/Installation.md
+++ b/Search Documentation.docc/Installation.md
@@ -59,7 +59,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearchUI', ">= 2.6.0", "< 3.0"
+      pod 'MapboxSearchUI', ">= 2.6.1", "< 3.0"
     end
     ```
 
@@ -68,7 +68,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearch', ">= 2.6.0", "< 3.0"
+      pod 'MapboxSearch', ">= 2.6.1", "< 3.0"
     end
     ```
 

--- a/Sources/Demo/Examples/ContinuousSearchViewController.swift
+++ b/Sources/Demo/Examples/ContinuousSearchViewController.swift
@@ -2,7 +2,7 @@ import MapboxSearch
 import UIKit
 
 class ContinuousSearchViewController: TextViewLoggerViewController {
-    let searchEngine = SearchEngine()
+    let searchEngine = SearchEngine(apiType: .searchBox)
     let textField = UITextField()
     let responseLabel = UILabel()
 

--- a/Sources/Demo/Examples/MapboxBoundingBoxController.swift
+++ b/Sources/Demo/Examples/MapboxBoundingBoxController.swift
@@ -4,7 +4,7 @@ import MapboxSearch
 import UIKit
 
 class MapboxBoundingBoxController: MapsViewController {
-    let searchEngine = CategorySearchEngine()
+    let searchEngine = CategorySearchEngine(apiType: .searchBox)
 
     let mapboxSFOfficeCoordinate = CLLocationCoordinate2D(latitude: 37.7911551, longitude: -122.3966103)
 

--- a/Sources/Demo/Examples/MapboxMapsCategoryResultsViewController.swift
+++ b/Sources/Demo/Examples/MapboxMapsCategoryResultsViewController.swift
@@ -2,7 +2,7 @@ import MapboxSearch
 import UIKit
 
 class MapboxMapsCategoryResultsViewController: MapsViewController {
-    let searchEngine = CategorySearchEngine()
+    let searchEngine = CategorySearchEngine(apiType: .searchBox)
 //    let searchEngine = CategorySearchEngine(accessToken: "<#You can pass access token manually#>")
 
     override func viewDidAppear(_ animated: Bool) {

--- a/Sources/Demo/Examples/SimpleListSearchViewController.swift
+++ b/Sources/Demo/Examples/SimpleListSearchViewController.swift
@@ -2,7 +2,7 @@ import MapboxSearch
 import UIKit
 
 class SimpleListSearchViewController: MapsViewController {
-    let searchEngine = SearchEngine()
+    let searchEngine = SearchEngine(apiType: .searchBox)
 //    let searchEngine = SearchEngine(accessToken: "<#You can pass access token manually#>")
 
     override func viewDidLoad() {

--- a/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
+++ b/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
@@ -1,2 +1,2 @@
 /// Mapbox Search SDK version variable
-public let mapboxSearchSDKVersion = "2.6.0"
+public let mapboxSearchSDKVersion = "2.6.1"


### PR DESCRIPTION
### Description
Update dependencies for 2.6.1 iOS SDK release to support the Core Search OpenHours fix

### Checklist
- [x] Update `CHANGELOG`
