### PR TITLE
[CI][iOS] Fix release pod setup.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,12 +236,13 @@ jobs:
       - parse-release-version
       - setup-authentication
       - install-mbx-ci-darwin
+      - install-gems
       - run: scripts/generate_podspecs.sh
       - run:
           name: Push podspecs to CocoaPods CDN Trunk
           command: |
-            pod trunk push MapboxSearch.podspec --synchronous
-            pod trunk push MapboxSearchUI.podspec --synchronous
+            bundle exec pod trunk push MapboxSearch.podspec --synchronous
+            bundle exec pod trunk push MapboxSearchUI.podspec --synchronous
       - run: brew install gh taiki-e/tap/parse-changelog
       - run: scripts/release_notes.sh
 


### PR DESCRIPTION
To ensure the job [post-SDK_Registry-release](https://app.circleci.com/pipelines/github/mapbox/mapbox-search-ios/2004/workflows/9b2c6ddd-780e-4465-8f7b-ad213b7e0ddd/jobs/5982) is alright.