### PR TITLE
Fix non-sending feedback event for the query search result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 ## 2.7.0-rc.1
 
-- [Core] Update dependencies
+- [Core] Update dependencies.
+- [Tech] Support sending feedback events to Telemetry.
 
 **MapboxCommon**: v24.9.0-rc.1
 **MapboxCoreSearch**: v2.7.0-rc.1

--- a/MapboxSearch.xcodeproj/project.pbxproj
+++ b/MapboxSearch.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 		2C705F062A137CEB00B8B773 /* SearchNavigationProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C705F052A137CEB00B8B773 /* SearchNavigationProfile.swift */; };
 		2C7FEBFA2CE78E6300B7ED22 /* PointAnnotation+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7FEBF92CE78E6300B7ED22 /* PointAnnotation+Search.swift */; };
 		2C7FEBFC2CE7A62C00B7ED22 /* MapView+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7FEBFB2CE7A62C00B7ED22 /* MapView+Search.swift */; };
+		2C88C6532D0C62ED00F46FBF /* EventsServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88C6522D0C62ED00F46FBF /* EventsServiceProtocol.swift */; };
 		2CA1E22129F09CD200A533CF /* PlaceAutocomplete.Suggestion+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA1E22029F09CD200A533CF /* PlaceAutocomplete.Suggestion+Tests.swift */; };
 		2CA1E22329F0A47600A533CF /* PlaceAutocompleteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA1E22229F0A47600A533CF /* PlaceAutocompleteTests.swift */; };
 		2CD6C03C29F1982100D865D1 /* EventsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD6C03B29F1982100D865D1 /* EventsManagerTests.swift */; };
@@ -666,6 +667,7 @@
 		2C705F052A137CEB00B8B773 /* SearchNavigationProfile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchNavigationProfile.swift; sourceTree = "<group>"; };
 		2C7FEBF92CE78E6300B7ED22 /* PointAnnotation+Search.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PointAnnotation+Search.swift"; sourceTree = "<group>"; };
 		2C7FEBFB2CE7A62C00B7ED22 /* MapView+Search.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MapView+Search.swift"; sourceTree = "<group>"; };
+		2C88C6522D0C62ED00F46FBF /* EventsServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsServiceProtocol.swift; sourceTree = "<group>"; };
 		2CA1E22029F09CD200A533CF /* PlaceAutocomplete.Suggestion+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaceAutocomplete.Suggestion+Tests.swift"; sourceTree = "<group>"; };
 		2CA1E22229F0A47600A533CF /* PlaceAutocompleteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceAutocompleteTests.swift; sourceTree = "<group>"; };
 		2CD6C03B29F1982100D865D1 /* EventsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsManagerTests.swift; sourceTree = "<group>"; };
@@ -1721,6 +1723,7 @@
 			isa = PBXGroup;
 			children = (
 				F97FA23F25C95ACD0085A311 /* EventAppMetadata.swift */,
+				2C88C6522D0C62ED00F46FBF /* EventsServiceProtocol.swift */,
 			);
 			path = Telemetry;
 			sourceTree = "<group>";
@@ -2687,6 +2690,7 @@
 				FEEDD2F82508DFE400DC0A98 /* RecordsProviderInteractorNativeCore.swift in Sources */,
 				F97E9A84268C7BBE00F6353D /* DefaultStringInterpolation+Extensions.swift in Sources */,
 				14FA657F295355BC00056E5B /* AdministrativeUnits.swift in Sources */,
+				2C88C6532D0C62ED00F46FBF /* EventsServiceProtocol.swift in Sources */,
 				F9274FF227394AE600708F37 /* TileRegionError.swift in Sources */,
 				FE1064F525B9A1C9007837BC /* NavigationOptions.swift in Sources */,
 				148DE668285755500085684D /* AddressAutofill+Suggestion.swift in Sources */,

