### PR TITLE
Release 2.12.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 ## 2.12.0-rc.1
 
+- [SearchResult] Added property `categoryIds` that returns canonical POI category IDs.
+- [SearchSuggestion] Added property `categoryIds` that returns canonical POI category IDs.
 - [Core] Update dependencies.
 
 **MapboxCommon**: v24.12.0-rc.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 ## 2.12.0-beta.2
 
+⚠️ Minor version has been aligned with other Mapbox SDK offerings. Search SDK v2.12.0 is a successor to v2.9.0. Versions 2.10 and 2.11 of the Search SDK do not exist.
+
 - [Core] Update dependencies.
 
 **MapboxCommon**: v24.12.0-beta.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 Guide: https://keepachangelog.com/en/1.0.0/
 -->
 
+## 2.12.0-rc.1
+
+- [Core] Update dependencies.
+
+**MapboxCommon**: v24.12.0-rc.1
+**MapboxCoreSearch**: v2.12.0-rc.1
+
 ## 2.12.0-beta.2
 
 - [Core] Update dependencies.

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.12.0-beta.1
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.12.0-beta.1
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.12.0-rc.1
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.12.0-rc.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.12.0-beta.1"
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.12.0-beta.1"
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.12.0-rc.1"
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.12.0-rc.1"

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 ## License
 
-Mapbox Search for iOS version 2.12.0-beta.2
+Mapbox Search for iOS version 2.12.0-rc.1
 Mapbox Search iOS SDK
 
 Copyright © 2021 - 2025 Mapbox, Inc. All rights reserved.

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearch'
-  s.version          = '2.12.0-beta.2'
+  s.version          = '2.12.0-rc.1'
   s.summary          = 'Search SDK for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.
@@ -24,6 +24,6 @@ Some iOS platform specifics applies.
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency "MapboxCoreSearch", '2.12.0-beta.1'
-  s.dependency "MapboxCommon", '24.12.0-beta.1'
+  s.dependency "MapboxCoreSearch", '2.12.0-rc.1'
+  s.dependency "MapboxCommon", '24.12.0-rc.1'
 end

--- a/MapboxSearch.xcodeproj/project.pbxproj
+++ b/MapboxSearch.xcodeproj/project.pbxproj
@@ -3732,7 +3732,7 @@
 			repositoryURL = "https://github.com/mapbox/mapbox-maps-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = "11.12.0-beta.1";
