### PR TITLE
Added categoryIDs properties to SearchResult & SearchSuggestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 ## 2.12.0-rc.1
 
-- [SearchResult] Added property `categoryIDs` that returns canonical POI category IDs.
-- [SearchSuggestion] Added property `categoryIDs` that returns canonical POI category IDs.
+- [SearchResult] Added property `categoryIds` that returns canonical POI category IDs.
+- [SearchSuggestion] Added property `categoryIds` that returns canonical POI category IDs.
 - [Core] Update dependencies.
 
 **MapboxCommon**: v24.12.0-rc.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 ## 2.12.0-rc.1
 
+- [SearchResult] Added property `categoryIDs` that returns canonical POI category IDs.
+- [SearchSuggestion] Added property `categoryIDs` that returns canonical POI category IDs.
 - [Core] Update dependencies.
 
 **MapboxCommon**: v24.12.0-rc.1

--- a/Sources/Demo/ResultDetailViewController.swift
+++ b/Sources/Demo/ResultDetailViewController.swift
@@ -166,10 +166,16 @@ extension SearchResult {
         }
 
         if let categories, !categories.isEmpty {
-            let categories = categories.count > 2 ? Array(categories.dropFirst(2)) : categories
 
             components.append(
                 (name: "Categories", value: categories.joined(separator: ","))
+            )
+        }
+
+        if let categoryIDs, !categoryIDs.isEmpty {
+
+            components.append(
+                (name: "Category IDs", value: categoryIDs.joined(separator: ","))
             )
         }
 

--- a/Sources/Demo/ResultDetailViewController.swift
+++ b/Sources/Demo/ResultDetailViewController.swift
@@ -172,10 +172,10 @@ extension SearchResult {
             )
         }
 
-        if let categoryIDs, !categoryIDs.isEmpty {
+        if let categoryIds, !categoryIds.isEmpty {
 
             components.append(
-                (name: "Category IDs", value: categoryIDs.joined(separator: ","))
+                (name: "Category IDs", value: categoryIds.joined(separator: ","))
             )
         }
 

--- a/Sources/MapboxSearch/PublicAPI/FavoriteRecord.swift
+++ b/Sources/MapboxSearch/PublicAPI/FavoriteRecord.swift
@@ -53,8 +53,11 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
         icon?.name
     }
 
-    /// Result categories types.
+    /// POI categories. Always empty for non-POI search results.
     public var categories: [String]?
+
+    /// Canonical POI category IDs. Always empty for non-POI results.
+    public var categoryIDs: [String]?
 
     /// Coordinates of building entries
     public var routablePoints: [RoutablePoint]?
@@ -88,6 +91,7 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
     ///   - serverIndex: The index in response from server
     ///   - accuracy: A point accuracy metric for the returned address
     ///   - categories: Favorite categories list
+    ///   - categoryIDs: Favorite category IDs list
     ///   - routablePoints: Coordinates of building entries
     ///   - searchRequest: original search request
     ///   - metadata: Associated metadata
@@ -105,6 +109,7 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
         serverIndex: Int?,
         accuracy: SearchResultAccuracy?,
         categories: [String]?,
+        categoryIDs: [String]?,
         routablePoints: [RoutablePoint]? = nil,
         resultType: SearchResultType,
         searchRequest: SearchRequestOptions,
@@ -122,6 +127,7 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
         self.serverIndex = serverIndex
         self.accuracy = accuracy
         self.categories = categories
+        self.categoryIDs = categoryIDs
         self.routablePoints = routablePoints
         self.type = resultType
         self.metadata = metadata
@@ -151,6 +157,7 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
             serverIndex: searchResult.serverIndex,
             accuracy: searchResult.accuracy,
             categories: searchResult.categories,
+            categoryIDs: searchResult.categoryIDs,
             routablePoints: searchResult.routablePoints,
             resultType: searchResult.type,
             searchRequest: searchResult.searchRequest,

--- a/Sources/MapboxSearch/PublicAPI/FavoriteRecord.swift
+++ b/Sources/MapboxSearch/PublicAPI/FavoriteRecord.swift
@@ -57,7 +57,7 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
     public var categories: [String]?
 
     /// Canonical POI category IDs. Always empty for non-POI results.
-    public var categoryIDs: [String]?
+    public var categoryIds: [String]?
 
     /// Coordinates of building entries
     public var routablePoints: [RoutablePoint]?
@@ -91,7 +91,7 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
     ///   - serverIndex: The index in response from server
     ///   - accuracy: A point accuracy metric for the returned address
     ///   - categories: Favorite categories list
-    ///   - categoryIDs: Favorite category IDs list
+    ///   - categoryIds: Favorite category IDs list
     ///   - routablePoints: Coordinates of building entries
     ///   - searchRequest: original search request
     ///   - metadata: Associated metadata
@@ -109,7 +109,7 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
         serverIndex: Int?,
         accuracy: SearchResultAccuracy?,
         categories: [String]?,
-        categoryIDs: [String]?,
+        categoryIds: [String]?,
         routablePoints: [RoutablePoint]? = nil,
         resultType: SearchResultType,
         searchRequest: SearchRequestOptions,
@@ -127,7 +127,7 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
         self.serverIndex = serverIndex
         self.accuracy = accuracy
         self.categories = categories
-        self.categoryIDs = categoryIDs
+        self.categoryIds = categoryIds
         self.routablePoints = routablePoints
         self.type = resultType
         self.metadata = metadata
@@ -157,7 +157,7 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
             serverIndex: searchResult.serverIndex,
             accuracy: searchResult.accuracy,
             categories: searchResult.categories,
