### PR TITLE
Release 2.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@
 Guide: https://keepachangelog.com/en/1.0.0/
 -->
 
-## Unreleased
+## 2.9.3
+
+- [Core] Update dependencies.
+
+**MapboxCommon**: v24.11.3
+**MapboxCoreSearch**: v2.9.3
+
 
 ## 2.9.0
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.9.0
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.11.0
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.9.3
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.11.3

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.11.0"
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.9.0"
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.11.3"
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.9.3"

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 ## License
 
-Mapbox Search for iOS version 2.9.0
+Mapbox Search for iOS version 2.9.3
 Mapbox Search iOS SDK
 
 Copyright © 2021 - 2025 Mapbox, Inc. All rights reserved.

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearch'
-  s.version          = '2.9.0'
+  s.version          = '2.9.3'
   s.summary          = 'Search SDK for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.
@@ -24,6 +24,6 @@ Some iOS platform specifics applies.
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency "MapboxCoreSearch", '2.9.0'
-  s.dependency "MapboxCommon", '24.11.0'
+  s.dependency "MapboxCoreSearch", '2.9.3'
+  s.dependency "MapboxCommon", '24.11.3'
 end

--- a/MapboxSearch.xcodeproj/project.pbxproj
+++ b/MapboxSearch.xcodeproj/project.pbxproj
@@ -3732,7 +3732,7 @@
 			repositoryURL = "https://github.com/mapbox/mapbox-maps-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 11.11.0;
+				version = 11.11.1;
 			};
 		};
 		043339CB2C61295D001650FA /* XCRemoteSwiftPackageReference "atlantis" */ = {
@@ -3756,7 +3756,7 @@
 			repositoryURL = "https://github.com/mapbox/mapbox-common-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 24.11.0;
+				version = 24.11.3;
 			};
 		};
 		F9C5573E2670CB0400BE8B94 /* XCRemoteSwiftPackageReference "CwlPreconditionTesting" */ = {

--- a/MapboxSearchUI.podspec
+++ b/MapboxSearchUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearchUI'
-  s.version          = '2.9.0'
+  s.version          = '2.9.3'
   s.summary          = 'Search UI for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.
@@ -23,5 +23,5 @@ Card style custom UI with full search functionality powered by Mapbox Search API
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency 'MapboxSearch', "2.9.0"
+  s.dependency 'MapboxSearch', "2.9.3"
 end

--- a/Package.swift
+++ b/Package.swift
@@ -4,9 +4,9 @@
 import PackageDescription
 import Foundation
 
-let (coreSearchVersion, coreSearchVersionHash) = ("2.9.0", "96095d817590a600ed96a1268eefadf9599dacb99e92def0739b0270216f2b2e")
+let (coreSearchVersion, coreSearchVersionHash) = ("2.9.3", "449cc55845421e684a6aef905e4a9a38a7e289dfe9708a897897aeb3bb56b4bf")
 
-let mapboxCommonSDKVersion = Version("24.11.0")
+let mapboxCommonSDKVersion = Version("24.11.3")
 
 let package = Package(
     name: "MapboxSearch",

--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ dependencies: [
 ##### MapboxSearch
 To integrate latest pre-release version of `MapboxSearch` into your Xcode project using CocoaPods, specify it in your `Podfile`:
 ```
-pod 'MapboxSearch', ">= 2.9.0", "< 3.0"
+pod 'MapboxSearch', ">= 2.9.3", "< 3.0"
 ```
 
 ##### MapboxSearchUI
 To integrate latest pre-release version of `MapboxSearchUI` into your Xcode project using CocoaPods, specify it in your `Podfile`:
 ```
-pod 'MapboxSearchUI', ">= 2.9.0", "< 3.0"
+pod 'MapboxSearchUI', ">= 2.9.3", "< 3.0"
 ```
 
 ### Carthage
@@ -109,7 +109,7 @@ pod 'MapboxSearchUI', ">= 2.9.0", "< 3.0"
 2. Follow the [Carthage Quick Start](https://github.com/Carthage/Carthage?tab=readme-ov-file#quick-start) and specificy the MapboxSearch dependency in your `Cartfile`:
 
 ```
-github "Mapbox/mapbox-search-ios" ~> 2.9.0
+github "Mapbox/mapbox-search-ios" ~> 2.9.3
 ```
 
 ## Contributing

--- a/Search Documentation.docc/Installation.md
+++ b/Search Documentation.docc/Installation.md
@@ -59,7 +59,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearchUI', ">= 2.9.0", "< 3.0"
+      pod 'MapboxSearchUI', ">= 2.9.3", "< 3.0"
     end
     ```
 
@@ -68,7 +68,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearch', ">= 2.9.0", "< 3.0"
+      pod 'MapboxSearch', ">= 2.9.3", "< 3.0"
     end
     ```
 

--- a/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
+++ b/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
@@ -1,2 +1,2 @@
 /// Mapbox Search SDK version variable
-public let mapboxSearchSDKVersion = "2.9.0"
+public let mapboxSearchSDKVersion = "2.9.3"


### PR DESCRIPTION
Currently a draft because `MapboxMaps 11.11.3` (SPM package) is not available.

----
Description
* Updates dependencies for 2.9.3

### Checklist
- [x] Update `CHANGELOG`
