### PR TITLE
Release 2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+## 2.9.0
+
+- [Core] Update dependencies.
+
+**MapboxCommon**: v24.11.0
+**MapboxCoreSearch**: v2.9.0
+
 ## 2.9.0-rc.2
 
 - [FavoriteRecord] Fix an issue where `routablePoints` were not set during the initialization of `FavoriteRecord`.
@@ -32,6 +39,13 @@ Guide: https://keepachangelog.com/en/1.0.0/
 - [Offline] Add `SearchOfflineManager.selectTileset(for:)` which allows you to select a tileset with the specified parameters, including language and worldview.
 - [Offline] Add `SearchOfflineManager.createTilesetDescriptor(tilesetParameters:)` and `SearchOfflineManager.createPlacesTilesetDescriptor(tilesetParameters:)` to specify tileset worldview.
 - [Offline] Deprecate `SearchOfflineManager.createTilesetDescriptor(dataset:version:language:)` and `SearchOfflineManager.createPlacesTilesetDescriptor(dataset:version:language:)`. Use corresponding methods with `tilesetParameters` instead.
+
+## 2.8.1
+
+- [Core] Update dependencies.
+
+**MapboxCommon**: v24.10.1
+**MapboxCoreSearch**: v2.8.1
 
 ## 2.8.0
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.9.0-rc.2
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.11.0-rc.2
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.9.0
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.11.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.11.0-rc.2"
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.9.0-rc.2"
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.11.0"
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.9.0"

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 ## License
 
-Mapbox Search for iOS version 2.9.0-rc.2
+Mapbox Search for iOS version 2.9.0
 Mapbox Search iOS SDK
 
 Copyright © 2021 - 2025 Mapbox, Inc. All rights reserved.

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearch'
-  s.version          = '2.9.0-rc.2'
+  s.version          = '2.9.0'
   s.summary          = 'Search SDK for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.
@@ -24,6 +24,6 @@ Some iOS platform specifics applies.
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency "MapboxCoreSearch", '2.9.0-rc.2'
-  s.dependency "MapboxCommon", '24.11.0-rc.2'
+  s.dependency "MapboxCoreSearch", '2.9.0'
+  s.dependency "MapboxCommon", '24.11.0'
 end

--- a/MapboxSearch.xcodeproj/project.pbxproj
+++ b/MapboxSearch.xcodeproj/project.pbxproj
@@ -3732,7 +3732,7 @@
 			repositoryURL = "https://github.com/mapbox/mapbox-maps-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = "11.11.0-rc.1";
