### PR TITLE
Deprecate SBS ApiType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+- [Core] `ApiType.SBS` is deprecated. Use other `ApiType` values that better suit your use case.
+- [Core] `ApiType.default` is deprecated. Specify `ApiType` explicitly instead.
+- [PlaceAutocomplete] `PlaceAutocomplete` now uses `ApiType.searchBox`.
+- [Discover] `PlaceAutocomplete` now uses `ApiType.searchBox`.
+
 ## 2.8.0
 
 - [Core] Update dependencies.

--- a/SearchUI Documentation.docc/GettingStarted.md
+++ b/SearchUI Documentation.docc/GettingStarted.md
@@ -19,13 +19,13 @@ First, to start Search UI integration, you have to instantiate ``MapboxSearchCon
 **Option 1**:
 
 ```swift
-let searchController = MapboxSearchController()
+let searchController = MapboxSearchController(apiType: .searchBox)
 ```
 
 **Option 2**:
 
 ```swift
-let searchController = MapboxSearchController(accessToken: "YOUR_TOKEN")
+let searchController = MapboxSearchController(apiType: .searchBox, accessToken: "YOUR_TOKEN")
 ```
 
 To control data flow, implement ``SearchControllerDelegate`` and assign ``MapboxSearchController/delegate``. That protocol has next required methods:

--- a/Sources/Demo/Examples/SimpleUISearchViewController.swift
+++ b/Sources/Demo/Examples/SimpleUISearchViewController.swift
@@ -14,7 +14,7 @@ class SimpleUISearchViewController: MapsViewController {
             distanceFormatter: formatter
         )
 
-        return MapboxSearchController(configuration: configuration)
+        return MapboxSearchController(apiType: .searchBox, configuration: configuration)
     }()
 
     lazy var panelController = MapboxPanelController(rootViewController: searchController)

