### PR TITLE
Fix routablePoints is not set in FavoriteRecord.init

### DIFF
--- a/Sources/MapboxSearch/PublicAPI/FavoriteRecord.swift
+++ b/Sources/MapboxSearch/PublicAPI/FavoriteRecord.swift
@@ -122,6 +122,7 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
         self.serverIndex = serverIndex
         self.accuracy = accuracy
         self.categories = categories
+        self.routablePoints = routablePoints
         self.type = resultType
         self.metadata = metadata
         self.searchRequest = searchRequest


### PR DESCRIPTION
`routablePoints` is given in `FavoriteRecord.init` but is not correctly set.