--- a/Sources/Demo/MapRootController.swift
+++ b/Sources/Demo/MapRootController.swift
@@ -89,7 +89,7 @@ class MapRootController: UIViewController {
 
     @discardableResult
     private func present(result: SearchResult) -> Bool {
-        let detailController = ResultDetailViewController(result: result)
+        let detailController = ResultDetailViewController(result: result, searchEngine: searchController.searchEngine)
         present(detailController, animated: true)
         return true
     }

--- a/Sources/Demo/PlaceAutocompleteMainViewController.swift
+++ b/Sources/Demo/PlaceAutocompleteMainViewController.swift
@@ -24,8 +24,8 @@ final class PlaceAutocompleteMainViewController: UIViewController {
 
 extension PlaceAutocompleteMainViewController: UISearchResultsUpdating {
     func updateSearchResults(for searchController: UISearchController) {
-        guard
-            let text = searchController.searchBar.text
+        guard let text = searchController.searchBar.text,
+              !text.isEmpty
         else {
             cachedSuggestions = []
 

--- a/Sources/MapboxSearch/InternalAPI/Telemetry/EventsServiceProtocol.swift
+++ b/Sources/MapboxSearch/InternalAPI/Telemetry/EventsServiceProtocol.swift
@@ -1,0 +1,8 @@
+import Foundation
+import MapboxCommon_Private
+
+protocol EventsServiceProtocol {
+    func sendEvent(for event: Event, callback: EventsServiceResponseCallback?)
+}
+
+extension EventsService: EventsServiceProtocol { }

--- a/Sources/MapboxSearch/PublicAPI/Telemetry/FeedbackManager.swift
+++ b/Sources/MapboxSearch/PublicAPI/Telemetry/FeedbackManager.swift
@@ -22,6 +22,7 @@ public class FeedbackManager {
         attributes["queryString"] = attributePlaceholder
         attributes["resultId"] = feedbackAttributes.id
         attributes["selectedItemName"] = feedbackAttributes.name
+        attributes["sessionIdentifier"] = attributePlaceholder
 
         if let coordinate = feedbackAttributes.coordinate {
             attributes["resultCoordinates"] = [coordinate.longitude, coordinate.latitude]
@@ -65,7 +66,9 @@ public class FeedbackManager {
             attributes["proximity"] = [proximity.value.longitude, proximity.value.latitude]
         }
 
-        attributes["responseUuid"] = response.responseUUID
+        if !response.responseUUID.isEmpty {
+            attributes["responseUuid"] = response.responseUUID
+        }
 
         // Result parameters
         // Mandatory field set -1 if no data available
@@ -185,12 +188,9 @@ public class FeedbackManager {
             try delegate.engine.makeFeedbackEvent(
                 request: response.request,
                 result: nil,
-                callback: { [eventsManager] eventTemplateName in
+                callback: { [eventsManager] eventJson in
                     do {
-                        let attributes = try eventsManager.prepareEventTemplate(
-                            eventTemplateName
-                        ).attributes
-
+                        let attributes = try eventsManager.prepareEventTemplate(eventJson)
                         completion(attributes)
                     } catch {
                         _Logger.searchSDK.error(
@@ -208,7 +208,7 @@ public class FeedbackManager {
                     do {
                         let attributes = try eventsManager.prepareEventTemplate(
                             eventTemplateName
-                        ).attributes
+                        )
 
                         completion(attributes)
                     } catch {

--- a/Tests/MapboxSearchTests/Telemetry/EventsManagerTests.swift
+++ b/Tests/MapboxSearchTests/Telemetry/EventsManagerTests.swift
@@ -1,13 +1,25 @@
 @testable import MapboxSearch
+import MapboxCommon_Private
 import XCTest
+
+final class EventsServiceMock: EventsServiceProtocol {
+    var events: [Event] = []
+
+    func sendEvent(for event: Event, callback: EventsServiceResponseCallback?) {
+        events.append(event)
+        callback?(.init(value: NSNull()))
+    }
+}
 
 final class EventsManagerTests: XCTestCase {
     var eventsManager: EventsManager!
+    var eventsService: EventsServiceMock!
 
     override func setUp() {
         super.setUp()
 
-        eventsManager = EventsManager()
+        eventsService = EventsServiceMock()
+        eventsManager = EventsManager(eventsService: eventsService)
     }
 
     func testUserAgent() {
@@ -17,5 +29,21 @@ final class EventsManagerTests: XCTestCase {
     func testPrepareEventTemplate() {
         let event = eventsManager.prepareEventTemplate(for: "templateEvent")
         XCTAssertEqual(event["userAgent"] as? String, "search-sdk-ios/\(mapboxSearchSDKVersion)")
+    }
+
+    func testSendEvent() {
+        let attributes = ["a": "b", "mapboxId": "value"]
+        let expectedAttributes = ["a": "b", "event": "search.feedback"]
+
+        eventsManager.sendEvent(.feedback, attributes: attributes, autoFlush: true)
+        let sentEvent1 = eventsService.events[0]
+        XCTAssertEqual(sentEvent1.priority, .immediate)
+        XCTAssertEqual(sentEvent1.attributes as? [String: String], expectedAttributes)
+        XCTAssertNil(sentEvent1.deferredOptions)
+
+        eventsManager.sendEvent(.feedback, attributes: attributes, autoFlush: false)
+        let sentEvent2 = eventsService.events[1]
+        XCTAssertEqual(sentEvent2.priority, .queued)
+
     }
 }


### PR DESCRIPTION
### Description
Partially fixes [#NAVIOS-2037](https://mapbox.atlassian.net/browse/NAVIOS-2037)

* Added support for feedback sending.
* Added the ability to send feedback for selected search result to the sample app.

The Android Search SDK [already supported the feedback](https://github.com/mapbox/mapbox-search-android/blob/b7240b1601d0419f2d094260effea5c78b3fe767/MapboxSearch/sdk/src/main/java/com/mapbox/search/analytics/AnalyticsServiceImpl.kt#L197).

### Checklist
- [x] Update `CHANGELOG`