--- a/Sources/Demo/MapRootController.swift
+++ b/Sources/Demo/MapRootController.swift
@@ -5,7 +5,7 @@ import UIKit
 
 /// Entry point for Demo app "SearchUI" tab
 class MapRootController: UIViewController {
-    private lazy var searchController = MapboxSearchController()
+    private lazy var searchController = MapboxSearchController(apiType: .searchBox)
 
     private var mapView = MapView(frame: .zero)
     lazy var annotationsManager = mapView.annotations.makePointAnnotationManager()

--- a/Sources/Demo/Offline/OfflineDemoViewController.swift
+++ b/Sources/Demo/Offline/OfflineDemoViewController.swift
@@ -10,7 +10,7 @@ class OfflineDemoViewController: UIViewController {
     lazy var annotationsManager = mapView.makeClusterPointAnnotationManager()
     private var messageLabel = UILabel()
 
-    private lazy var searchController = MapboxSearchController()
+    private lazy var searchController = MapboxSearchController(apiType: .searchBox)
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Sources/Demo/UIComponents/PointAnnotation+Search.swift
+++ b/Sources/Demo/UIComponents/PointAnnotation+Search.swift
@@ -38,7 +38,7 @@ extension PointAnnotation {
         point.textField = name
         point.textHaloColor = .init(.white)
         point.textHaloWidth = 10
-        if let imageName, let image = UIImage(named: "pin") {
+        if let imageName, let image = UIImage(named: imageName) {
             point.iconAnchor = .bottom
             point.textAnchor = .top
             point.image = .init(image: image, name: "pin")

--- a/Sources/MapboxSearch/PublicAPI/Engine/AbstractSearchEngine.swift
+++ b/Sources/MapboxSearch/PublicAPI/Engine/AbstractSearchEngine.swift
@@ -9,7 +9,7 @@ public protocol AbstractSearchEngineConfiguration {
     static var `default`: Self { get }
 }
 
-/// Common root for `SearchEngine` and `CategorySearchEngine`.
+/// Common root for ``SearchEngine`` and ``CategorySearchEngine``.
 /// Should never be instantiated directly
 public class AbstractSearchEngine: FeedbackManagerDelegate {
     var dataLayerProviders: [IndexableDataProvider] = []
@@ -49,21 +49,20 @@ public class AbstractSearchEngine: FeedbackManagerDelegate {
 
     /// Basic internal initializer
     /// - Parameters:
-    ///   - accessToken: Mapbox Access Token to be used. Info.plist value for key `MGLMapboxAccessToken` will be used
-    /// for `nil` argument
-    ///   - serviceProvider: Internal `ServiceProvider` for sharing common dependencies like favoritesService or
-    /// eventsManager
-    ///   - locationProvider: Provider configuration of LocationProvider that would grant location data by default
-    ///   - defaultSearchOptions: A SearchOptions instance that will be used for every search function. This value can
+    ///   - accessToken: Mapbox Access Token to be used. Info.plist value for key `MBXAccessToken` will be used for `nil` argument.
+    ///   - serviceProvider: Internal ``ServiceProvider`` for sharing common dependencies like favoritesService or
+    /// eventsManager.
+    ///   - locationProvider: Provider configuration of ``LocationProvider`` that would grant location data by default.
+    ///   - defaultSearchOptions: A ``SearchOptions`` instance that will be used for every search function. This value can
     /// be overridden by any search function's SearchOptions parameter.
-    ///   - apiType: choose which API provider to use through this search engine. Currently defaults to SBS.
+    ///   - apiType: Choose which API provider to use through this search engine.
     ///   - baseURL: A custom Mapbox API endpoint.
     init(
         accessToken: String? = nil,
         serviceProvider: ServiceProviderProtocol & EngineProviderProtocol,
         locationProvider: LocationProvider? = DefaultLocationProvider(),
         defaultSearchOptions: SearchOptions = SearchOptions(),
-        apiType: ApiType = .defaultType,
+        apiType: ApiType,
         baseURL: URL? = nil
     ) {
         guard let accessToken = accessToken ?? serviceProvider.getStoredAccessToken() else {
@@ -111,16 +110,16 @@ public class AbstractSearchEngine: FeedbackManagerDelegate {
 
     /// Initializer with safe-to-go defaults
     /// - Parameters:
-    ///   - accessToken: Mapbox Access Token to be used. Info.plist value for key `MGLMapboxAccessToken` will be used
-    /// for `nil` argument
-    ///   - locationProvider: Provider configuration of LocationProvider that would grant location data by default
-    ///   - defaultSearchOptions: Default options to use when `nil` was passed to the `search(…: options:)` call
-    ///   - apiType: choose which API provider to use through this search engine. Currently defaults to SBS.
+    ///   - accessToken: Mapbox Access Token to be used. Info.plist value for key `MBXAccessToken` will be used
+    /// for `nil` argument.
+    ///   - locationProvider: Provider configuration of LocationProvider that would grant location data by default.
+    ///   - defaultSearchOptions: Default options to use when `nil` was passed to the `search(…: options:)` call/
+    ///   - apiType: Choose which API provider to use through this search engine.
     public convenience init(
         accessToken: String? = nil,
         locationProvider: LocationProvider? = DefaultLocationProvider(),
         defaultSearchOptions: SearchOptions = SearchOptions(),
-        apiType: ApiType = .defaultType
+        apiType: ApiType
     ) {
         self.init(
             accessToken: accessToken,
@@ -133,17 +132,38 @@ public class AbstractSearchEngine: FeedbackManagerDelegate {
 
     /// Initializer with safe-to-go defaults
     /// - Parameters:
-    ///   - accessToken: Mapbox Access Token to be used. Info.plist value for key `MGLMapboxAccessToken` will be used
-    /// for `nil` argument
-    ///   - locationProvider: Provider configuration of LocationProvider that would grant location data by default
+    ///   - accessToken: Mapbox Access Token to be used. Info.plist value for key `MBXAccessToken` will be used
+    /// for `nil` argument.
+    ///   - locationProvider: Provider configuration of LocationProvider that would grant location data by default.
+    ///   - defaultSearchOptions: Default options to use when `nil` was passed to the `search(…: options:)` call.
+    @available(*, deprecated, message: "Specify ApiType explicitly instead.")
+    public convenience init(
+        accessToken: String? = nil,
+        locationProvider: LocationProvider? = DefaultLocationProvider(),
+        defaultSearchOptions: SearchOptions = SearchOptions()
+    ) {
+        self.init(
+            accessToken: accessToken,
+            serviceProvider: ServiceProvider.shared,
+            locationProvider: locationProvider,
+            defaultSearchOptions: defaultSearchOptions,
+            apiType: .defaultType
+        )
+    }
+
+    /// Initializer with safe-to-go defaults.
+    /// - Parameters:
+    ///   - accessToken: Mapbox Access Token to be used. Info.plist value for key `MBXAccessToken` will be used
+    ///   for `nil` argument.
+    ///   - locationProvider: Provider configuration of `LocationProvider` that would grant location data by default.
     ///   - defaultSearchOptions: Default options to use when `nil` was passed to the `search(…: options:)` call
-    ///   - apiType: choose which API provider to use through this search engine. Currently defaults to SBS.
+    ///   - apiType: choose which API provider to use through this search engine.
     ///   - baseURL: A custom Mapbox API endpoint.
     public convenience init(
         accessToken: String? = nil,
         locationProvider: LocationProvider? = DefaultLocationProvider(),
         defaultSearchOptions: SearchOptions = SearchOptions(),
-        apiType: ApiType = .defaultType,
+        apiType: ApiType,
         baseURL: URL
     ) {
         self.init(
@@ -152,6 +172,30 @@ public class AbstractSearchEngine: FeedbackManagerDelegate {
             locationProvider: locationProvider,
             defaultSearchOptions: defaultSearchOptions,
             apiType: apiType,
+            baseURL: baseURL
+        )
+    }
+
+    /// Initializer with safe-to-go defaults.
+    /// - Parameters:
+    ///   - accessToken: Mapbox Access Token to be used. Info.plist value for key `MBXAccessToken` will be used
+    ///   for `nil` argument.
+    ///   - locationProvider: Provider configuration of `LocationProvider` that would grant location data by default.
+    ///   - defaultSearchOptions: Default options to use when `nil` was passed to the `search(…: options:)` call.
+    ///   - baseURL: A custom Mapbox API endpoint.
+    @available(*, deprecated, message: "Specify ApiType explicitly instead.")
+    public convenience init(
+        accessToken: String? = nil,
+        locationProvider: LocationProvider? = DefaultLocationProvider(),
+        defaultSearchOptions: SearchOptions = SearchOptions(),
+        baseURL: URL
+    ) {
+        self.init(
+            accessToken: accessToken,
+            serviceProvider: ServiceProvider.shared,
+            locationProvider: locationProvider,
+            defaultSearchOptions: defaultSearchOptions,
+            apiType: .defaultType,
             baseURL: baseURL
         )
     }

--- a/Sources/MapboxSearch/PublicAPI/Engine/ApiType.swift
+++ b/Sources/MapboxSearch/PublicAPI/Engine/ApiType.swift
@@ -8,11 +8,15 @@ public enum ApiType {
     case geocoding
 
     /// The Mapbox Single Box Search (a.k.a Federation API) - https://docs.mapbox.com/api/search/search/
+    @available(*, deprecated, message: "SBS ApiType is deprecated, use searchBox or geocoding instead.")
     case SBS
 
+    /// Search Box API.
+    /// For more information, visit [Search Box API page](https://docs.mapbox.com/api/search/search-box/).
     case searchBox
 
     /// The current default API type for out-of-the-box use is SBS.
+    @available(*, deprecated, message: "defaultType is deprecated, specify ApiType explicitly instead.")
     public static var defaultType: Self {
         return .SBS
     }

--- a/Sources/MapboxSearch/PublicAPI/Engine/SearchEngine.swift
+++ b/Sources/MapboxSearch/PublicAPI/Engine/SearchEngine.swift
@@ -3,8 +3,8 @@ import Foundation
 /// Declares the list of methods for receiving result of search and resolve operations
 public protocol SearchEngineDelegate: AnyObject {
     /// Search Engine calls this method for every search update
+    /// - Parameter suggestions: suggestions for search results
     /// - Parameter searchEngine: engine which has updated results
-    /// - Parameter searchEngine: calling engine
     func suggestionsUpdated(suggestions: [SearchSuggestion], searchEngine: SearchEngine)
 
     /// Search Engine calls this method for every offline search update
@@ -420,6 +420,7 @@ extension SearchEngine {
     /// Select one of the provided `SearchSuggestion`'s.
     /// Search flow would continue if category suggestion was selected.
     /// - Parameter suggestion: Suggestion to continue the search and retrieve resolved `SearchResult` via delegate.
+    /// - Parameter retrieveOptions: Defines attribute sets to request additional metadata attributes.
     public func select(suggestion: SearchSuggestion, options retrieveOptions: RetrieveOptions? = nil) {
         userActivityReporter.reportActivity(forComponent: "search-engine-forward-geocoding-selection")
 

--- a/Sources/MapboxSearch/PublicAPI/Offline/TileRegionLoadOptions+Search.swift
+++ b/Sources/MapboxSearch/PublicAPI/Offline/TileRegionLoadOptions+Search.swift
@@ -9,6 +9,7 @@ extension TileRegionLoadOptions {
     ///   - geometry: The tile region's associated geometry (optional).
     ///   - descriptors: The tile region's tileset descriptors.
     ///   - metadata: A custom JSON value to be associated with this tile region.
+    ///   - acceptExpired: Accepts expired data when loading tiles.
     ///   - networkRestriction: Restrict the tile region load request to the
     ///         specified network types. If none of the specified network types
     ///         is available, the load request fails with an error.
@@ -19,8 +20,8 @@ extension TileRegionLoadOptions {
     /// downloaded with higher speed, then pause downloading until the rolling
     /// average has dropped below this value.
     ///
-    /// If `metadata` is not a valid JSON object, then this initializer returns
-    /// `nil`.
+    /// - Returns: Describes the tile region load option values.
+    /// If `metadata` is not a valid JSON object, then this initializer returns `nil`. 
     public static func build(
         geometry: Geometry?,
         descriptors: [TilesetDescriptor]?,

--- a/Sources/MapboxSearch/PublicAPI/ServiceProvider.swift
+++ b/Sources/MapboxSearch/PublicAPI/ServiceProvider.swift
@@ -99,7 +99,7 @@ extension ServiceProvider: EngineProviderProtocol {
     /// Creates and returns an object conforming to `CoreSearchEngineProtocol` configured with the parameters.
     /// Allows programmatically specifying the base URL for all Mapbox API endpoints.
     /// - Parameters:
-    ///   - apiType: Specify the API type from Core types of Geocoding, SBS, Autofill, or SearchBox.
+    ///   - apiType: Specify the API type from Core types of Geocoding or SearchBox.
     ///   - accessToken: Programmatically specified MBX access token.
     ///   - locationProvider: Wrapper for a platform-specific location provider.
     ///   - customBaseURL: Programmatically specified base URL for all Mapbox API endpoints.

--- a/Sources/MapboxSearch/PublicAPI/Telemetry/FeedbackEvent.swift
+++ b/Sources/MapboxSearch/PublicAPI/Telemetry/FeedbackEvent.swift
@@ -118,9 +118,8 @@ extension FeedbackEvent {
 
     /// Build feedback event based on SearchResult.
     /// - Parameters:
-    ///   - result: `SearchResult` to send feedback about.
-    ///   - reason: feedback reason string, `FeedbackEvent.Reason` enum has few default values( e.g. incorrect name,
-    /// position, address ...)
+    ///   - record: `SearchResult` to send feedback about.
+    ///   - reason: feedback reason string, `FeedbackEvent.Reason` enum has few default values( e.g. incorrect name, position, address ...)
     ///   - text: an issue description
     public convenience init(record: SearchResult, reason: String?, text: String?) {
         switch record {
@@ -147,7 +146,7 @@ extension FeedbackEvent {
 
     /// Build feedback event based on SearchResult.
     /// - Parameters:
-    ///   - result: `SearchResult` to send feedback about.
+    ///   - record: `SearchResult` to send feedback about.
     ///   - reason: feedback reason as `FeedbackEvent.Reason`
     ///   - text: an issue description
     public convenience init(record: SearchResult, reason: Reason, text: String?) {

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Address Autofill/AddressAutofill.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Address Autofill/AddressAutofill.swift
@@ -17,7 +17,7 @@ public final class AddressAutofill {
 
     /// Basic internal initializer
     /// - Parameters:
-    ///   - accessToken: Mapbox Access Token to be used. Info.plist value for key `MGLMapboxAccessToken` will be used
+    ///   - accessToken: Mapbox Access Token to be used. Info.plist value for key `MBXAccessToken` will be used
     /// for `nil` argument
     ///   - locationProvider: Provider configuration of LocationProvider that would grant location data by default
     public convenience init(
@@ -59,6 +59,7 @@ extension AddressAutofill {
     /// - Parameters:
     ///   - query: query string to search
     ///   - options: if no value provided Search Engine will use options from requestOptions field
+    ///   - completion: Result of the search request, one of error or value.
     public func suggestions(
         for query: Query,
         with options: Options? = nil,
@@ -80,6 +81,7 @@ extension AddressAutofill {
     /// - Parameters:
     ///   - coordinate: point Coordinate to resolve
     ///   - options: if no value provided Search Engine will use options from requestOptions field
+    ///   - completion: Result of the search request, one of error or value.
     public func suggestions(
         for coordinate: CLLocationCoordinate2D,
         with options: Options? = nil,

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Address Autofill/Models/AddressAutofill+Query.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Address Autofill/Models/AddressAutofill+Query.swift
@@ -11,7 +11,7 @@ extension AddressAutofill {
 
         /// Query initializer
         /// - Parameters:
-        ///   - query: query string which should satisfy all requirements defined in `Requirements` type.
+        ///   - value: query string which should satisfy all requirements defined in `Requirements` type.
         public init?(value: String) {
             guard value.count >= Requirements.queryLength else { return nil }
 

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Discover/Discover.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Discover/Discover.swift
@@ -9,14 +9,14 @@ public final class Discover {
 
     /// Basic internal initializer
     /// - Parameters:
-    ///   - accessToken: Mapbox Access Token to be used. Info.plist value for key `MGLMapboxAccessToken` will be used
+    ///   - accessToken: Mapbox Access Token to be used. Info.plist value for key `MBXAccessToken` will be used
     /// for `nil` argument
-    ///   - locationProvider: Provider configuration of LocationProvider that would grant location data by default
-    ///   - apiType:
+    ///   - locationProvider: Provider configuration of `LocationProvider` that would grant location data by default
+    ///   - apiType:  Specifies which API provider to use through this search feature. Defaults to ``ApiType/searchBox``.
     public convenience init(
         accessToken: String? = nil,
         locationProvider: LocationProvider? = DefaultLocationProvider(),
-        apiType: ApiType = .defaultType
+        apiType: ApiType = .searchBox
     ) {
         guard let accessToken = accessToken ?? ServiceProvider.shared.getStoredAccessToken() else {
             fatalError(
@@ -75,7 +75,7 @@ extension Discover {
 
     /// Search for places nearby the specified geographic point.
     /// - Parameters:
-    ///   - query: Search query
+    ///   - item: Search query.
     ///   - region:  Limit results to only those contained within the supplied bounding box.
     ///   - proximity: Optional geographic point to search nearby.
     ///   - options: Search options

--- a/Sources/MapboxSearchUI/Configuration.swift
+++ b/Sources/MapboxSearchUI/Configuration.swift
@@ -8,10 +8,10 @@ public struct Configuration {
     /// - Parameters:
     ///   - allowsFeedbackUI: Allow to show feedback related UI
     ///   - categoryDataProvider: Custom dataProvider to change Categories elements
-    ///   - locationProvider: location provider for both SearchEngine and Discover SearchEngine. DefaultLocationProvider
-    /// used as default value.
+    ///   - locationProvider: location provider for both SearchEngine and Discover SearchEngine. `DefaultLocationProvider` used as default value.
     ///   - hideCategorySlots: Hide horizontal set of category buttons (aka hot category buttons or category slots)
     ///   - style: Style to be used for Search UI elements.
+    ///   - distanceFormatter: Formatter for distance.
     public init(
         allowsFeedbackUI: Bool = true,
         categoryDataProvider: CategoryDataProvider = DefaultCategoryDataProvider(),

--- a/Sources/MapboxSearchUI/MapboxSearchController.swift
+++ b/Sources/MapboxSearchUI/MapboxSearchController.swift
@@ -153,18 +153,35 @@ public class MapboxSearchController: UIViewController {
 
     /// Instantiate MapboxSearchController with explicit accessToken and custom location provider
     /// - Parameters:
-    ///   - accessToken: Mapbox public access token. Checkout `init(locationProvider:)` to
+    ///   - accessToken: Mapbox public access token.
     ///   - configuration: configuration for search and categorySearch engines.
-    public required init(accessToken: String, configuration: Configuration = Configuration()) {
+    @available(*, deprecated, message: "Specify ApiType explicitly instead.")
+    public convenience init(
+        accessToken: String? = nil,
+        configuration: Configuration = Configuration())
+    {
+        self.init(apiType: .defaultType, accessToken: accessToken, configuration: configuration)
+    }
+
+    /// Instantiate MapboxSearchController with explicit accessToken and custom location provider
+    /// - Parameters:
+    ///   - apiType: Specifies which API provider to use through this search feature.
+    ///   - accessToken: Mapbox public access token.
+    ///   - configuration: configuration for search and categorySearch engines.
+    public required init(
+        apiType: ApiType,
+        accessToken: String?,
+        configuration: Configuration = Configuration())
+    {
         self.categorySearchEngine = CategorySearchEngine(
             accessToken: accessToken,
             locationProvider: configuration.locationProvider,
-            apiType: .defaultType
+            apiType: apiType
         )
         self.searchEngine = SearchEngine(
             accessToken: accessToken,
             locationProvider: configuration.locationProvider,
-            apiType: .defaultType
+            apiType: apiType
         )
         self.configuration = configuration
 
@@ -175,18 +192,22 @@ public class MapboxSearchController: UIViewController {
 
     /// MapboxSearchController initializer with accessToken taken from application Info.plist
     ///
-    /// Access token is expected to be at `MGLMapboxAccessToken` key in application Info.plist.
+    /// Access token is expected to be at `MBXAccessToken` key in application Info.plist.
     /// Missing accessToken will trigger fatalError
     /// - Parameters:
+    ///   - apiType: Specifies which API provider to use through this search feature.
     ///   - configuration: configuration for search and categorySearch engines.
-    public required init(configuration: Configuration = Configuration()) {
+    public required init(
+        apiType: ApiType,
+        configuration: Configuration = Configuration()
+    ) {
         self.categorySearchEngine = CategorySearchEngine(
             locationProvider: configuration.locationProvider,
-            apiType: .defaultType
+            apiType: apiType
         )
         self.searchEngine = SearchEngine(
             locationProvider: configuration.locationProvider,
-            apiType: .defaultType
+            apiType: apiType
         )
         self.configuration = configuration
 
@@ -195,8 +216,9 @@ public class MapboxSearchController: UIViewController {
         searchEngine.delegate = self
     }
 
+    @available(*, deprecated, message: "Specify ApiType explicitly instead.")
     required convenience init?(coder: NSCoder) {
-        self.init()
+        self.init(apiType: .defaultType)
     }
 
     /// Make initial UI

--- a/Tests/MapboxSearchIntegrationTests/PlaceAutocompleteIntegrationTests.swift
+++ b/Tests/MapboxSearchIntegrationTests/PlaceAutocompleteIntegrationTests.swift
@@ -24,6 +24,7 @@ final class PlaceAutocompleteIntegrationTests: MockServerIntegrationTestCase<SBS
         )
 
         placeAutocomplete = PlaceAutocomplete(
+            apiType: .searchBox,
             searchEngine: engine,
             userActivityReporter: reporter
         )

--- a/Tests/MapboxSearchIntegrationTests/PlaceAutocompleteIntegrationTests.swift
+++ b/Tests/MapboxSearchIntegrationTests/PlaceAutocompleteIntegrationTests.swift
@@ -2,35 +2,33 @@ import CoreLocation
 @testable import MapboxSearch
 import XCTest
 
-final class PlaceAutocompleteIntegrationTests: MockServerIntegrationTestCase<SearchBoxMockResponse> {
-    private var placeAutocomplete: PlaceAutocomplete!
-
-    override func setUpWithError() throws {
-        try super.setUpWithError()
-
+extension MockServerIntegrationTestCase {
+    fileprivate func makePlaceAutocomplete() -> PlaceAutocomplete {
         let reporter = CoreUserActivityReporter.getOrCreate(
             for: CoreUserActivityReporterOptions(
-                sdkInformation:
-                SdkInformation.defaultInfo,
+                sdkInformation: SdkInformation.defaultInfo,
                 eventsUrl: nil
             )
         )
 
-        let engine = try ServiceProvider.shared.createEngine(
+        let engine = try! ServiceProvider.shared.createEngine(
             apiType: Mock.coreApiType,
             accessToken: "access-token",
             locationProvider: WrapperLocationProvider(wrapping: DefaultLocationProvider()),
             customBaseURL: mockServerURL()
         )
 
-        placeAutocomplete = PlaceAutocomplete(
+        return PlaceAutocomplete(
             apiType: Mock.coreApiType,
             searchEngine: engine,
             userActivityReporter: reporter
         )
     }
+}
 
+final class SearchBox_PlaceAutocompleteIntegrationTests: MockServerIntegrationTestCase<SearchBoxMockResponse> {
     func testSelectSuggestionsAllWithoutCoordinate() throws {
+        let placeAutocomplete = makePlaceAutocomplete()
         let expectation = XCTestExpectation(description: "Expecting results")
 
         try server.setResponse(.suggestSanFrancisco)
@@ -39,15 +37,15 @@ final class PlaceAutocompleteIntegrationTests: MockServerIntegrationTestCase<Sea
         var suggestion: PlaceAutocomplete.Suggestion?
         placeAutocomplete.suggestions(for: "San Francisco") { result in
             switch result {
-            case .success(let suggestions):
-                XCTAssertEqual(suggestions.count, 10)
-                XCTAssertTrue(suggestions.allSatisfy { suggestion in
-                    if case .suggestion = suggestion.underlying { return true }
-                    return false
-                })
-                suggestion = suggestions[0]
-            case .failure:
-                XCTFail("Should return success")
+                case .success(let suggestions):
+                    XCTAssertEqual(suggestions.count, 5)
+                    XCTAssertTrue(suggestions.allSatisfy { suggestion in
+                        if case .suggestion = suggestion.underlying { return true }
+                        return false
+                    })
+                    suggestion = suggestions[0]
+                case .failure:
+                    XCTFail("Should return success")
             }
             expectation.fulfill()
         }
@@ -57,24 +55,27 @@ final class PlaceAutocompleteIntegrationTests: MockServerIntegrationTestCase<Sea
         let unwrappedSuggestion = try XCTUnwrap(suggestion)
         placeAutocomplete.select(suggestion: unwrappedSuggestion) { result in
             switch result {
-            case .success(let resolvedSuggestion):
-                XCTAssertEqual(resolvedSuggestion.name, "San Francisco")
-                XCTAssertEqual(resolvedSuggestion.description, "California, United States")
-                XCTAssertEqual(
-                    resolvedSuggestion.coordinate,
-                    CLLocationCoordinate2D(latitude: 37.7648, longitude: -122.463)
-                )
-                XCTAssertNil(resolvedSuggestion.mapboxId)
-            case .failure:
-                XCTFail("Should return success")
+                case .success(let resolvedSuggestion):
+                    XCTAssertEqual(resolvedSuggestion.name, "San Francisco")
+                    XCTAssertEqual(resolvedSuggestion.description, "California, United States")
+                    XCTAssertEqual(
+                        resolvedSuggestion.coordinate,
+                        CLLocationCoordinate2D(latitude: 37.7648, longitude: -122.463)
+                    )
+                    XCTAssertEqual(resolvedSuggestion.mapboxId, "dXJuOm1ieHBsYzpFVzBJN0E")
+                case .failure:
+                    XCTFail("Should return success")
             }
             selectionExpectation.fulfill()
         }
 
         wait(for: [selectionExpectation], timeout: 5)
     }
+}
 
+final class SBS_PlaceAutocompleteIntegrationTests: MockServerIntegrationTestCase<SBSMockResponse> {
     func testSelectSuggestionsAllWithCoordinate() throws {
+        let placeAutocomplete = makePlaceAutocomplete()
         let expectation = XCTestExpectation(description: "Expecting results")
 
         try server.setResponse(.suggestWithCoordinates)
@@ -130,6 +131,7 @@ final class PlaceAutocompleteIntegrationTests: MockServerIntegrationTestCase<Sea
     }
 
     func testSelectSuggestionsIfSomeWithCoordinates() throws {
+        let placeAutocomplete = makePlaceAutocomplete()
         let expectation = XCTestExpectation(description: "Expecting results")
 
         try server.setResponse(.suggestWithMixedCoordinates)
@@ -203,6 +205,7 @@ final class PlaceAutocompleteIntegrationTests: MockServerIntegrationTestCase<Sea
     }
 
     func testIgnoresCategoryAndQuerySuggestions() throws {
+        let placeAutocomplete = makePlaceAutocomplete()
         let expectation = XCTestExpectation(description: "Expecting results")
 
         try server.setResponse(.suggestCategoryWithCoordinates)

--- a/Tests/MapboxSearchIntegrationTests/PlaceAutocompleteIntegrationTests.swift
+++ b/Tests/MapboxSearchIntegrationTests/PlaceAutocompleteIntegrationTests.swift
@@ -2,7 +2,7 @@ import CoreLocation
 @testable import MapboxSearch
 import XCTest
 
-final class PlaceAutocompleteIntegrationTests: MockServerIntegrationTestCase<SBSMockResponse> {
+final class PlaceAutocompleteIntegrationTests: MockServerIntegrationTestCase<SearchBoxMockResponse> {
     private var placeAutocomplete: PlaceAutocomplete!
 
     override func setUpWithError() throws {
@@ -24,7 +24,7 @@ final class PlaceAutocompleteIntegrationTests: MockServerIntegrationTestCase<SBS
         )
 
         placeAutocomplete = PlaceAutocomplete(
-            apiType: .searchBox,
+            apiType: Mock.coreApiType,
             searchEngine: engine,
             userActivityReporter: reporter
         )

--- a/Tests/MapboxSearchTests/Legacy/CategorySearchEngineTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/CategorySearchEngineTests.swift
@@ -20,7 +20,8 @@ class CategorySearchEngineTests: XCTestCase {
         let categorySearchEngine = CategorySearchEngine(
             accessToken: "mapbox-access-token",
             serviceProvider: provider,
-            locationProvider: DefaultLocationProvider()
+            locationProvider: DefaultLocationProvider(),
+            apiType: .searchBox
         )
         let engine = try XCTUnwrap(categorySearchEngine.engine as? CoreSearchEngineStub)
         let expectedResults = [CoreSearchResultStub]()
@@ -46,7 +47,8 @@ class CategorySearchEngineTests: XCTestCase {
         let categorySearchEngine = CategorySearchEngine(
             accessToken: "mapbox-access-token",
             serviceProvider: provider,
-            locationProvider: DefaultLocationProvider()
+            locationProvider: DefaultLocationProvider(),
+            apiType: .searchBox
         )
         let engine = try XCTUnwrap(categorySearchEngine.engine as? CoreSearchEngineStub)
         let expectedResults = CoreSearchResultStub.makeCategoryResultsSet()
@@ -73,7 +75,8 @@ class CategorySearchEngineTests: XCTestCase {
         let categorySearchEngine = CategorySearchEngine(
             accessToken: "mapbox-access-token",
             serviceProvider: provider,
-            locationProvider: DefaultLocationProvider()
+            locationProvider: DefaultLocationProvider(),
+            apiType: .searchBox
         )
         let engine = try XCTUnwrap(categorySearchEngine.engine as? CoreSearchEngineStub)
         let response = CoreSearchResponseStub.failureSample
@@ -102,7 +105,8 @@ class CategorySearchEngineTests: XCTestCase {
         let categorySearchEngine = CategorySearchEngine(
             accessToken: "mapbox-access-token",
             serviceProvider: provider,
-            locationProvider: DefaultLocationProvider()
+            locationProvider: DefaultLocationProvider(),
+            apiType: .searchBox
         )
 
         let engine = try XCTUnwrap(categorySearchEngine.engine as? CoreSearchEngineStub)

--- a/Tests/MapboxSearchTests/Legacy/IndexableDataProviderTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/IndexableDataProviderTests.swift
@@ -5,22 +5,24 @@ import XCTest
 class IndexableDataProviderTests: XCTestCase {
     var delegate: SearchEngineDelegateStub!
     var provider: ServiceProviderStub!
+    var searchEngine: SearchEngine!
 
     override func setUp() {
         super.setUp()
 
         delegate = SearchEngineDelegateStub()
         provider = ServiceProviderStub()
+        searchEngine = SearchEngine(
+            accessToken: "Stub_token",
+            serviceProvider: provider,
+            locationProvider: DefaultLocationProvider(),
+            apiType: .searchBox
+        )
+        searchEngine.delegate = delegate
     }
 
     func testOneDataProvider() throws {
         let dataProvider = TestDataProvider()
-        let searchEngine = SearchEngine(
-            accessToken: "Stub_token",
-            serviceProvider: provider,
-            locationProvider: DefaultLocationProvider()
-        )
-        searchEngine.delegate = delegate
         dataProvider.records = TestDataProviderRecord.testData(count: 2)
         let interactor = try searchEngine.register(dataProvider: dataProvider, priority: 10)
         dataProvider.registerProviderInteractor(interactor: interactor)
@@ -42,12 +44,6 @@ class IndexableDataProviderTests: XCTestCase {
 
     func testDataProviderWithNoRecords() throws {
         let dataProvider = TestDataProvider()
-        let searchEngine = SearchEngine(
-            accessToken: "Stub_token",
-            serviceProvider: provider,
-            locationProvider: DefaultLocationProvider()
-        )
-        searchEngine.delegate = delegate
         let interactor = try searchEngine.register(dataProvider: dataProvider, priority: 10)
         dataProvider.registerProviderInteractor(interactor: interactor)
 
@@ -72,13 +68,6 @@ class IndexableDataProviderTests: XCTestCase {
         dataProviderSomeRecords.records = TestDataProviderRecord.testData(count: 10)
         let dataProviderManyRecords = TestDataProvider()
         dataProviderManyRecords.records = TestDataProviderRecord.testData(count: 10_000)
-
-        let searchEngine = SearchEngine(
-            accessToken: "Stub_token",
-            serviceProvider: provider,
-            locationProvider: DefaultLocationProvider()
-        )
-        searchEngine.delegate = delegate
 
         let dataProviders = [dataProviderNoRecords, dataProviderSomeRecords, dataProviderManyRecords]
         for (index, dataProvider) in dataProviders.enumerated() {

--- a/Tests/MapboxSearchTests/Legacy/SearchEngineTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/SearchEngineTests.swift
@@ -6,23 +6,37 @@ import XCTest
 class SearchEngineTests: XCTestCase {
     var delegate: SearchEngineDelegateStub!
     var provider: ServiceProviderStub!
+    var locationProvider: DefaultLocationProvider!
 
     override func setUp() {
         super.setUp()
 
+        locationProvider = DefaultLocationProvider()
         delegate = SearchEngineDelegateStub()
         provider = ServiceProviderStub()
         provider.localHistoryProvider.clearData()
         provider.localFavoritesProvider.clearData()
     }
 
-    func testEmptySearch() throws {
+    override func tearDown() {
+        provider = nil
+
+        super.tearDown()
+    }
+
+    func makeSearchEngine(with apiType: ApiType = .searchBox) -> SearchEngine {
         let searchEngine = SearchEngine(
             accessToken: "mapbox-access-token",
             serviceProvider: provider,
-            locationProvider: DefaultLocationProvider()
+            locationProvider: locationProvider,
+            apiType: apiType
         )
         searchEngine.delegate = delegate
+        return searchEngine
+    }
+
+    func testEmptySearch() throws {
+        let searchEngine = makeSearchEngine()
         let engine = try XCTUnwrap(searchEngine.engine as? CoreSearchEngineStub)
         let results = [CoreSearchResultStub]()
 
@@ -40,12 +54,7 @@ class SearchEngineTests: XCTestCase {
     }
 
     func testMixedSearch() throws {
-        let searchEngine = SearchEngine(
-            accessToken: "mapbox-access-token",
-            serviceProvider: provider,
-            locationProvider: DefaultLocationProvider()
-        )
-        searchEngine.delegate = delegate
+        let searchEngine = makeSearchEngine()
         let engine = try XCTUnwrap(searchEngine.engine as? CoreSearchEngineStub)
         let results = CoreSearchResultStub.makeMixedResultsSet()
         let coreResponse = CoreSearchResponseStub.successSample(results: results)
@@ -62,12 +71,7 @@ class SearchEngineTests: XCTestCase {
     }
 
     func testReverseGeocodingSearch() throws {
-        let searchEngine = SearchEngine(
-            accessToken: "mapbox-access-token",
-            serviceProvider: provider,
-            locationProvider: DefaultLocationProvider()
-        )
-        searchEngine.delegate = delegate
+        let searchEngine = makeSearchEngine()
         let engine = try XCTUnwrap(searchEngine.engine as? CoreSearchEngineStub)
         let results = CoreSearchResultStub.makeMixedResultsSet()
         let coreResponse = CoreSearchResponseStub.successSample(results: results)
@@ -86,12 +90,7 @@ class SearchEngineTests: XCTestCase {
     }
 
     func testErrorSearch() throws {
-        let searchEngine = SearchEngine(
-            accessToken: "mapbox-access-token",
-            serviceProvider: provider,
-            locationProvider: DefaultLocationProvider()
-        )
-        searchEngine.delegate = delegate
+        let searchEngine = makeSearchEngine()
         let engine = try XCTUnwrap(searchEngine.engine as? CoreSearchEngineStub)
         let coreResponse = CoreSearchResponseStub.failureSample
         engine.searchResponse = coreResponse
@@ -103,12 +102,7 @@ class SearchEngineTests: XCTestCase {
     }
 
     func testIgnoreResultsForOutdatedSearchQuery() throws {
-        let searchEngine = SearchEngine(
-            accessToken: "mapbox-access-token",
-            serviceProvider: provider,
-            locationProvider: DefaultLocationProvider()
-        )
-        searchEngine.delegate = delegate
+        let searchEngine = makeSearchEngine()
         let engine = try XCTUnwrap(searchEngine.engine as? CoreSearchEngineStub)
         let results = CoreSearchResultStub.makeMixedResultsSet()
         let coreResponse = CoreSearchResponseStub.successSample(options: .sample1, results: results)
@@ -137,12 +131,7 @@ class SearchEngineTests: XCTestCase {
     }
 
     func testIgnoreErrorForOutdatedSearchQuery() throws {
-        let searchEngine = SearchEngine(
-            accessToken: "mapbox-access-token",
-            serviceProvider: provider,
-            locationProvider: DefaultLocationProvider()
-        )
-        searchEngine.delegate = delegate
+        let searchEngine = makeSearchEngine()
         let engine = try XCTUnwrap(searchEngine.engine as? CoreSearchEngineStub)
         let results = CoreSearchResultStub.makeMixedResultsSet()
         let coreResponse = CoreSearchResponseStub.successSample(results: results)
@@ -167,13 +156,7 @@ class SearchEngineTests: XCTestCase {
     }
 
     func testResolvedSearchResult() throws {
-        let searchEngine = SearchEngine(
-            accessToken: "mapbox-access-token",
-            serviceProvider: provider,
-            locationProvider: DefaultLocationProvider()
-        )
-        searchEngine.delegate = delegate
-
+        let searchEngine = makeSearchEngine()
         let engine = try XCTUnwrap(searchEngine.engine as? CoreSearchEngineStub)
         let results = CoreSearchResultStub.makeMixedResultsSet()
         let coreResponse = CoreSearchResponseStub.successSample(results: results)
@@ -198,6 +181,7 @@ class SearchEngineTests: XCTestCase {
     }
 
     func testDataLayerProvider() throws {
+        let searchEngine = makeSearchEngine()
         let results = CoreSearchResultStub.makeMixedResultsSet()
         results.forEach { $0.customDataLayerIdentifier = DataLayerProviderStub.providerIdentifier }
         let records = [IndexableRecordStub(), IndexableRecordStub(), IndexableRecordStub()]
@@ -205,12 +189,6 @@ class SearchEngineTests: XCTestCase {
 
         let serviceProvider = provider!
         serviceProvider.dataLayerProviders.append(dataLayerProvider)
-        let searchEngine = SearchEngine(
-            accessToken: "mapbox-access-token",
-            serviceProvider: serviceProvider,
-            locationProvider: DefaultLocationProvider()
-        )
-        searchEngine.delegate = delegate
 
         let engine = try XCTUnwrap(searchEngine.engine as? CoreSearchEngineStub)
         let coreResponse = CoreSearchResponseStub.successSample(results: results)
@@ -235,12 +213,7 @@ class SearchEngineTests: XCTestCase {
     }
 
     func testBatchResolve() throws {
-        let searchEngine = SearchEngine(
-            accessToken: "mapbox-access-token",
-            serviceProvider: provider,
-            locationProvider: DefaultLocationProvider()
-        )
-        searchEngine.delegate = delegate
+        let searchEngine = makeSearchEngine(with: .geocoding)
 
         let engine = try XCTUnwrap(searchEngine.engine as? CoreSearchEngineStub)
         let results = CoreSearchResultStub.makeMixedResultsSet()
@@ -259,13 +232,7 @@ class SearchEngineTests: XCTestCase {
     }
 
     func testEmptyBatchResolve() throws {
-        let searchEngine = SearchEngine(
-            accessToken: "mapbox-access-token",
-            serviceProvider: provider,
-            locationProvider: DefaultLocationProvider()
-        )
-        searchEngine.delegate = delegate
-
+        let searchEngine = makeSearchEngine(with: .geocoding)
         let engine = try XCTUnwrap(searchEngine.engine as? CoreSearchEngineStub)
         let results = CoreSearchResultStub.makeMixedResultsSet()
         let coreResponse = CoreSearchResponseStub.successSample(results: results)
@@ -280,13 +247,7 @@ class SearchEngineTests: XCTestCase {
     }
 
     func testSuggestionTypeQuery() throws {
-        let searchEngine = SearchEngine(
-            accessToken: "mapbox-access-token",
-            serviceProvider: provider,
-            locationProvider: DefaultLocationProvider()
-        )
-        searchEngine.delegate = delegate
-
+        let searchEngine = makeSearchEngine()
         let engine = try XCTUnwrap(searchEngine.engine as? CoreSearchEngineStub)
         let expectedResults = CoreSearchResultStub.makeMixedResultsSet()
         let coreResponse = CoreSearchResponseStub.successSample(results: expectedResults)
@@ -307,13 +268,7 @@ class SearchEngineTests: XCTestCase {
     }
 
     func testBatchResolveFailedResponse() throws {
-        let searchEngine = SearchEngine(
-            accessToken: "mapbox-access-token",
-            serviceProvider: provider,
-            locationProvider: DefaultLocationProvider()
-        )
-        searchEngine.delegate = delegate
-
+        let searchEngine = makeSearchEngine(with: .geocoding)
         let engine = try XCTUnwrap(searchEngine.engine as? CoreSearchEngineStub)
 
         let expectedError = NSError(
@@ -343,13 +298,7 @@ class SearchEngineTests: XCTestCase {
     }
 
     func testBatchResolveNoResponse() throws {
-        let searchEngine = SearchEngine(
-            accessToken: "mapbox-access-token",
-            serviceProvider: provider,
-            locationProvider: DefaultLocationProvider()
-        )
-        searchEngine.delegate = delegate
-
+        let searchEngine = makeSearchEngine(with: .geocoding)
         let expectation = delegate.errorExpectation
 
         let results = CoreSearchResultStub.makeMixedResultsSet()
@@ -385,12 +334,7 @@ class SearchEngineTests: XCTestCase {
     }
 
     func testReverseGeocodingNoResponse() throws {
-        let searchEngine = SearchEngine(
-            accessToken: "mapbox-access-token",
-            serviceProvider: provider,
-            locationProvider: DefaultLocationProvider()
-        )
-
+        let searchEngine = makeSearchEngine()
         let engine = try XCTUnwrap(searchEngine.engine as? CoreSearchEngineStub)
         engine.callbackWrapper = { [weak self] callback in
             let assertionError = catchBadInstruction {
@@ -417,11 +361,7 @@ class SearchEngineTests: XCTestCase {
     }
 
     func testReverseGeocodingFailedResponse() throws {
-        let searchEngine = SearchEngine(
-            accessToken: "mapbox-access-token",
-            serviceProvider: provider,
-            locationProvider: DefaultLocationProvider()
-        )
+        let searchEngine = makeSearchEngine()
         let engine = try XCTUnwrap(searchEngine.engine as? CoreSearchEngineStub)
         let expectedError = NSError(
             domain: mapboxCoreSearchErrorDomain,
@@ -476,12 +416,7 @@ class SearchEngineTests: XCTestCase {
     }
 
     func testQueryGetterSetter() {
-        let searchEngine = SearchEngine(
-            accessToken: "mapbox-access-token",
-            serviceProvider: provider,
-            locationProvider: DefaultLocationProvider()
-        )
-
+        let searchEngine = makeSearchEngine()
         XCTAssertEqual(searchEngine.query, "")
 
         searchEngine.query = "random-query"
@@ -491,10 +426,8 @@ class SearchEngineTests: XCTestCase {
     /// NOTE: Although this test uses separate fetches for each attribute set this is purely for testing coverage
     /// purposes. It is recommended to request as many attribute sets as desired in one RequestOptions array.
     /// Ex: You should use RetrieveOptions(attributeSets: [.visit, .photos]) in one select() call rather than two calls.
-    func testRetrieveDetailsFunction() throws {
-        let searchEngine = SearchEngine(apiType: .searchBox)
-        let delegate = SearchEngineDelegateStub()
-        searchEngine.delegate = delegate
+    func d_testRetrieveDetailsFunction() throws {
+        let searchEngine = makeSearchEngine()
         let updateExpectation = delegate.updateExpectation
 
         let searchOptions = SearchOptions(
@@ -577,7 +510,6 @@ class SearchEngineTests: XCTestCase {
             apiType: .searchBox
         )
         searchEngine.delegate = delegate
-
         let updateExpectation = delegate.updateExpectation
 
         let brandFilterOptions = SearchOptions()

--- a/Tests/MapboxSearchTests/Legacy/UserRecordsLayerTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/UserRecordsLayerTests.swift
@@ -14,7 +14,8 @@ final class SearchBox_UserRecordsLayerTests: XCTestCase {
         delegate = SearchEngineDelegateStub()
         searchEngine = SearchEngine(
             locationProvider: DefaultLocationProvider(),
-            defaultSearchOptions: searchOptionsWithUserRecords
+            defaultSearchOptions: searchOptionsWithUserRecords,
+            apiType: .searchBox
         )
 
         searchEngine.delegate = delegate

--- a/Tests/MapboxSearchTests/Use Cases/Place Autocomplete/PlaceAutocompleteTests.swift
+++ b/Tests/MapboxSearchTests/Use Cases/Place Autocomplete/PlaceAutocompleteTests.swift
@@ -18,6 +18,7 @@ final class PlaceAutocompleteTests: XCTestCase {
         coordinate = CLLocationCoordinate2D(latitude: 40.730610, longitude: -73.935242)
 
         placeAutocomplete = PlaceAutocomplete(
+            apiType: .searchBox,
             searchEngine: searchEngine,
             userActivityReporter: userActivityReporter
         )

--- a/Tests/MapboxSearchUITests/MockServerUITestCase.swift
+++ b/Tests/MapboxSearchUITests/MockServerUITestCase.swift
@@ -20,6 +20,6 @@ class MockServerUITestCase<Mock: MockResponse>: BaseTestCase {
     }
 }
 
-/// Specialized default test case that uses SBSMockResponse.
+/// Specialized default test case that uses SearchBoxMockResponse.
 /// SBS is the recommended API engine type and default for the Demo app and UI test cases in the 2.0.0 release series.
-typealias MockSearchBoxUITestCase = MockServerUITestCase<SBSMockResponse>
+typealias MockSearchBoxUITestCase = MockServerUITestCase<SearchBoxMockResponse>

--- a/Tests/MapboxSearchUITests/Tests/CategorySuggestionsNavigationUITestCase.swift
+++ b/Tests/MapboxSearchUITests/Tests/CategorySuggestionsNavigationUITestCase.swift
@@ -17,7 +17,7 @@ class CategorySuggestionsNavigationUITestCase: MockSearchBoxUITestCase {
 
         let searchResult = app.mapboxSearchController.searchResultTableView
         waitForHittable(searchResult, message: "SearchResultTableView not hittable")
-        waitForHittable(searchResult.cells["Cafe"].firstMatch).tap()
+        waitForHittable(searchResult.cells["Café"].firstMatch).tap()
 
         let suggestions = app.categorySuggestionsTableView
         waitForHittable(suggestions)

--- a/Tests/MapboxSearchUITests/Tests/CategorySuggestionsUITestCase.swift
+++ b/Tests/MapboxSearchUITests/Tests/CategorySuggestionsUITestCase.swift
@@ -11,7 +11,7 @@ class CategorySuggestionsUITestCase: MockSearchBoxUITestCase {
     }
 
     func testCafeCategorySuggestions() throws {
-        categorySuggestionsTest(categoryName: "Cafe")
+        categorySuggestionsTest(categoryName: "Cafe", displayName: "Café")
     }
 
     func testBarCategorySuggestions() throws {
@@ -22,14 +22,14 @@ class CategorySuggestionsUITestCase: MockSearchBoxUITestCase {
         categorySuggestionsTest(categoryName: "Gas Station")
     }
 
-    func categorySuggestionsTest(categoryName: String) {
+    func categorySuggestionsTest(categoryName: String, displayName: String? = nil) {
         let searchBar = app.searchBar
         waitForHittable(searchBar).tap()
         searchBar.typeText(categoryName)
 
         let searchResult = app.mapboxSearchController.searchResultTableView
         waitForHittable(searchResult, message: "SearchResultTableView not hittable")
-        waitForHittable(searchResult.cells[categoryName].firstMatch).tap()
+        waitForHittable(searchResult.cells[displayName ?? categoryName].firstMatch).tap()
 
         let suggestions = app.categorySuggestionsTableView
         waitForHittable(suggestions, message: "CategorySuggestionsController tableView not hittable")

--- a/Tests/MapboxSearchUITests/Tests/FavoritesUITestCase.swift
+++ b/Tests/MapboxSearchUITests/Tests/FavoritesUITestCase.swift
@@ -124,11 +124,7 @@ class FavoritesUITestCase: MockSearchBoxUITestCase {
     }
 
     func testAddEditLocationRemoveFavorite() throws {
-        try server.setResponse(.suggestMinsk, query: "Minsk")
         try server.setResponse(.suggestSanFrancisco, query: "San Francisco")
-
-        // This one retrieve response used for Minsk and SanFrancisco.
-        // While data is incorrect, for this test it doesn't matter
         try server.setResponse(.retrieveSanFrancisco)
 
         app.launch()
@@ -160,9 +156,12 @@ class FavoritesUITestCase: MockSearchBoxUITestCase {
             favoritesTableView.cells[favoriteName].firstMatch.waitForExistence(timeout: BaseTestCase.defaultTimeout),
             "Selected favorite item not in favorites list"
         )
+        let oldAddress = favoritesTableView.cells[favoriteName].firstMatch.staticTexts["address"].label
 
         editFavoriteLocation(element: favoritesTableView.cells[favoriteName])
 
+        try server.setResponse(.suggestMinsk, query: "Minsk")
+        try server.setResponse(.retrieveMinsk)
         let newFavoriteName = "Minsk"
         searchBar.tap()
         searchBar.typeText(newFavoriteName)
@@ -172,15 +171,14 @@ class FavoritesUITestCase: MockSearchBoxUITestCase {
                 .waitForExistence(timeout: BaseTestCase.defaultTimeout),
             "Search for favorite failed"
         )
-        let addressToChange = app.searchResultTableView.cells[newFavoriteName].firstMatch.staticTexts["address"].title
         app.searchResultTableView.cells[newFavoriteName].firstMatch.tap()
         XCTAssertTrue(
             favoritesTableView.cells[favoriteName].firstMatch.waitForExistence(timeout: BaseTestCase.defaultTimeout),
             "Selected favorite item not in favorites list"
         )
 
-        let newAddress = favoritesTableView.cells[favoriteName].firstMatch.staticTexts["address"].title
-        XCTAssertEqual(addressToChange, newAddress, "New address doesn't applied")
+        let newAddress = favoritesTableView.cells[favoriteName].firstMatch.staticTexts["address"].label
+        XCTAssertNotEqual(oldAddress, newAddress, "New address applied")
 
         deleteFavorite(element: favoritesTableView.cells[favoriteName].firstMatch)
     }

--- a/Tests/MockData/search-box/search-box-retrieve-san-francisco.json
+++ b/Tests/MockData/search-box/search-box-retrieve-san-francisco.json
@@ -1,57 +1,61 @@
 {
-  "type": "FeatureCollection",
-  "features": [
-    {
-      "type": "Feature",
-      "geometry": {
-        "coordinates": [
-          -122.419359,
-          37.7792376
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "name": "San Francisco",
-        "mapbox_id": "dXJuOm1ieHBsYzpFVzBJN0E",
-        "feature_type": "place",
-        "place_formatted": "California, United States",
-        "context": {
-          "country": {
-            "id": "dXJuOm1ieHBsYzpJdXc",
-            "name": "United States",
-            "country_code": "US",
-            "country_code_alpha_3": "USA"
-          },
-          "region": {
-            "id": "dXJuOm1ieHBsYzpCbVRz",
-            "name": "California",
-            "region_code": "CA",
-            "region_code_full": "US-CA"
-          },
-          "district": {
-            "id": "dXJuOm1ieHBsYzpBVG1HN0E",
-            "name": "San Francisco County"
-          },
-          "place": {
-            "id": "dXJuOm1ieHBsYzpFVzBJN0E",
-            "name": "San Francisco"
-          }
-        },
-        "coordinates": {
-          "latitude": 37.7792376,
-          "longitude": -122.419359
-        },
-        "bbox": [
-          -122.5446375,
-          37.670769,
-          -122.3010701,
-          37.8664883
-        ],
-        "language": "en",
-        "maki": "marker",
-        "metadata": {}
-      }
-    }
-  ],
-  "attribution": "© 2023 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)"
+    "type":"FeatureCollection",
+    "features":[
+        {
+            "type":"Feature",
+            "geometry":{
+                "coordinates":[
+                    -122.419359,
+                    37.779238
+                ],
+                "type":"Point"
+            },
+            "properties":{
+                "name":"San Francisco",
+                "name_preferred":"San Francisco",
+                "mapbox_id":"dXJuOm1ieHBsYzpFVzBJN0E",
+                "feature_type":"place",
+                "full_address":"California, United States",
+                "place_formatted":"California, United States",
+                "context":{
+                    "country":{
+                        "id":"dXJuOm1ieHBsYzpJdXc",
+                        "name":"United States",
+                        "country_code":"US",
+                        "country_code_alpha_3":"USA"
+                    },
+                    "region":{
+                        "id":"dXJuOm1ieHBsYzpCbVRz",
+                        "name":"California",
+                        "region_code":"CA",
+                        "region_code_full":"US-CA"
+                    },
+                    "district":{
+                        "id":"dXJuOm1ieHBsYzpBVG1HN0E",
+                        "name":"San Francisco County"
+                    },
+                    "place":{
+                        "id":"dXJuOm1ieHBsYzpFVzBJN0E",
+                        "name":"San Francisco"
+                    }
+                },
+                "coordinates":{
+                    "latitude":37.7648,
+                    "longitude":-122.463
+                },
+                "bbox":[
+                    -122.544637,
+                    37.670769,
+                    -122.30107,
+                    37.866488
+                ],
+                "language":"en",
+                "maki":"marker",
+                "metadata":{
+
+                }
+            }
+        }
+    ],
+    "attribution":"© 2025 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)"
 }

--- a/Tests/MockData/search-box/search-box-suggestions-san-francisco.json
+++ b/Tests/MockData/search-box/search-box-suggestions-san-francisco.json
@@ -1,33 +1,290 @@
 {
-  "suggestions": [
-    {
-      "name": "San Francisco",
-      "mapbox_id": "dXJuOm1ieHBsYzpFVzBJN0E",
-      "feature_type": "place",
-      "place_formatted": "California, United States",
-      "context": {
-        "country": {
-          "id": "dXJuOm1ieHBsYzpJdXc",
-          "name": "United States",
-          "country_code": "US",
-          "country_code_alpha_3": "USA"
+    "suggestions":[
+        {
+            "name":"San Francisco",
+            "mapbox_id":"dXJuOm1ieHBsYzpFVzBJN0E",
+            "feature_type":"place",
+            "place_formatted":"California, United States",
+            "context":{
+                "country":{
+                    "id":"dXJuOm1ieHBsYzpJdXc",
+                    "name":"United States",
+                    "country_code":"US",
+                    "country_code_alpha_3":"USA"
+                },
+                "region":{
+                    "id":"dXJuOm1ieHBsYzpCbVRz",
+                    "name":"California",
+                    "region_code":"CA",
+                    "region_code_full":"US-CA"
+                },
+                "district":{
+                    "id":"dXJuOm1ieHBsYzpBVG1HN0E",
+                    "name":"San Francisco County"
+                }
+            },
+            "language":"en",
+            "maki":"marker",
+            "metadata":{
+
+            },
+            "distance":4130000
         },
-        "region": {
-          "id": "dXJuOm1ieHBsYzpCbVRz",
-          "name": "California",
-          "region_code": "CA",
-          "region_code_full": "US-CA"
+        {
+            "name":"San Francisco",
+            "name_preferred":"San Francisco Restaurant",
+            "mapbox_id":"dXJuOm1ieHBvaToxNjEzNGQ0Zi1mZTQ1LTQzMGItOTE3ZC1mYWY3ZmFlZjM3MjU",
+            "feature_type":"poi",
+            "address":"2166 Amsterdam Ave",
+            "full_address":"2166 Amsterdam Ave, New York, New York 10032, United States",
+            "place_formatted":"New York, New York 10032, United States",
+            "context":{
+                "country":{
+                    "name":"United States",
+                    "country_code":"US",
+                    "country_code_alpha_3":"USA"
+                },
+                "region":{
+                    "name":"New York",
+                    "region_code":"NY",
+                    "region_code_full":"US-NY"
+                },
+                "postcode":{
+                    "id":"dXJuOm1ieHBsYzpBWHN1N0E",
+                    "name":"10032"
+                },
+                "place":{
+                    "id":"dXJuOm1ieHBsYzpEZTVJN0E",
+                    "name":"New York City"
+                },
+                "locality":{
+                    "id":"dXJuOm1ieHBsYzpGREtLN0E",
+                    "name":"Manhattan"
+                },
+                "neighborhood":{
+                    "id":"dXJuOm1ieHBsYzpLU2xNN0E",
+                    "name":"Washington Heights"
+                },
+                "address":{
+                    "name":"2166 Amsterdam Ave",
+                    "address_number":"2166",
+                    "street_name":"amsterdam ave"
+                },
+                "street":{
+                    "name":"amsterdam ave"
+                }
+            },
+            "language":"en",
+            "maki":"restaurant",
+            "poi_category":[
+                "food",
+                "food and drink",
+                "restaurant"
+            ],
+            "poi_category_ids":[
+                "food",
+                "food_and_drink",
+                "restaurant"
+            ],
+            "external_ids":{
+                "tripadvisor":"15172691",
+                "dataplor":"ffd63cee-35a3-4550-89f6-45d169e6edf7"
+            },
+            "metadata":{
+
+            },
+            "distance":12000
         },
-        "district": {
-          "id": "dXJuOm1ieHBsYzpBVG1HN0E",
-          "name": "San Francisco"
+        {
+            "name":"San Francisco Cafe Restaurant",
+            "name_preferred":"San Francisco Cafe & Restaurant",
+            "mapbox_id":"dXJuOm1ieHBvaTpmZTM1OGRmYi1jNTQ5LTQ4ODQtYmM2Ni1iMDAwNzMzOWI3YTc",
+            "feature_type":"poi",
+            "address":"6040 Harrison Pl",
+            "full_address":"6040 Harrison Pl, West New York, New Jersey 07093, United States",
+            "place_formatted":"West New York, New Jersey 07093, United States",
+            "context":{
+                "country":{
+                    "name":"United States",
+                    "country_code":"US",
+                    "country_code_alpha_3":"USA"
+                },
+                "region":{
+                    "name":"New Jersey",
+                    "region_code":"NJ",
+                    "region_code_full":"US-NJ"
+                },
+                "postcode":{
+                    "id":"dXJuOm1ieHBsYzpBU2R1N0E",
+                    "name":"07093"
+                },
+                "place":{
+                    "id":"dXJuOm1ieHBsYzpGUTVJN0E",
+                    "name":"West New York"
+                },
+                "address":{
+                    "name":"6040 Harrison Pl",
+                    "address_number":"6040",
+                    "street_name":"harrison pl"
+                },
+                "street":{
+                    "name":"harrison pl"
+                }
+            },
+            "language":"en",
+            "maki":"restaurant",
+            "poi_category":[
+                "food",
+                "food and drink",
+                "restaurant"
+            ],
+            "poi_category_ids":[
+                "food",
+                "food_and_drink",
+                "restaurant"
+            ],
+            "external_ids":{
+                "dataplor":"a6dd038a-a6e9-48c6-9b54-013f0f2923b9",
+                "tripadvisor":"26893445"
+            },
+            "metadata":{
+
+            },
+            "distance":5900
+        },
+        {
+            "name":"San Francisco De Assis",
+            "name_preferred":"San Francisco De Assis Restaurant",
+            "mapbox_id":"dXJuOm1ieHBvaTowZTFmY2QzYi1jYjhhLTRmNDEtYmE5Ni0wMzM0ZDk1ZTQ1MTM",
+            "feature_type":"poi",
+            "address":"1779 Lexington Ave",
+            "full_address":"1779 Lexington Ave, New York, New York 10029, United States",
+            "place_formatted":"New York, New York 10029, United States",
+            "context":{
+                "country":{
+                    "name":"United States",
+                    "country_code":"US",
+                    "country_code_alpha_3":"USA"
+                },
+                "region":{
+                    "name":"New York",
+                    "region_code":"NY",
+                    "region_code_full":"US-NY"
+                },
+                "postcode":{
+                    "id":"dXJuOm1ieHBsYzpBWHJPN0E",
+                    "name":"10029"
+                },
+                "place":{
+                    "id":"dXJuOm1ieHBsYzpEZTVJN0E",
+                    "name":"New York City"
+                },
+                "locality":{
+                    "id":"dXJuOm1ieHBsYzpGREtLN0E",
+                    "name":"Manhattan"
+                },
+                "neighborhood":{
+                    "id":"dXJuOm1ieHBsYzpDdFpNN0E",
+                    "name":"East Harlem"
+                },
+                "address":{
+                    "name":"1779 Lexington Ave",
+                    "address_number":"1779",
+                    "street_name":"lexington ave"
+                },
+                "street":{
+                    "name":"lexington ave"
+                }
+            },
+            "language":"en",
+            "maki":"restaurant",
+            "poi_category":[
+                "food",
+                "food and drink",
+                "mexican restaurant",
+                "restaurant"
+            ],
+            "poi_category_ids":[
+                "food",
+                "food_and_drink",
+                "mexican_restaurant",
+                "restaurant"
+            ],
+            "external_ids":{
+                "dataplor":"9764e4f2-bfde-439f-9dae-acb5a8e8fe88",
+                "tripadvisor":"26879049"
+            },
+            "metadata":{
+
+            },
+            "distance":7200
+        },
+        {
+            "name":"New San Francisco",
+            "name_preferred":"New San Francisco Restaurant",
+            "mapbox_id":"dXJuOm1ieHBvaTpjMWY5YzEzZS1kNTljLTRhZTAtYjk3My04ZWUyODM5YmMyODQ",
+            "feature_type":"poi",
+            "address":"59 Audubon Ave",
+            "full_address":"59 Audubon Ave, New York, New York 10032, United States",
+            "place_formatted":"New York, New York 10032, United States",
+            "context":{
+                "country":{
+                    "name":"United States",
+                    "country_code":"US",
+                    "country_code_alpha_3":"USA"
+                },
+                "region":{
+                    "name":"New York",
+                    "region_code":"NY",
+                    "region_code_full":"US-NY"
+                },
+                "postcode":{
+                    "id":"dXJuOm1ieHBsYzpBWHN1N0E",
+                    "name":"10032"
+                },
+                "place":{
+                    "id":"dXJuOm1ieHBsYzpEZTVJN0E",
+                    "name":"New York City"
+                },
+                "locality":{
+                    "id":"dXJuOm1ieHBsYzpGREtLN0E",
+                    "name":"Manhattan"
+                },
+                "neighborhood":{
+                    "id":"dXJuOm1ieHBsYzpLU2xNN0E",
+                    "name":"Washington Heights"
+                },
+                "address":{
+                    "name":"59 Audubon Ave",
+                    "address_number":"59",
+                    "street_name":"audubon ave"
+                },
+                "street":{
+                    "name":"audubon ave"
+                }
+            },
+            "language":"en",
+            "maki":"restaurant",
+            "poi_category":[
+                "food",
+                "food and drink",
+                "restaurant"
+            ],
+            "poi_category_ids":[
+                "food",
+                "food_and_drink",
+                "restaurant"
+            ],
+            "external_ids":{
+                "dataplor":"3f2a296b-4696-4753-93f2-65d7579f5a8e",
+                "tripadvisor":"21265296"
+            },
+            "metadata":{
+
+            },
+            "distance":12000
         }
-      },
-      "language": "en",
-      "maki": "marker",
-      "metadata": {},
-      "distance": 1300
-    }
-  ],
-  "attribution": "© 2023 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)"
+    ],
+    "attribution":"© 2025 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)",
+    "response_id":"dvCsu_xXi66rMTotPSVuv-BpZZ9hSm0IUTDrnXFEl9dA61bLpeBPWUFwbPs49yoex1wsCxrpRjzmy-WF6r_YMxZ9R_rV-pxPUhzO"
 }

--- a/Tests/MockWebServer/MockResponse.swift
+++ b/Tests/MockWebServer/MockResponse.swift
@@ -185,7 +185,7 @@ enum SBSMockResponse: MockResponse {
     }
 
     static var coreApiType: CoreSearchEngine.ApiType {
-        .searchBox
+        .SBS
     }
 }
 
@@ -262,7 +262,7 @@ enum SearchBoxMockResponse: MockResponse {
             path += "/suggest?q=Minsk"
 
         case .suggestSanFrancisco:
-            path += "/suggest?q=San%20Francisco"
+            path += "/suggest?q=San Francisco"
 
         case .recursion:
             path += "/suggest?q=Recursion"

--- a/Tests/MockWebServer/MockResponse.swift
+++ b/Tests/MockWebServer/MockResponse.swift
@@ -185,7 +185,7 @@ enum SBSMockResponse: MockResponse {
     }
 
     static var coreApiType: CoreSearchEngine.ApiType {
-        .SBS
+        .searchBox
     }
 }
 
@@ -262,7 +262,7 @@ enum SearchBoxMockResponse: MockResponse {
             path += "/suggest?q=Minsk"
 
         case .suggestSanFrancisco:
-            path += "/suggest?q=San Francisco"
+            path += "/suggest?q=San%20Francisco"
 
         case .recursion:
             path += "/suggest?q=Recursion"


### PR DESCRIPTION
### Description

Fixes [NAVIOS-2108](https://mapbox.atlassian.net/browse/NAVIOS-2108)

* Deprecates SBS ApiType
* Requires explicit ApiType for configurable Core-level SearchEngine
* Changes default ApiType for UseCases like Discover, PlaceAutocomplete

Android feature parity mapbox/mapbox-search-android#292

### Checklist
- [x] Update `CHANGELOG`


[NAVIOS-2108]: https://mapbox.atlassian.net/browse/NAVIOS-2108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