+				version = 11.11.0;
 			};
 		};
 		043339CB2C61295D001650FA /* XCRemoteSwiftPackageReference "atlantis" */ = {
@@ -3756,7 +3756,7 @@
 			repositoryURL = "https://github.com/mapbox/mapbox-common-ios";
 			requirement = {
 				kind = exactVersion;
-				version = "24.11.0-rc.2";
+				version = 24.11.0;
 			};
 		};
 		F9C5573E2670CB0400BE8B94 /* XCRemoteSwiftPackageReference "CwlPreconditionTesting" */ = {

--- a/MapboxSearchUI.podspec
+++ b/MapboxSearchUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearchUI'
-  s.version          = '2.9.0-rc.2'
+  s.version          = '2.9.0'
   s.summary          = 'Search UI for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.
@@ -23,5 +23,5 @@ Card style custom UI with full search functionality powered by Mapbox Search API
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency 'MapboxSearch', "2.9.0-rc.2"
+  s.dependency 'MapboxSearch', "2.9.0"
 end

--- a/Package.swift
+++ b/Package.swift
@@ -4,9 +4,9 @@
 import PackageDescription
 import Foundation
 
-let (coreSearchVersion, coreSearchVersionHash) = ("2.9.0-rc.2", "6039da490dea725e95c1a6ca319b5be938e0a98b33cd439f85b24bc6456a569b")
+let (coreSearchVersion, coreSearchVersionHash) = ("2.9.0", "96095d817590a600ed96a1268eefadf9599dacb99e92def0739b0270216f2b2e")
 
-let mapboxCommonSDKVersion = Version("24.11.0-rc.2")
+let mapboxCommonSDKVersion = Version("24.11.0")
 
 let package = Package(
     name: "MapboxSearch",

--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ dependencies: [
 ##### MapboxSearch
 To integrate latest pre-release version of `MapboxSearch` into your Xcode project using CocoaPods, specify it in your `Podfile`:
 ```
-pod 'MapboxSearch', ">= 2.9.0-rc.2", "< 3.0"
+pod 'MapboxSearch', ">= 2.9.0", "< 3.0"
 ```
 
 ##### MapboxSearchUI
 To integrate latest pre-release version of `MapboxSearchUI` into your Xcode project using CocoaPods, specify it in your `Podfile`:
 ```
-pod 'MapboxSearchUI', ">= 2.9.0-rc.2", "< 3.0"
+pod 'MapboxSearchUI', ">= 2.9.0", "< 3.0"
 ```
 
 ### Carthage
@@ -109,7 +109,7 @@ pod 'MapboxSearchUI', ">= 2.9.0-rc.2", "< 3.0"
 2. Follow the [Carthage Quick Start](https://github.com/Carthage/Carthage?tab=readme-ov-file#quick-start) and specificy the MapboxSearch dependency in your `Cartfile`:
 
 ```
-github "Mapbox/mapbox-search-ios" ~> 2.9.0-rc.2
+github "Mapbox/mapbox-search-ios" ~> 2.9.0
 ```
 
 ## Contributing

--- a/Search Documentation.docc/Installation.md
+++ b/Search Documentation.docc/Installation.md
@@ -59,7 +59,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearchUI', ">= 2.9.0-rc.2", "< 3.0"
+      pod 'MapboxSearchUI', ">= 2.9.0", "< 3.0"
     end
     ```
 
@@ -68,7 +68,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearch', ">= 2.9.0-rc.2", "< 3.0"
+      pod 'MapboxSearch', ">= 2.9.0", "< 3.0"
     end
     ```
 

--- a/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
+++ b/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
@@ -1,2 +1,2 @@
 /// Mapbox Search SDK version variable
-public let mapboxSearchSDKVersion = "2.9.0-rc.2"
+public let mapboxSearchSDKVersion = "2.9.0"

--- a/Sources/MapboxSearch/PublicAPI/ServiceProvider.swift
+++ b/Sources/MapboxSearch/PublicAPI/ServiceProvider.swift
@@ -87,7 +87,8 @@ extension ServiceProvider: EngineProviderProtocol {
             baseUrl: Self.customBaseURL,
             apiType: NSNumber(value: apiType.rawValue),
             sdkInformation: SdkInformation.defaultInfo,
-            eventsUrl: nil
+            eventsUrl: nil,
+            onlineRequestTimeout: nil
         )
 
         return CoreSearchEngine(
@@ -118,7 +119,8 @@ extension ServiceProvider: EngineProviderProtocol {
             baseUrl: customBaseURL,
             apiType: NSNumber(value: apiType.rawValue),
             sdkInformation: SdkInformation.defaultInfo,
-            eventsUrl: nil
+            eventsUrl: nil,
+            onlineRequestTimeout: nil
         )
 
         return CoreSearchEngine(

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/CoreSearchResultStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/CoreSearchResultStub.swift
@@ -152,7 +152,8 @@ extension CoreSearchResultProtocol {
             userRecordID: userRecordID,
             userRecordPriority: 100,
             action: action,
-            serverIndex: serverIndex
+            serverIndex: serverIndex,
+            bbox: nil
         )
     }
 }


### PR DESCRIPTION
### Description
- Updates dependencies for 2.9.0
- Adopts a new property `EngineOptions.onlineRequestTimeout`. This configuration will not be exposed in the public API.

### Checklist
- [x] Update `CHANGELOG`