-            categoryIDs: searchResult.categoryIDs,
+            categoryIds: searchResult.categoryIds,
             routablePoints: searchResult.routablePoints,
             resultType: searchResult.type,
             searchRequest: searchResult.searchRequest,

--- a/Sources/MapboxSearch/PublicAPI/HistoryRecord.swift
+++ b/Sources/MapboxSearch/PublicAPI/HistoryRecord.swift
@@ -79,8 +79,11 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
     /// SearchEngine would track that tokens to match results
     public var additionalTokens: Set<String>?
 
-    /// Categories associated with original result
+    /// POI categories associated with the original result
     public var categories: [String]?
+
+    /// Canonical POI category IDs associated with the original result
+    public var categoryIDs: [String]?
 
     /// Original search request.
     public let searchRequest: SearchRequestOptions
@@ -104,6 +107,7 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
     ///   - address: History address
     ///   - metadata: Associated metadata
     ///   - categories: Categories of original object
+    ///   - categoryIDs: Category IDs of original object
     ///   - searchRequest: The original search request
     ///   - routablePoints: Coordinates of building entries
     ///   - descriptionText: Address formatted with the medium style
@@ -122,6 +126,7 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
         address: Address?,
         metadata: SearchResultMetadata? = nil,
         categories: [String]? = nil,
+        categoryIDs: [String]? = nil,
         searchRequest: SearchRequestOptions,
         routablePoints: [RoutablePoint]? = nil,
         descriptionText: String? = nil
@@ -140,6 +145,7 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
         self.address = address
         self.metadata = metadata
         self.categories = categories
+        self.categoryIDs = categoryIDs
         self.searchRequest = searchRequest
         self.routablePoints = routablePoints
         self.descriptionText = descriptionText ?? address?.formattedAddress(style: .medium)
@@ -169,6 +175,7 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
         self.address = searchResult.address
         self.metadata = searchResult.metadata
         self.categories = searchResult.categories
+        self.categoryIDs = searchResult.categoryIDs
         self.searchRequest = searchResult.searchRequest
         self.routablePoints = searchResult.routablePoints
         self.descriptionText = searchResult.descriptionText

--- a/Sources/MapboxSearch/PublicAPI/HistoryRecord.swift
+++ b/Sources/MapboxSearch/PublicAPI/HistoryRecord.swift
@@ -83,7 +83,7 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
     public var categories: [String]?
 
     /// Canonical POI category IDs associated with the original result
-    public var categoryIDs: [String]?
+    public var categoryIds: [String]?
 
     /// Original search request.
     public let searchRequest: SearchRequestOptions
@@ -107,7 +107,7 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
     ///   - address: History address
     ///   - metadata: Associated metadata
     ///   - categories: Categories of original object
-    ///   - categoryIDs: Category IDs of original object
+    ///   - categoryIds: Category IDs of original object
     ///   - searchRequest: The original search request
     ///   - routablePoints: Coordinates of building entries
     ///   - descriptionText: Address formatted with the medium style
@@ -126,7 +126,7 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
         address: Address?,
         metadata: SearchResultMetadata? = nil,
         categories: [String]? = nil,
-        categoryIDs: [String]? = nil,
+        categoryIds: [String]? = nil,
         searchRequest: SearchRequestOptions,
         routablePoints: [RoutablePoint]? = nil,
         descriptionText: String? = nil
@@ -145,7 +145,7 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
         self.address = address
         self.metadata = metadata
         self.categories = categories
-        self.categoryIDs = categoryIDs
+        self.categoryIds = categoryIds
         self.searchRequest = searchRequest
         self.routablePoints = routablePoints
         self.descriptionText = descriptionText ?? address?.formattedAddress(style: .medium)
@@ -175,7 +175,7 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
         self.address = searchResult.address
         self.metadata = searchResult.metadata
         self.categories = searchResult.categories
-        self.categoryIDs = searchResult.categoryIDs
+        self.categoryIds = searchResult.categoryIds
         self.searchRequest = searchResult.searchRequest
         self.routablePoints = searchResult.routablePoints
         self.descriptionText = searchResult.descriptionText

