### PR TITLE
Fix MapboxCoreSearch framework connection with the sample app to fix runtime sample crash on a real device

### DIFF
--- a/MapboxSearch.xcodeproj/project.pbxproj
+++ b/MapboxSearch.xcodeproj/project.pbxproj
@@ -153,6 +153,8 @@
 		14FBBBAF2881673E00721935 /* AddressAutofill.Query+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14FBBBAE2881673E00721935 /* AddressAutofill.Query+Tests.swift */; };
 		2C10133429F1C6200094413F /* PlaceAutocompleteIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C10133329F1C6200094413F /* PlaceAutocompleteIntegrationTests.swift */; };
 		2C18E9F429F0A83900FD96E6 /* PlaceAutocompleteSuggestionStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C18E9F229F0A82E00FD96E6 /* PlaceAutocompleteSuggestionStub.swift */; };
+		2C52F3842D396FB3006B8F0E /* MapboxCoreSearch.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E648C0B526428D2B0044315F /* MapboxCoreSearch.xcframework */; };
+		2C52F3852D396FB3006B8F0E /* MapboxCoreSearch.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E648C0B526428D2B0044315F /* MapboxCoreSearch.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		2C705F062A137CEB00B8B773 /* SearchNavigationProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C705F052A137CEB00B8B773 /* SearchNavigationProfile.swift */; };
 		2C7FEBFA2CE78E6300B7ED22 /* PointAnnotation+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7FEBF92CE78E6300B7ED22 /* PointAnnotation+Search.swift */; };
 		2C7FEBFC2CE7A62C00B7ED22 /* MapView+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7FEBFB2CE7A62C00B7ED22 /* MapView+Search.swift */; };
@@ -552,6 +554,7 @@
 			dstSubfolderSpec = 10;
 			files = (
 				FEBC00DB243C6D32000B268B /* MapboxSearch.framework in Embed Frameworks */,
+				2C52F3852D396FB3006B8F0E /* MapboxCoreSearch.xcframework in Embed Frameworks */,
 				FEBC00DF243C6D32000B268B /* MapboxSearchUI.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -1015,6 +1018,7 @@
 				043339CD2C61295D001650FA /* Atlantis in Frameworks */,
 				042BEB1A2C2DE30E0004CD7B /* MapboxMaps in Frameworks */,
 				FEBC00DA243C6D32000B268B /* MapboxSearch.framework in Frameworks */,
+				2C52F3842D396FB3006B8F0E /* MapboxCoreSearch.xcframework in Frameworks */,
 				FEBC00DE243C6D32000B268B /* MapboxSearchUI.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1132,15 +1136,6 @@
 			path = Resources;
 			sourceTree = "<group>";
 		};
-		04A26C632C75359B00443527 /* SearchRequest */ = {
-			isa = PBXGroup;
-			children = (
-				049FE3A72C6A50BB00F54FB2 /* RetrieveOptions.swift */,
-				04A26C642C7535BD00443527 /* DetailsOptions.swift */,
-			);
-			path = SearchRequest;
-			sourceTree = "<group>";
-		};
 		0498A7412CB4866E008F8903 /* Forward */ = {
 			isa = PBXGroup;
 			children = (
@@ -1149,6 +1144,15 @@
 				046D17142CB587190038F38E /* ForwardExampleSearchEngine.swift */,
 			);
 			name = Forward;
+			sourceTree = "<group>";
+		};
+		04A26C632C75359B00443527 /* SearchRequest */ = {
+			isa = PBXGroup;
+			children = (
+				049FE3A72C6A50BB00F54FB2 /* RetrieveOptions.swift */,
+				04A26C642C7535BD00443527 /* DetailsOptions.swift */,
+			);
+			path = SearchRequest;
 			sourceTree = "<group>";
 		};
 		04C127562B62FFD000884325 /* Engine */ = {


### PR DESCRIPTION
### Description

This pull request contains fixes only in the sample app and doesn't change the SDK behavior.

The MapboxCoreSearch changed its format. Since v2.7.0-beta.1 it is a dynamic library (`Mach-O 64-bit dynamically linked shared library arm64`) instead of previously used a static library (`current ar archive`). 

This change causes the runtime crash in the sample app due to the not loaded dynamic library MapboxCoreSearch. 

This is because the library MapboxCoreSearch was not linked to the sample. MapboxCommon was linked because the sample target was linked with the Maps SDK, which depends on MapboxCommon.

The sample app does not use SPM for MapboxSearch dependency, it is manually linked with the libraries instead. This approach is used to enable additional build phases for MapboxSearch targets, e.g. SwiftLint, `scripts/generate_sdk_version_swift.sh` call. 

So the simplest fix here is to manually link the library MapboxCoreSearch. This will help to keep all the configured builds working, whilst replacing it with the SPM dependencies will require the sample project to be restructured.  


### Checklist
- [ ] Update `CHANGELOG`