+				version = "11.12.0-rc.1";
 			};
 		};
 		043339CB2C61295D001650FA /* XCRemoteSwiftPackageReference "atlantis" */ = {
@@ -3756,7 +3756,7 @@
 			repositoryURL = "https://github.com/mapbox/mapbox-common-ios";
 			requirement = {
 				kind = exactVersion;
-				version = "24.12.0-beta.1";
+				version = "24.12.0-rc.1";
 			};
 		};
 		F9C5573E2670CB0400BE8B94 /* XCRemoteSwiftPackageReference "CwlPreconditionTesting" */ = {

--- a/MapboxSearchUI.podspec
+++ b/MapboxSearchUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearchUI'
-  s.version          = '2.12.0-beta.2'
+  s.version          = '2.12.0-rc.1'
   s.summary          = 'Search UI for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.
@@ -23,5 +23,5 @@ Card style custom UI with full search functionality powered by Mapbox Search API
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency 'MapboxSearch', "24.12.0-beta.1"
+  s.dependency 'MapboxSearch', "2.12.0-rc.1"
 end

--- a/Package.swift
+++ b/Package.swift
@@ -4,9 +4,9 @@
 import PackageDescription
 import Foundation
 
-let (coreSearchVersion, coreSearchVersionHash) = ("2.12.0-beta.1", "a87d96e56b35e0381c89a48c9a53b73f55daf5306ee0064a9928a6934acf9a5e")
+let (coreSearchVersion, coreSearchVersionHash) = ("2.12.0-rc.1", "b02a2a1e6ced081d584f4851f9dab0504eec9791a50aa75a51b83077496d2806")
 
-let mapboxCommonSDKVersion = Version("24.12.0-beta.1")
+let mapboxCommonSDKVersion = Version("24.12.0-rc.1")
 
 let package = Package(
     name: "MapboxSearch",

--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ dependencies: [
 ##### MapboxSearch
 To integrate latest pre-release version of `MapboxSearch` into your Xcode project using CocoaPods, specify it in your `Podfile`:
 ```
-pod 'MapboxSearch', ">= 2.12.0-beta.2", "< 3.0"
+pod 'MapboxSearch', ">= 2.12.0-rc.1", "< 3.0"
 ```
 
 ##### MapboxSearchUI
 To integrate latest pre-release version of `MapboxSearchUI` into your Xcode project using CocoaPods, specify it in your `Podfile`:
 ```
-pod 'MapboxSearchUI', ">= 2.12.0-beta.2", "< 3.0"
+pod 'MapboxSearchUI', ">= 2.12.0-rc.1", "< 3.0"
 ```
 
 ### Carthage
@@ -109,7 +109,7 @@ pod 'MapboxSearchUI', ">= 2.12.0-beta.2", "< 3.0"
 2. Follow the [Carthage Quick Start](https://github.com/Carthage/Carthage?tab=readme-ov-file#quick-start) and specificy the MapboxSearch dependency in your `Cartfile`:
 
 ```
-github "Mapbox/mapbox-search-ios" ~> 2.12.0-beta.2
+github "Mapbox/mapbox-search-ios" ~> 2.12.0-rc.1
 ```
 
 ## Contributing

--- a/Search Documentation.docc/Installation.md
+++ b/Search Documentation.docc/Installation.md
@@ -59,7 +59,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearchUI', ">= 2.12.0-beta.2", "< 3.0"
+      pod 'MapboxSearchUI', ">= 2.12.0-rc.1", "< 3.0"
     end
     ```
 
@@ -68,7 +68,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearch', ">= 2.12.0-beta.2", "< 3.0"
+      pod 'MapboxSearch', ">= 2.12.0-rc.1", "< 3.0"
     end
     ```
 

--- a/Sources/Demo/ResultDetailViewController.swift
+++ b/Sources/Demo/ResultDetailViewController.swift
@@ -166,10 +166,16 @@ extension SearchResult {
         }
 
         if let categories, !categories.isEmpty {
-            let categories = categories.count > 2 ? Array(categories.dropFirst(2)) : categories
 
             components.append(
                 (name: "Categories", value: categories.joined(separator: ","))
+            )
+        }
+
+        if let categoryIds, !categoryIds.isEmpty {
+
+            components.append(
+                (name: "Category IDs", value: categoryIds.joined(separator: ","))
             )
         }
 

--- a/Sources/MapboxSearch/PublicAPI/FavoriteRecord.swift
+++ b/Sources/MapboxSearch/PublicAPI/FavoriteRecord.swift
@@ -53,8 +53,11 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
         icon?.name
     }
 
-    /// Result categories types.
+    /// POI categories. Always empty for non-POI search results.
     public var categories: [String]?
+
+    /// Canonical POI category IDs. Always empty for non-POI results.
+    public var categoryIds: [String]?
 
     /// Coordinates of building entries
     public var routablePoints: [RoutablePoint]?
@@ -88,6 +91,7 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
     ///   - serverIndex: The index in response from server
     ///   - accuracy: A point accuracy metric for the returned address
     ///   - categories: Favorite categories list
+    ///   - categoryIds: Favorite category IDs list
     ///   - routablePoints: Coordinates of building entries
     ///   - searchRequest: original search request
     ///   - metadata: Associated metadata
@@ -105,6 +109,7 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
         serverIndex: Int?,
         accuracy: SearchResultAccuracy?,
         categories: [String]?,
+        categoryIds: [String]?,
         routablePoints: [RoutablePoint]? = nil,
         resultType: SearchResultType,
         searchRequest: SearchRequestOptions,
@@ -122,6 +127,7 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
         self.serverIndex = serverIndex
         self.accuracy = accuracy
         self.categories = categories
+        self.categoryIds = categoryIds
         self.routablePoints = routablePoints
         self.type = resultType
         self.metadata = metadata
@@ -151,6 +157,7 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
             serverIndex: searchResult.serverIndex,
             accuracy: searchResult.accuracy,
             categories: searchResult.categories,
+            categoryIds: searchResult.categoryIds,
             routablePoints: searchResult.routablePoints,
             resultType: searchResult.type,
             searchRequest: searchResult.searchRequest,

--- a/Sources/MapboxSearch/PublicAPI/HistoryRecord.swift
+++ b/Sources/MapboxSearch/PublicAPI/HistoryRecord.swift
@@ -79,8 +79,11 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
     /// SearchEngine would track that tokens to match results
     public var additionalTokens: Set<String>?
 
-    /// Categories associated with original result
+    /// POI categories associated with the original result
     public var categories: [String]?
+
+    /// Canonical POI category IDs associated with the original result
+    public var categoryIds: [String]?
 
     /// Original search request.
     public let searchRequest: SearchRequestOptions
@@ -104,6 +107,7 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
     ///   - address: History address
     ///   - metadata: Associated metadata
     ///   - categories: Categories of original object
+    ///   - categoryIds: Category IDs of original object
     ///   - searchRequest: The original search request
     ///   - routablePoints: Coordinates of building entries
     ///   - descriptionText: Address formatted with the medium style
@@ -122,6 +126,7 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
         address: Address?,
         metadata: SearchResultMetadata? = nil,
         categories: [String]? = nil,
+        categoryIds: [String]? = nil,
         searchRequest: SearchRequestOptions,
         routablePoints: [RoutablePoint]? = nil,
         descriptionText: String? = nil
@@ -140,6 +145,7 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
         self.address = address
         self.metadata = metadata
         self.categories = categories
+        self.categoryIds = categoryIds
         self.searchRequest = searchRequest
         self.routablePoints = routablePoints
         self.descriptionText = descriptionText ?? address?.formattedAddress(style: .medium)
@@ -169,6 +175,7 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
         self.address = searchResult.address
         self.metadata = searchResult.metadata
         self.categories = searchResult.categories
+        self.categoryIds = searchResult.categoryIds
         self.searchRequest = searchResult.searchRequest
         self.routablePoints = searchResult.routablePoints
         self.descriptionText = searchResult.descriptionText

--- a/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
+++ b/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
@@ -1,2 +1,2 @@
 /// Mapbox Search SDK version variable
-public let mapboxSearchSDKVersion = "2.12.0-beta.2"
+public let mapboxSearchSDKVersion = "2.12.0-rc.1"

--- a/Sources/MapboxSearch/PublicAPI/Search Results/ExternalRecordPlaceholder.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/ExternalRecordPlaceholder.swift
@@ -24,6 +24,8 @@ class ExternalRecordPlaceholder: SearchResultSuggestion, CoreResponseProvider {
 
     var categories: [String]?
 
+    var categoryIds: [String]?
+
     var suggestionType: SearchSuggestType = .POI
 
     var distance: CLLocationDistance?
@@ -48,6 +50,7 @@ class ExternalRecordPlaceholder: SearchResultSuggestion, CoreResponseProvider {
         self.distance = coreResult.distanceToProximity
         self.originalResponse = CoreSearchResultResponse(coreResult: coreResult, response: response)
         self.categories = coreResult.categories
+        self.categoryIds = coreResult.categoryIDs
         self.serverIndex = coreResult.serverIndex?.intValue
         self.estimatedTime = coreResult.estimatedTime
         self.descriptionText = coreResult.addresses?.first.map(Address.init)?.formattedAddress(style: .medium)

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchBrandSuggestionImpl.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchBrandSuggestionImpl.swift
@@ -30,7 +30,7 @@ class SearchBrandSuggestionImpl: SearchBrandSuggestion, CoreResponseProvider {
 
     var categories: [String]?
 
-    var categoryIDs: [String]?
+    var categoryIds: [String]?
 
     var distance: CLLocationDistance?
 
@@ -59,7 +59,7 @@ class SearchBrandSuggestionImpl: SearchBrandSuggestion, CoreResponseProvider {
         self.distance = coreResult.distanceToProximity
         self.batchResolveSupported = coreResult.action?.multiRetrievable ?? false
         self.categories = coreResult.categories
-        self.categoryIDs = coreResult.categoryIDs
+        self.categoryIds = coreResult.categoryIDs
 
         self.descriptionText = coreResult.addressDescription
         self.estimatedTime = coreResult.estimatedTime

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchCategorySuggestionImpl.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchCategorySuggestionImpl.swift
@@ -24,7 +24,7 @@ class SearchCategorySuggestionImpl: SearchCategorySuggestion, CoreResponseProvid
 
     var categories: [String]?
 
-    var categoryIDs: [String]?
+    var categoryIds: [String]?
 
     var distance: CLLocationDistance?
 
@@ -55,7 +55,7 @@ class SearchCategorySuggestionImpl: SearchCategorySuggestion, CoreResponseProvid
         self.distance = coreResult.distanceToProximity
         self.batchResolveSupported = coreResult.action?.multiRetrievable ?? false
         self.categories = coreResult.categories
-        self.categoryIDs = coreResult.categoryIDs
+        self.categoryIds = coreResult.categoryIDs
 
         self.descriptionText = coreResult.addressDescription
         self.estimatedTime = coreResult.estimatedTime

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchQuerySuggestionImpl.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchQuerySuggestionImpl.swift
@@ -22,6 +22,8 @@ class SearchQuerySuggestionImpl: SearchQuerySuggestion, CoreResponseProvider {
 
     var categories: [String]?
 
+    var categoryIds: [String]?
+
     var suggestionType: SearchSuggestType
 
     var distance: CLLocationDistance?
@@ -50,6 +52,7 @@ class SearchQuerySuggestionImpl: SearchQuerySuggestion, CoreResponseProvider {
         self.distance = coreResult.distanceToProximity
         self.batchResolveSupported = coreResult.action?.multiRetrievable ?? false
         self.categories = coreResult.categories
+        self.categoryIds = coreResult.categoryIDs
         self.estimatedTime = coreResult.estimatedTime
         self.descriptionText = coreResult.addressDescription
         self.estimatedTime = coreResult.estimatedTime

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchResult.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchResult.swift
@@ -38,8 +38,11 @@ public protocol SearchResult {
     /// Contains formatted address.
     var descriptionText: String? { get }
 
-    /// Result categories types.
+    /// POI categories. Always empty for non-POI search results.
     var categories: [String]? { get }
+
+    /// Canonical POI category IDs. Always empty for non-POI results.
+    var categoryIds: [String]? { get }
 
     /// Coordinates of building entries
     var routablePoints: [RoutablePoint]? { get }

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchResultSuggestionImpl.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchResultSuggestionImpl.swift
@@ -22,6 +22,8 @@ class SearchResultSuggestionImpl: SearchResultSuggestion, CoreResponseProvider {
 
     var categories: [String]?
 
+    var categoryIds: [String]?
+
     var suggestionType: SearchSuggestType
 
     var descriptionText: String?
@@ -64,6 +66,7 @@ class SearchResultSuggestionImpl: SearchResultSuggestion, CoreResponseProvider {
         self.distance = coreResult.distanceToProximity
         self.batchResolveSupported = coreResult.action?.multiRetrievable ?? false
         self.categories = coreResult.categories
+        self.categoryIds = coreResult.categoryIDs
         self.estimatedTime = coreResult.estimatedTime
         self.descriptionText = coreResult.addressDescription
         self.estimatedTime = coreResult.estimatedTime

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchSuggestion.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchSuggestion.swift
@@ -26,8 +26,11 @@ public protocol SearchSuggestion {
     /// Usually contains pre-formatted address.
     var descriptionText: String? { get }
 
-    /// Result categories types.
+    /// POI categories. Always empty for non-POI search suggestions.
     var categories: [String]? { get }
+
+    /// Canonical POI category IDs. Always empty for non-POI search suggestions.
+    var categoryIds: [String]? { get }
 
     /// Result address.
     var address: Address? { get }

--- a/Sources/MapboxSearch/PublicAPI/Search Results/ServerSearchResult.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/ServerSearchResult.swift
@@ -29,6 +29,8 @@ class ServerSearchResult: SearchResult, SearchResultSuggestion, CoreResponseProv
 
     var categories: [String]?
 
+    var categoryIds: [String]?
+
     var routablePoints: [RoutablePoint]?
 
     let dataLayerIdentifier = SearchEngine.providerIdentifier
@@ -80,6 +82,7 @@ class ServerSearchResult: SearchResult, SearchResultSuggestion, CoreResponseProv
         self.accuracy = coreResult.resultAccuracy.flatMap(SearchResultAccuracy.from(coreAccuracy:))
         self.address = coreResult.addresses?.first.map(Address.init)
         self.categories = coreResult.categories
+        self.categoryIds = coreResult.categoryIDs
         self.coordinateCodable = .init(center.coordinate)
         self.originalResponse = CoreSearchResultResponse(coreResult: coreResult, response: response)
 

--- a/Tests/MapboxSearchTests/Common/Data Samples/SearchResultStub+Samples.swift
+++ b/Tests/MapboxSearchTests/Common/Data Samples/SearchResultStub+Samples.swift
@@ -5,6 +5,7 @@ extension SearchResultStub {
         id: "sample-1",
         mapboxId: UUID().uuidString, // not actually UUID format but useful for tests
         categories: ["sample-1", "sample-2"],
+        categoryIds: ["sample-catID-1", "sample-catID-2"],
         name: "Sample No 1",
         matchingName: nil,
         serverIndex: nil,

--- a/Tests/MapboxSearchTests/Common/Models/Search Result/SearchResultSuggestionImplTests.swift
+++ b/Tests/MapboxSearchTests/Common/Models/Search Result/SearchResultSuggestionImplTests.swift
@@ -46,6 +46,48 @@ class SearchResultSuggestionImplTests: XCTestCase {
         XCTAssertEqual(suggestionImpl.namePreferred, coreResult.namePreferred)
     }
 
+    func testSuccessfulInitForCategories() throws {
+        let coreResult = CoreSearchResultStub(
+            id: "sample-2",
+            mapboxId: "sample-2",
+            type: .poi,
+            centerLocation: nil,
+            categories: ["category1", "category2"]
+        )
+        let suggestionImpl = try XCTUnwrap(SearchResultSuggestionImpl(
+            coreResult: coreResult,
+            response: CoreSearchResponseStub(
+                id: 42,
+                options: .sample1,
+                result: .success([])
+            )
+        ))
+        XCTAssertEqual(suggestionImpl.suggestionType, .POI)
+        XCTAssertEqual(suggestionImpl.name, coreResult.names.first)
+        XCTAssertEqual(suggestionImpl.categories, coreResult.categories)
+    }
+
+    func testSuccessfulInitForCategoryIds() throws {
+        let coreResult = CoreSearchResultStub(
+            id: "sample-2",
+            mapboxId: "sample-2",
+            type: .poi,
+            centerLocation: nil,
+            categoryIDs: ["categoryID1", "categoryID2"]
+        )
+        let suggestionImpl = try XCTUnwrap(SearchResultSuggestionImpl(
+            coreResult: coreResult,
+            response: CoreSearchResponseStub(
+                id: 42,
+                options: .sample1,
+                result: .success([])
+            )
+        ))
+        XCTAssertEqual(suggestionImpl.suggestionType, .POI)
+        XCTAssertEqual(suggestionImpl.name, coreResult.names.first)
+        XCTAssertEqual(suggestionImpl.categoryIds, coreResult.categoryIDs)
+    }
+
     func testFailedInit() throws {
         XCTAssertNil(SearchResultSuggestionImpl(
             coreResult: CoreSearchResultStub(

--- a/Tests/MapboxSearchTests/Common/Models/Search Result/SearchResultTests.swift
+++ b/Tests/MapboxSearchTests/Common/Models/Search Result/SearchResultTests.swift
@@ -18,4 +18,40 @@ class SearchResultTests: XCTestCase {
         XCTAssertEqual(resultStub.placemark.location?.coordinate.latitude, 12)
         XCTAssertEqual(resultStub.placemark.location?.coordinate.longitude, -35)
     }
+
+    func testCategories() throws {
+        let expectedCategories = ["category1", "category2"]
+        let resultStub = SearchResultStub(
+            id: "unit-test-random",
+            mapboxId: nil,
+            categories: expectedCategories,
+            name: "Unit Test",
+            matchingName: nil,
+            serverIndex: nil,
+            resultType: .POI,
+            coordinate: .init(latitude: 12, longitude: -35),
+            distance: nil,
+            metadata: .pizzaMetadata
+        )
+
+        XCTAssertEqual(resultStub.categories, expectedCategories)
+    }
+
+    func testCategoryIds() throws {
+        let expectedCategoryIds = ["categoryID1", "categoryID2"]
+        let resultStub = SearchResultStub(
+            id: "unit-test-random",
+            mapboxId: nil,
+            categoryIds: expectedCategoryIds,
+            name: "Unit Test",
+            matchingName: nil,
+            serverIndex: nil,
+            resultType: .POI,
+            coordinate: .init(latitude: 12, longitude: -35),
+            distance: nil,
+            metadata: .pizzaMetadata
+        )
+
+        XCTAssertEqual(resultStub.categoryIds, expectedCategoryIds)
+    }
 }

--- a/Tests/MapboxSearchTests/Common/Models/Search Result/ServerSearchResultTests.swift
+++ b/Tests/MapboxSearchTests/Common/Models/Search Result/ServerSearchResultTests.swift
@@ -91,4 +91,24 @@ class ServerSearchResultTests: XCTestCase {
         XCTAssertNotNil(result.distance)
         XCTAssertEqual(result.distance, 0.0)
     }
+
+    func testServerSearchResultCategoriesField() throws {
+        let expectedCategories = ["category1", "category2"]
+        let coreResult = CoreSearchResultStub(id: UUID().uuidString, mapboxId: "", type: .address, categories: expectedCategories)
+        let result = try XCTUnwrap(ServerSearchResult(
+            coreResult: coreResult,
+            response: CoreSearchResponseStub.failureSample
+        ))
+        XCTAssertEqual(result.categories, expectedCategories)
+    }
+
+    func testServerSearchResultCategoryIdsField() throws {
+        let expectedCategoryIds = ["categoryID1", "categoryID2"]
+        let coreResult = CoreSearchResultStub(id: UUID().uuidString, mapboxId: "", type: .address, categoryIDs: expectedCategoryIds)
+        let result = try XCTUnwrap(ServerSearchResult(
+            coreResult: coreResult,
+            response: CoreSearchResponseStub.failureSample
+        ))
+        XCTAssertEqual(result.categoryIds, expectedCategoryIds)
+    }
 }

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/CoreSearchResultStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/CoreSearchResultStub.swift
@@ -55,7 +55,9 @@ class CoreSearchResultStub: CoreSearchResultProtocol {
             mapboxId: dataProviderRecord.mapboxId,
             type: dataProviderRecord.type.coreType,
             names: [dataProviderRecord.name],
-            languages: ["en"]
+            languages: ["en"],
+            categories: dataProviderRecord.categories,
+            categoryIDs: dataProviderRecord.categoryIds
         )
     }
 

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/SearchResultStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/SearchResultStub.swift
@@ -7,6 +7,7 @@ class SearchResultStub: SearchResult {
         mapboxId: String?,
         accuracy: SearchResultAccuracy? = nil,
         categories: [String]? = nil,
+        categoryIds: [String]? = nil,
         name: String,
         matchingName: String?,
         serverIndex: Int?,
@@ -24,6 +25,7 @@ class SearchResultStub: SearchResult {
         self.mapboxId = mapboxId
         self.accuracy = accuracy
         self.categories = categories
+        self.categoryIds = categoryIds
         self.name = name
         self.matchingName = matchingName
         self.serverIndex = serverIndex
@@ -44,6 +46,7 @@ class SearchResultStub: SearchResult {
     var mapboxId: String?
     var accuracy: SearchResultAccuracy?
     var categories: [String]?
+    var categoryIds: [String]?
     var name: String
     var matchingName: String?
     var serverIndex: Int?

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/SearchResultSuggestionStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/SearchResultSuggestionStub.swift
@@ -18,6 +18,8 @@ struct SearchResultSuggestionStub: SearchResultSuggestion {
 
     var categories: [String]?
 
+    var categoryIds: [String]?
+
     var descriptionText: String? = "Test description text"
 
     var iconName: String? = Maki.bar.name

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/SearchSuggestionStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/SearchSuggestionStub.swift
@@ -7,6 +7,7 @@ struct SearchSuggestionStub: SearchSuggestion {
     var name: String = "Test Name"
     var namePreferred: String? = "POI Preferred name"
     var categories: [String]?
+    var categoryIds: [String]?
     var descriptionText: String? = "Test Description"
     var address: Address?
     var iconName: String?

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/TestDataProviderRecord.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/TestDataProviderRecord.swift
@@ -12,6 +12,7 @@ struct TestDataProviderRecord: IndexableRecord, SearchResult {
     var coordinate: CLLocationCoordinate2D
     var iconName: String?
     var categories: [String]?
+    var categoryIds: [String]?
     var routablePoints: [RoutablePoint]?
     var distance: CLLocationDistance?
     var address: Address?
@@ -28,7 +29,9 @@ struct TestDataProviderRecord: IndexableRecord, SearchResult {
             let record = TestDataProviderRecord(
                 type: .POI,
                 name: "name_\(index)",
-                coordinate: CLLocationCoordinate2D(latitude: 53.89, longitude: 27.55)
+                coordinate: CLLocationCoordinate2D(latitude: 53.89, longitude: 27.55),
+                categories: ["cat-1", "cat-2"],
+                categoryIds: ["cat-ID-1", "cat-ID-2"]
             )
             results.append(record)
         }

--- a/Tests/MapboxSearchTests/Legacy/CodablePersistentServiceTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/CodablePersistentServiceTests.swift
@@ -41,6 +41,7 @@ class CodablePersistentServiceTests: XCTestCase {
             serverIndex: nil,
             accuracy: nil,
             categories: [],
+            categoryIds: [],
             resultType: .address(subtypes: [.address]),
             searchRequest: .init(query: "Sample", proximity: nil)
         )

--- a/Tests/MapboxSearchTests/Legacy/FavoriteRecordTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/FavoriteRecordTests.swift
@@ -11,6 +11,7 @@ class FavoriteRecordTests: XCTestCase {
         XCTAssertEqual(record.name, "Custom Name")
         XCTAssertEqual(record.address, resultStub.address)
         XCTAssertEqual(record.categories, resultStub.categories)
+        XCTAssertEqual(record.categoryIds, resultStub.categoryIds)
         XCTAssertEqual(record.coordinateCodable, resultStub.coordinateCodable)
         XCTAssertEqual(record.coordinate, resultStub.coordinate)
         XCTAssertEqual(record.icon, .bar)

--- a/Tests/MapboxSearchTests/Legacy/HistoryRecordTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/HistoryRecordTests.swift
@@ -75,6 +75,8 @@ class HistoryRecordTests: XCTestCase {
         XCTAssertEqual(record.historyType, .result)
         XCTAssertEqual(record.type, result.type)
         XCTAssertEqual(record.address, result.address)
+        XCTAssertEqual(record.categories, result.categories)
+        XCTAssertEqual(record.categoryIds, result.categoryIds)
         XCTAssertEqual(record.metadata, result.metadata)
         XCTAssertEqual(record.routablePoints, result.routablePoints)
         XCTAssertEqual(record.distance, 100.0)

--- a/Tests/MapboxSearchTests/Legacy/SearchCategorySuggestionImplTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/SearchCategorySuggestionImplTests.swift
@@ -9,7 +9,9 @@ class SearchCategorySuggestionImplTests: XCTestCase {
             mapboxId: "sample-2",
             type: .category,
             namePreferred: "Preferred name",
-            centerLocation: nil
+            centerLocation: nil,
+            categories: ["cat-1"],
+            categoryIDs: ["cat-ID-1"]
         )
         let suggestionImpl = try XCTUnwrap(SearchCategorySuggestionImpl(
             coreResult: coreResult,
@@ -22,6 +24,8 @@ class SearchCategorySuggestionImplTests: XCTestCase {
         XCTAssertEqual(suggestionImpl.suggestionType, .category)
         XCTAssertEqual(suggestionImpl.name, coreResult.names.first)
         XCTAssertEqual(suggestionImpl.namePreferred, "Preferred name")
+        XCTAssertEqual(suggestionImpl.categories, ["cat-1"])
+        XCTAssertEqual(suggestionImpl.categoryIds, ["cat-ID-1"])
     }
 
     func testFailedInitForPOI() throws {


### PR DESCRIPTION
Description
* Updates dependencies for 2.12.0-rc.1
* Added properties `categoryIds` to  `SearchResult` and `SearchSuggestion` that return canonical POI category IDs.

### Checklist
- [x] Update `CHANGELOG`