--- a/Sources/MapboxSearch/PublicAPI/Search Results/ExternalRecordPlaceholder.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/ExternalRecordPlaceholder.swift
@@ -24,7 +24,7 @@ class ExternalRecordPlaceholder: SearchResultSuggestion, CoreResponseProvider {
 
     var categories: [String]?
 
-    var categoryIDs: [String]?
+    var categoryIds: [String]?
 
     var suggestionType: SearchSuggestType = .POI
 
@@ -50,7 +50,7 @@ class ExternalRecordPlaceholder: SearchResultSuggestion, CoreResponseProvider {
         self.distance = coreResult.distanceToProximity
         self.originalResponse = CoreSearchResultResponse(coreResult: coreResult, response: response)
         self.categories = coreResult.categories
-        self.categoryIDs = coreResult.categoryIDs
+        self.categoryIds = coreResult.categoryIDs
         self.serverIndex = coreResult.serverIndex?.intValue
         self.estimatedTime = coreResult.estimatedTime
         self.descriptionText = coreResult.addresses?.first.map(Address.init)?.formattedAddress(style: .medium)

--- a/Sources/MapboxSearch/PublicAPI/Search Results/ExternalRecordPlaceholder.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/ExternalRecordPlaceholder.swift
@@ -24,6 +24,8 @@ class ExternalRecordPlaceholder: SearchResultSuggestion, CoreResponseProvider {
 
     var categories: [String]?
 
+    var categoryIDs: [String]?
+
     var suggestionType: SearchSuggestType = .POI
 
     var distance: CLLocationDistance?
@@ -48,6 +50,7 @@ class ExternalRecordPlaceholder: SearchResultSuggestion, CoreResponseProvider {
         self.distance = coreResult.distanceToProximity
         self.originalResponse = CoreSearchResultResponse(coreResult: coreResult, response: response)
         self.categories = coreResult.categories
+        self.categoryIDs = coreResult.categoryIDs
         self.serverIndex = coreResult.serverIndex?.intValue
         self.estimatedTime = coreResult.estimatedTime
         self.descriptionText = coreResult.addresses?.first.map(Address.init)?.formattedAddress(style: .medium)

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchBrandSuggestionImpl.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchBrandSuggestionImpl.swift
@@ -30,7 +30,7 @@ class SearchBrandSuggestionImpl: SearchBrandSuggestion, CoreResponseProvider {
 
     var categories: [String]?
 
-    var categoryIDs: [String]?
+    var categoryIds: [String]?
 
     var distance: CLLocationDistance?
 
@@ -59,7 +59,7 @@ class SearchBrandSuggestionImpl: SearchBrandSuggestion, CoreResponseProvider {
         self.distance = coreResult.distanceToProximity
         self.batchResolveSupported = coreResult.action?.multiRetrievable ?? false
         self.categories = coreResult.categories
-        self.categoryIDs = coreResult.categoryIDs
+        self.categoryIds = coreResult.categoryIDs
 
         self.descriptionText = coreResult.addressDescription
         self.estimatedTime = coreResult.estimatedTime

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchCategorySuggestionImpl.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchCategorySuggestionImpl.swift
@@ -24,7 +24,7 @@ class SearchCategorySuggestionImpl: SearchCategorySuggestion, CoreResponseProvid
 
     var categories: [String]?
 
-    var categoryIDs: [String]?
+    var categoryIds: [String]?
 
     var distance: CLLocationDistance?
 
@@ -55,7 +55,7 @@ class SearchCategorySuggestionImpl: SearchCategorySuggestion, CoreResponseProvid
         self.distance = coreResult.distanceToProximity
         self.batchResolveSupported = coreResult.action?.multiRetrievable ?? false
         self.categories = coreResult.categories
-        self.categoryIDs = coreResult.categoryIDs
+        self.categoryIds = coreResult.categoryIDs
 
         self.descriptionText = coreResult.addressDescription
         self.estimatedTime = coreResult.estimatedTime

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchQuerySuggestionImpl.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchQuerySuggestionImpl.swift
@@ -22,7 +22,7 @@ class SearchQuerySuggestionImpl: SearchQuerySuggestion, CoreResponseProvider {
 
     var categories: [String]?
 
-    var categoryIDs: [String]?
+    var categoryIds: [String]?
 
     var suggestionType: SearchSuggestType
 
@@ -52,7 +52,7 @@ class SearchQuerySuggestionImpl: SearchQuerySuggestion, CoreResponseProvider {
         self.distance = coreResult.distanceToProximity
         self.batchResolveSupported = coreResult.action?.multiRetrievable ?? false
         self.categories = coreResult.categories
-        self.categoryIDs = coreResult.categoryIDs
+        self.categoryIds = coreResult.categoryIDs
         self.estimatedTime = coreResult.estimatedTime
         self.descriptionText = coreResult.addressDescription
         self.estimatedTime = coreResult.estimatedTime

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchQuerySuggestionImpl.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchQuerySuggestionImpl.swift
@@ -22,6 +22,8 @@ class SearchQuerySuggestionImpl: SearchQuerySuggestion, CoreResponseProvider {
 
     var categories: [String]?
 
+    var categoryIDs: [String]?
+
     var suggestionType: SearchSuggestType
 
     var distance: CLLocationDistance?
@@ -50,6 +52,7 @@ class SearchQuerySuggestionImpl: SearchQuerySuggestion, CoreResponseProvider {
         self.distance = coreResult.distanceToProximity
         self.batchResolveSupported = coreResult.action?.multiRetrievable ?? false
         self.categories = coreResult.categories
+        self.categoryIDs = coreResult.categoryIDs
         self.estimatedTime = coreResult.estimatedTime
         self.descriptionText = coreResult.addressDescription
         self.estimatedTime = coreResult.estimatedTime

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchResult.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchResult.swift
@@ -38,8 +38,11 @@ public protocol SearchResult {
     /// Contains formatted address.
     var descriptionText: String? { get }
 
-    /// Result categories types.
+    /// POI categories. Always empty for non-POI search results.
     var categories: [String]? { get }
+
+    /// Canonical POI category IDs. Always empty for non-POI results.
+    var categoryIDs: [String]? { get }
 
     /// Coordinates of building entries
     var routablePoints: [RoutablePoint]? { get }

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchResult.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchResult.swift
@@ -42,7 +42,7 @@ public protocol SearchResult {
     var categories: [String]? { get }
 
     /// Canonical POI category IDs. Always empty for non-POI results.
-    var categoryIDs: [String]? { get }
+    var categoryIds: [String]? { get }
 
     /// Coordinates of building entries
     var routablePoints: [RoutablePoint]? { get }

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchResultSuggestionImpl.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchResultSuggestionImpl.swift
@@ -22,7 +22,7 @@ class SearchResultSuggestionImpl: SearchResultSuggestion, CoreResponseProvider {
 
     var categories: [String]?
 
-    var categoryIDs: [String]?
+    var categoryIds: [String]?
 
     var suggestionType: SearchSuggestType
 
@@ -66,7 +66,7 @@ class SearchResultSuggestionImpl: SearchResultSuggestion, CoreResponseProvider {
         self.distance = coreResult.distanceToProximity
         self.batchResolveSupported = coreResult.action?.multiRetrievable ?? false
         self.categories = coreResult.categories
-        self.categoryIDs = coreResult.categoryIDs
+        self.categoryIds = coreResult.categoryIDs
         self.estimatedTime = coreResult.estimatedTime
         self.descriptionText = coreResult.addressDescription
         self.estimatedTime = coreResult.estimatedTime

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchResultSuggestionImpl.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchResultSuggestionImpl.swift
@@ -22,6 +22,8 @@ class SearchResultSuggestionImpl: SearchResultSuggestion, CoreResponseProvider {
 
     var categories: [String]?
 
+    var categoryIDs: [String]?
+
     var suggestionType: SearchSuggestType
 
     var descriptionText: String?
@@ -64,6 +66,7 @@ class SearchResultSuggestionImpl: SearchResultSuggestion, CoreResponseProvider {
         self.distance = coreResult.distanceToProximity
         self.batchResolveSupported = coreResult.action?.multiRetrievable ?? false
         self.categories = coreResult.categories
+        self.categoryIDs = coreResult.categoryIDs
         self.estimatedTime = coreResult.estimatedTime
         self.descriptionText = coreResult.addressDescription
         self.estimatedTime = coreResult.estimatedTime

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchSuggestion.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchSuggestion.swift
@@ -30,7 +30,7 @@ public protocol SearchSuggestion {
     var categories: [String]? { get }
 
     /// Canonical POI category IDs. Always empty for non-POI search suggestions.
-    var categoryIDs: [String]? { get }
+    var categoryIds: [String]? { get }
 
     /// Result address.
     var address: Address? { get }

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchSuggestion.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchSuggestion.swift
@@ -26,8 +26,11 @@ public protocol SearchSuggestion {
     /// Usually contains pre-formatted address.
     var descriptionText: String? { get }
 
-    /// Result categories types.
+    /// POI categories. Always empty for non-POI search suggestions.
     var categories: [String]? { get }
+
+    /// Canonical POI category IDs. Always empty for non-POI search suggestions.
+    var categoryIDs: [String]? { get }
 
     /// Result address.
     var address: Address? { get }

--- a/Sources/MapboxSearch/PublicAPI/Search Results/ServerSearchResult.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/ServerSearchResult.swift
@@ -29,7 +29,7 @@ class ServerSearchResult: SearchResult, SearchResultSuggestion, CoreResponseProv
 
     var categories: [String]?
 
-    var categoryIDs: [String]?
+    var categoryIds: [String]?
 
     var routablePoints: [RoutablePoint]?
 
@@ -82,7 +82,7 @@ class ServerSearchResult: SearchResult, SearchResultSuggestion, CoreResponseProv
         self.accuracy = coreResult.resultAccuracy.flatMap(SearchResultAccuracy.from(coreAccuracy:))
         self.address = coreResult.addresses?.first.map(Address.init)
         self.categories = coreResult.categories
-        self.categoryIDs = coreResult.categoryIDs
+        self.categoryIds = coreResult.categoryIDs
         self.coordinateCodable = .init(center.coordinate)
         self.originalResponse = CoreSearchResultResponse(coreResult: coreResult, response: response)
 

--- a/Sources/MapboxSearch/PublicAPI/Search Results/ServerSearchResult.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/ServerSearchResult.swift
@@ -29,6 +29,8 @@ class ServerSearchResult: SearchResult, SearchResultSuggestion, CoreResponseProv
 
     var categories: [String]?
 
+    var categoryIDs: [String]?
+
     var routablePoints: [RoutablePoint]?
 
     let dataLayerIdentifier = SearchEngine.providerIdentifier
@@ -80,6 +82,7 @@ class ServerSearchResult: SearchResult, SearchResultSuggestion, CoreResponseProv
         self.accuracy = coreResult.resultAccuracy.flatMap(SearchResultAccuracy.from(coreAccuracy:))
         self.address = coreResult.addresses?.first.map(Address.init)
         self.categories = coreResult.categories
+        self.categoryIDs = coreResult.categoryIDs
         self.coordinateCodable = .init(center.coordinate)
         self.originalResponse = CoreSearchResultResponse(coreResult: coreResult, response: response)
 

--- a/Tests/MapboxSearchTests/Common/Data Samples/SearchResultStub+Samples.swift
+++ b/Tests/MapboxSearchTests/Common/Data Samples/SearchResultStub+Samples.swift
@@ -5,6 +5,7 @@ extension SearchResultStub {
         id: "sample-1",
         mapboxId: UUID().uuidString, // not actually UUID format but useful for tests
         categories: ["sample-1", "sample-2"],
+        categoryIDs: ["sample-catID-1", "sample-catID-2"],
         name: "Sample No 1",
         matchingName: nil,
         serverIndex: nil,

--- a/Tests/MapboxSearchTests/Common/Data Samples/SearchResultStub+Samples.swift
+++ b/Tests/MapboxSearchTests/Common/Data Samples/SearchResultStub+Samples.swift
@@ -5,7 +5,7 @@ extension SearchResultStub {
         id: "sample-1",
         mapboxId: UUID().uuidString, // not actually UUID format but useful for tests
         categories: ["sample-1", "sample-2"],
-        categoryIDs: ["sample-catID-1", "sample-catID-2"],
+        categoryIds: ["sample-catID-1", "sample-catID-2"],
         name: "Sample No 1",
         matchingName: nil,
         serverIndex: nil,

--- a/Tests/MapboxSearchTests/Common/Models/Search Result/SearchResultSuggestionImplTests.swift
+++ b/Tests/MapboxSearchTests/Common/Models/Search Result/SearchResultSuggestionImplTests.swift
@@ -67,7 +67,7 @@ class SearchResultSuggestionImplTests: XCTestCase {
         XCTAssertEqual(suggestionImpl.categories, coreResult.categories)
     }
 
-    func testSuccessfulInitForCategoryIDs() throws {
+    func testSuccessfulInitForCategoryIds() throws {
         let coreResult = CoreSearchResultStub(
             id: "sample-2",
             mapboxId: "sample-2",
@@ -85,7 +85,7 @@ class SearchResultSuggestionImplTests: XCTestCase {
         ))
         XCTAssertEqual(suggestionImpl.suggestionType, .POI)
         XCTAssertEqual(suggestionImpl.name, coreResult.names.first)
-        XCTAssertEqual(suggestionImpl.categoryIDs, coreResult.categoryIDs)
+        XCTAssertEqual(suggestionImpl.categoryIds, coreResult.categoryIDs)
     }
 
     func testFailedInit() throws {

--- a/Tests/MapboxSearchTests/Common/Models/Search Result/SearchResultSuggestionImplTests.swift
+++ b/Tests/MapboxSearchTests/Common/Models/Search Result/SearchResultSuggestionImplTests.swift
@@ -46,6 +46,48 @@ class SearchResultSuggestionImplTests: XCTestCase {
         XCTAssertEqual(suggestionImpl.namePreferred, coreResult.namePreferred)
     }
 
+    func testSuccessfulInitForCategories() throws {
+        let coreResult = CoreSearchResultStub(
+            id: "sample-2",
+            mapboxId: "sample-2",
+            type: .poi,
+            centerLocation: nil,
+            categories: ["category1", "category2"]
+        )
+        let suggestionImpl = try XCTUnwrap(SearchResultSuggestionImpl(
+            coreResult: coreResult,
+            response: CoreSearchResponseStub(
+                id: 42,
+                options: .sample1,
+                result: .success([])
+            )
+        ))
+        XCTAssertEqual(suggestionImpl.suggestionType, .POI)
+        XCTAssertEqual(suggestionImpl.name, coreResult.names.first)
+        XCTAssertEqual(suggestionImpl.categories, coreResult.categories)
+    }
+
+    func testSuccessfulInitForCategoryIDs() throws {
+        let coreResult = CoreSearchResultStub(
+            id: "sample-2",
+            mapboxId: "sample-2",
+            type: .poi,
+            centerLocation: nil,
+            categoryIDs: ["categoryID1", "categoryID2"]
+        )
+        let suggestionImpl = try XCTUnwrap(SearchResultSuggestionImpl(
+            coreResult: coreResult,
+            response: CoreSearchResponseStub(
+                id: 42,
+                options: .sample1,
+                result: .success([])
+            )
+        ))
+        XCTAssertEqual(suggestionImpl.suggestionType, .POI)
+        XCTAssertEqual(suggestionImpl.name, coreResult.names.first)
+        XCTAssertEqual(suggestionImpl.categoryIDs, coreResult.categoryIDs)
+    }
+
     func testFailedInit() throws {
         XCTAssertNil(SearchResultSuggestionImpl(
             coreResult: CoreSearchResultStub(

--- a/Tests/MapboxSearchTests/Common/Models/Search Result/SearchResultTests.swift
+++ b/Tests/MapboxSearchTests/Common/Models/Search Result/SearchResultTests.swift
@@ -18,4 +18,40 @@ class SearchResultTests: XCTestCase {
         XCTAssertEqual(resultStub.placemark.location?.coordinate.latitude, 12)
         XCTAssertEqual(resultStub.placemark.location?.coordinate.longitude, -35)
     }
+
+    func testCategories() throws {
+        let expectedCategories = ["category1", "category2"]
+        let resultStub = SearchResultStub(
+            id: "unit-test-random",
+            mapboxId: nil,
+            categories: expectedCategories,
+            name: "Unit Test",
+            matchingName: nil,
+            serverIndex: nil,
+            resultType: .POI,
+            coordinate: .init(latitude: 12, longitude: -35),
+            distance: nil,
+            metadata: .pizzaMetadata
+        )
+
+        XCTAssertEqual(resultStub.categories, expectedCategories)
+    }
+
+    func testCategoryIDs() throws {
+        let expectedCategoryIDs = ["categoryID1", "categoryID2"]
+        let resultStub = SearchResultStub(
+            id: "unit-test-random",
+            mapboxId: nil,
+            categories: expectedCategoryIDs,
+            name: "Unit Test",
+            matchingName: nil,
+            serverIndex: nil,
+            resultType: .POI,
+            coordinate: .init(latitude: 12, longitude: -35),
+            distance: nil,
+            metadata: .pizzaMetadata
+        )
+
+        XCTAssertEqual(resultStub.categoryIDs, expectedCategoryIDs)
+    }
 }

--- a/Tests/MapboxSearchTests/Common/Models/Search Result/SearchResultTests.swift
+++ b/Tests/MapboxSearchTests/Common/Models/Search Result/SearchResultTests.swift
@@ -42,7 +42,7 @@ class SearchResultTests: XCTestCase {
         let resultStub = SearchResultStub(
             id: "unit-test-random",
             mapboxId: nil,
-            categories: expectedCategoryIDs,
+            categoryIDs: expectedCategoryIDs,
             name: "Unit Test",
             matchingName: nil,
             serverIndex: nil,

--- a/Tests/MapboxSearchTests/Common/Models/Search Result/SearchResultTests.swift
+++ b/Tests/MapboxSearchTests/Common/Models/Search Result/SearchResultTests.swift
@@ -37,12 +37,12 @@ class SearchResultTests: XCTestCase {
         XCTAssertEqual(resultStub.categories, expectedCategories)
     }
 
-    func testCategoryIDs() throws {
-        let expectedCategoryIDs = ["categoryID1", "categoryID2"]
+    func testCategoryIds() throws {
+        let expectedCategoryIds = ["categoryID1", "categoryID2"]
         let resultStub = SearchResultStub(
             id: "unit-test-random",
             mapboxId: nil,
-            categoryIDs: expectedCategoryIDs,
+            categoryIds: expectedCategoryIds,
             name: "Unit Test",
             matchingName: nil,
             serverIndex: nil,
@@ -52,6 +52,6 @@ class SearchResultTests: XCTestCase {
             metadata: .pizzaMetadata
         )
 
-        XCTAssertEqual(resultStub.categoryIDs, expectedCategoryIDs)
+        XCTAssertEqual(resultStub.categoryIds, expectedCategoryIds)
     }
 }

--- a/Tests/MapboxSearchTests/Common/Models/Search Result/ServerSearchResultTests.swift
+++ b/Tests/MapboxSearchTests/Common/Models/Search Result/ServerSearchResultTests.swift
@@ -91,4 +91,24 @@ class ServerSearchResultTests: XCTestCase {
         XCTAssertNotNil(result.distance)
         XCTAssertEqual(result.distance, 0.0)
     }
+
+    func testServerSearchResultCategoriesField() throws {
+        let expectedCategories = ["category1", "category2"]
+        let coreResult = CoreSearchResultStub(id: UUID().uuidString, mapboxId: "", type: .address, categories: expectedCategories)
+        let result = try XCTUnwrap(ServerSearchResult(
+            coreResult: coreResult,
+            response: CoreSearchResponseStub.failureSample
+        ))
+        XCTAssertEqual(result.categories, expectedCategories)
+    }
+
+    func testServerSearchResultCategoryIDsField() throws {
+        let expectedCategoryIDs = ["categoryID1", "categoryID2"]
+        let coreResult = CoreSearchResultStub(id: UUID().uuidString, mapboxId: "", type: .address, categoryIDs: expectedCategoryIDs)
+        let result = try XCTUnwrap(ServerSearchResult(
+            coreResult: coreResult,
+            response: CoreSearchResponseStub.failureSample
+        ))
+        XCTAssertEqual(result.categoryIDs, expectedCategoryIDs)
+    }
 }

--- a/Tests/MapboxSearchTests/Common/Models/Search Result/ServerSearchResultTests.swift
+++ b/Tests/MapboxSearchTests/Common/Models/Search Result/ServerSearchResultTests.swift
@@ -102,13 +102,13 @@ class ServerSearchResultTests: XCTestCase {
         XCTAssertEqual(result.categories, expectedCategories)
     }
 
-    func testServerSearchResultCategoryIDsField() throws {
-        let expectedCategoryIDs = ["categoryID1", "categoryID2"]
-        let coreResult = CoreSearchResultStub(id: UUID().uuidString, mapboxId: "", type: .address, categoryIDs: expectedCategoryIDs)
+    func testServerSearchResultCategoryIdsField() throws {
+        let expectedCategoryIds = ["categoryID1", "categoryID2"]
+        let coreResult = CoreSearchResultStub(id: UUID().uuidString, mapboxId: "", type: .address, categoryIDs: expectedCategoryIds)
         let result = try XCTUnwrap(ServerSearchResult(
             coreResult: coreResult,
             response: CoreSearchResponseStub.failureSample
         ))
-        XCTAssertEqual(result.categoryIDs, expectedCategoryIDs)
+        XCTAssertEqual(result.categoryIds, expectedCategoryIds)
     }
 }

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/CoreSearchResultStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/CoreSearchResultStub.swift
@@ -55,7 +55,9 @@ class CoreSearchResultStub: CoreSearchResultProtocol {
             mapboxId: dataProviderRecord.mapboxId,
             type: dataProviderRecord.type.coreType,
             names: [dataProviderRecord.name],
-            languages: ["en"]
+            languages: ["en"],
+            categories: dataProviderRecord.categories,
+            categoryIDs: dataProviderRecord.categoryIDs
         )
     }
 

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/CoreSearchResultStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/CoreSearchResultStub.swift
@@ -57,7 +57,7 @@ class CoreSearchResultStub: CoreSearchResultProtocol {
             names: [dataProviderRecord.name],
             languages: ["en"],
             categories: dataProviderRecord.categories,
-            categoryIDs: dataProviderRecord.categoryIDs
+            categoryIDs: dataProviderRecord.categoryIds
         )
     }
 

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/SearchResultStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/SearchResultStub.swift
@@ -7,6 +7,7 @@ class SearchResultStub: SearchResult {
         mapboxId: String?,
         accuracy: SearchResultAccuracy? = nil,
         categories: [String]? = nil,
+        categoryIDs: [String]? = nil,
         name: String,
         matchingName: String?,
         serverIndex: Int?,
@@ -24,6 +25,7 @@ class SearchResultStub: SearchResult {
         self.mapboxId = mapboxId
         self.accuracy = accuracy
         self.categories = categories
+        self.categoryIDs = categoryIDs
         self.name = name
         self.matchingName = matchingName
         self.serverIndex = serverIndex
@@ -44,6 +46,7 @@ class SearchResultStub: SearchResult {
     var mapboxId: String?
     var accuracy: SearchResultAccuracy?
     var categories: [String]?
+    var categoryIDs: [String]?
     var name: String
     var matchingName: String?
     var serverIndex: Int?

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/SearchResultStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/SearchResultStub.swift
@@ -7,7 +7,7 @@ class SearchResultStub: SearchResult {
         mapboxId: String?,
         accuracy: SearchResultAccuracy? = nil,
         categories: [String]? = nil,
-        categoryIDs: [String]? = nil,
+        categoryIds: [String]? = nil,
         name: String,
         matchingName: String?,
         serverIndex: Int?,
@@ -25,7 +25,7 @@ class SearchResultStub: SearchResult {
         self.mapboxId = mapboxId
         self.accuracy = accuracy
         self.categories = categories
-        self.categoryIDs = categoryIDs
+        self.categoryIds = categoryIds
         self.name = name
         self.matchingName = matchingName
         self.serverIndex = serverIndex
@@ -46,7 +46,7 @@ class SearchResultStub: SearchResult {
     var mapboxId: String?
     var accuracy: SearchResultAccuracy?
     var categories: [String]?
-    var categoryIDs: [String]?
+    var categoryIds: [String]?
     var name: String
     var matchingName: String?
     var serverIndex: Int?

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/SearchResultSuggestionStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/SearchResultSuggestionStub.swift
@@ -18,7 +18,7 @@ struct SearchResultSuggestionStub: SearchResultSuggestion {
 
     var categories: [String]?
 
-    var categoryIDs: [String]?
+    var categoryIds: [String]?
 
     var descriptionText: String? = "Test description text"
 

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/SearchResultSuggestionStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/SearchResultSuggestionStub.swift
@@ -18,6 +18,8 @@ struct SearchResultSuggestionStub: SearchResultSuggestion {
 
     var categories: [String]?
 
+    var categoryIDs: [String]?
+
     var descriptionText: String? = "Test description text"
 
     var iconName: String? = Maki.bar.name

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/SearchSuggestionStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/SearchSuggestionStub.swift
@@ -7,7 +7,7 @@ struct SearchSuggestionStub: SearchSuggestion {
     var name: String = "Test Name"
     var namePreferred: String? = "POI Preferred name"
     var categories: [String]?
-    var categoryIDs: [String]?
+    var categoryIds: [String]?
     var descriptionText: String? = "Test Description"
     var address: Address?
     var iconName: String?

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/SearchSuggestionStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/SearchSuggestionStub.swift
@@ -7,6 +7,7 @@ struct SearchSuggestionStub: SearchSuggestion {
     var name: String = "Test Name"
     var namePreferred: String? = "POI Preferred name"
     var categories: [String]?
+    var categoryIDs: [String]?
     var descriptionText: String? = "Test Description"
     var address: Address?
     var iconName: String?

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/TestDataProviderRecord.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/TestDataProviderRecord.swift
@@ -12,6 +12,7 @@ struct TestDataProviderRecord: IndexableRecord, SearchResult {
     var coordinate: CLLocationCoordinate2D
     var iconName: String?
     var categories: [String]?
+    var categoryIDs: [String]?
     var routablePoints: [RoutablePoint]?
     var distance: CLLocationDistance?
     var address: Address?
@@ -28,7 +29,9 @@ struct TestDataProviderRecord: IndexableRecord, SearchResult {
             let record = TestDataProviderRecord(
                 type: .POI,
                 name: "name_\(index)",
-                coordinate: CLLocationCoordinate2D(latitude: 53.89, longitude: 27.55)
+                coordinate: CLLocationCoordinate2D(latitude: 53.89, longitude: 27.55),
+                categories: ["cat-1", "cat-2"],
+                categoryIDs: ["cat-ID-1", "cat-ID-2"]
             )
             results.append(record)
         }

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/TestDataProviderRecord.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/TestDataProviderRecord.swift
@@ -12,7 +12,7 @@ struct TestDataProviderRecord: IndexableRecord, SearchResult {
     var coordinate: CLLocationCoordinate2D
     var iconName: String?
     var categories: [String]?
-    var categoryIDs: [String]?
+    var categoryIds: [String]?
     var routablePoints: [RoutablePoint]?
     var distance: CLLocationDistance?
     var address: Address?
@@ -31,7 +31,7 @@ struct TestDataProviderRecord: IndexableRecord, SearchResult {
                 name: "name_\(index)",
                 coordinate: CLLocationCoordinate2D(latitude: 53.89, longitude: 27.55),
                 categories: ["cat-1", "cat-2"],
-                categoryIDs: ["cat-ID-1", "cat-ID-2"]
+                categoryIds: ["cat-ID-1", "cat-ID-2"]
             )
             results.append(record)
         }

--- a/Tests/MapboxSearchTests/Legacy/CodablePersistentServiceTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/CodablePersistentServiceTests.swift
@@ -41,6 +41,7 @@ class CodablePersistentServiceTests: XCTestCase {
             serverIndex: nil,
             accuracy: nil,
             categories: [],
+            categoryIDs: [],
             resultType: .address(subtypes: [.address]),
             searchRequest: .init(query: "Sample", proximity: nil)
         )

--- a/Tests/MapboxSearchTests/Legacy/CodablePersistentServiceTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/CodablePersistentServiceTests.swift
@@ -41,7 +41,7 @@ class CodablePersistentServiceTests: XCTestCase {
             serverIndex: nil,
             accuracy: nil,
             categories: [],
-            categoryIDs: [],
+            categoryIds: [],
             resultType: .address(subtypes: [.address]),
             searchRequest: .init(query: "Sample", proximity: nil)
         )

--- a/Tests/MapboxSearchTests/Legacy/FavoriteRecordTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/FavoriteRecordTests.swift
@@ -11,7 +11,7 @@ class FavoriteRecordTests: XCTestCase {
         XCTAssertEqual(record.name, "Custom Name")
         XCTAssertEqual(record.address, resultStub.address)
         XCTAssertEqual(record.categories, resultStub.categories)
-        XCTAssertEqual(record.categoryIDs, resultStub.categoryIDs)
+        XCTAssertEqual(record.categoryIds, resultStub.categoryIds)
         XCTAssertEqual(record.coordinateCodable, resultStub.coordinateCodable)
         XCTAssertEqual(record.coordinate, resultStub.coordinate)
         XCTAssertEqual(record.icon, .bar)

--- a/Tests/MapboxSearchTests/Legacy/FavoriteRecordTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/FavoriteRecordTests.swift
@@ -11,6 +11,7 @@ class FavoriteRecordTests: XCTestCase {
         XCTAssertEqual(record.name, "Custom Name")
         XCTAssertEqual(record.address, resultStub.address)
         XCTAssertEqual(record.categories, resultStub.categories)
+        XCTAssertEqual(record.categoryIDs, resultStub.categoryIDs)
         XCTAssertEqual(record.coordinateCodable, resultStub.coordinateCodable)
         XCTAssertEqual(record.coordinate, resultStub.coordinate)
         XCTAssertEqual(record.icon, .bar)

--- a/Tests/MapboxSearchTests/Legacy/HistoryRecordTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/HistoryRecordTests.swift
@@ -76,7 +76,7 @@ class HistoryRecordTests: XCTestCase {
         XCTAssertEqual(record.type, result.type)
         XCTAssertEqual(record.address, result.address)
         XCTAssertEqual(record.categories, result.categories)
-        XCTAssertEqual(record.categoryIDs, result.categoryIDs)
+        XCTAssertEqual(record.categoryIds, result.categoryIds)
         XCTAssertEqual(record.metadata, result.metadata)
         XCTAssertEqual(record.routablePoints, result.routablePoints)
         XCTAssertEqual(record.distance, 100.0)

--- a/Tests/MapboxSearchTests/Legacy/HistoryRecordTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/HistoryRecordTests.swift
@@ -75,6 +75,8 @@ class HistoryRecordTests: XCTestCase {
         XCTAssertEqual(record.historyType, .result)
         XCTAssertEqual(record.type, result.type)
         XCTAssertEqual(record.address, result.address)
+        XCTAssertEqual(record.categories, result.categories)
+        XCTAssertEqual(record.categoryIDs, result.categoryIDs)
         XCTAssertEqual(record.metadata, result.metadata)
         XCTAssertEqual(record.routablePoints, result.routablePoints)
         XCTAssertEqual(record.distance, 100.0)

--- a/Tests/MapboxSearchTests/Legacy/SearchCategorySuggestionImplTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/SearchCategorySuggestionImplTests.swift
@@ -9,7 +9,9 @@ class SearchCategorySuggestionImplTests: XCTestCase {
             mapboxId: "sample-2",
             type: .category,
             namePreferred: "Preferred name",
-            centerLocation: nil
+            centerLocation: nil,
+            categories: ["cat-1"],
+            categoryIDs: ["cat-ID-1"]
         )
         let suggestionImpl = try XCTUnwrap(SearchCategorySuggestionImpl(
             coreResult: coreResult,
@@ -22,6 +24,8 @@ class SearchCategorySuggestionImplTests: XCTestCase {
         XCTAssertEqual(suggestionImpl.suggestionType, .category)
         XCTAssertEqual(suggestionImpl.name, coreResult.names.first)
         XCTAssertEqual(suggestionImpl.namePreferred, "Preferred name")
+        XCTAssertEqual(suggestionImpl.categories, ["cat-1"])
+        XCTAssertEqual(suggestionImpl.categoryIDs, ["cat-ID-1"])
     }
 
     func testFailedInitForPOI() throws {

--- a/Tests/MapboxSearchTests/Legacy/SearchCategorySuggestionImplTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/SearchCategorySuggestionImplTests.swift
@@ -25,7 +25,7 @@ class SearchCategorySuggestionImplTests: XCTestCase {
         XCTAssertEqual(suggestionImpl.name, coreResult.names.first)
         XCTAssertEqual(suggestionImpl.namePreferred, "Preferred name")
         XCTAssertEqual(suggestionImpl.categories, ["cat-1"])
-        XCTAssertEqual(suggestionImpl.categoryIDs, ["cat-ID-1"])
+        XCTAssertEqual(suggestionImpl.categoryIds, ["cat-ID-1"])
     }
 
     func testFailedInitForPOI() throws {


### PR DESCRIPTION
### Description
Fixes [NAVIOS-2177 [Search][Parity] Add categoryIds properties in Search SDK iOS](https://mapbox.atlassian.net/browse/NAVIOS-2177) 

### Checklist
- [x] Update `CHANGELOG`
