### PR TITLE
Release 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 Guide: https://keepachangelog.com/en/1.0.0/
 -->
 
-## Unreleased
+## 2.2.1
 
-<!-- Add changes for active work here -->
+- [Core] Update MapboxCommon
+
+**MapboxCommon**: v24.5.1
 
 ## 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 ## 2.2.1
 
-- [Core] Update MapboxCommon
+- [Core] Update MapboxCommon and MapboxCoreSearch package dependencies
 
 **MapboxCommon**: v24.5.1
+**MapboxCoreSearch**: v2.2.1
 
 ## 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Guide: https://keepachangelog.com/en/1.0.0/
 - [Core] Update MapboxCommon and MapboxCoreSearch package dependencies
 
 **MapboxCommon**: v24.5.1
-**MapboxCoreSearch**: v2.2.1
+**MapboxCoreSearch**: v2.2.1 (Swift Package Manager) / v2.2.2 (CocoaPods)
 
 ## 2.2.0
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.2.0
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.5.0
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.5.1

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.2.0
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.2.1
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.5.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.5.0"
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.5.1"
 binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.2.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.5.1"
-binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.2.0"
+binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.2.1"

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 ## License
 
-Mapbox Search for iOS version 2.0.1
+Mapbox Search for iOS version 2.2.1
 Mapbox Search iOS SDK
 
 Copyright © 2021 - 2024 Mapbox, Inc. All rights reserved.

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearch'
-  s.version          = '2.2.0'
+  s.version          = '2.2.1'
   s.summary          = 'Search SDK for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.
@@ -25,5 +25,5 @@ Some iOS platform specifics applies.
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
   s.dependency "MapboxCoreSearch", '2.2.0'
-  s.dependency "MapboxCommon", '24.5.0'
+  s.dependency "MapboxCommon", '24.5.1'
 end

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -24,6 +24,6 @@ Some iOS platform specifics applies.
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency "MapboxCoreSearch", '2.2.0'
+  s.dependency "MapboxCoreSearch", '2.2.2'
   s.dependency "MapboxCommon", '24.5.1'
 end

--- a/MapboxSearch.xcodeproj/project.pbxproj
+++ b/MapboxSearch.xcodeproj/project.pbxproj
@@ -3552,7 +3552,7 @@
 			repositoryURL = "https://github.com/mapbox/mapbox-common-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = "24.5.0-rc.1";
+				version = 24.5.1;
 			};
 		};
 		042BEB182C2DE30E0004CD7B /* XCRemoteSwiftPackageReference "mapbox-maps-ios" */ = {
@@ -3560,7 +3560,7 @@
 			repositoryURL = "https://github.com/mapbox/mapbox-maps-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = "11.5.0-rc.1";
+				version = 11.5.4;
 			};
 		};
 		149948E5290A8ACE00E7E619 /* XCRemoteSwiftPackageReference "swifter" */ = {

--- a/MapboxSearchUI.podspec
+++ b/MapboxSearchUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearchUI'
-  s.version          = '2.2.0'
+  s.version          = '2.2.1'
   s.summary          = 'Search UI for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.
@@ -23,5 +23,5 @@ Card style custom UI with full search functionality powered by Mapbox Search API
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency 'MapboxSearch', "2.2.0"
+  s.dependency 'MapboxSearch', "2.2.1"
 end

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import Foundation
 
 let (coreSearchVersion, coreSearchVersionHash) = ("2.2.0", "350fb52d0bc1caf60e14270aa603aab1f4f2ae7a907eddf24e1b700fbd709f6d")
 
-let mapboxCommonSDKVersion = Version("24.5.0")
+let mapboxCommonSDKVersion = Version("24.5.1")
 
 let package = Package(
     name: "MapboxSearch",

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 import Foundation
 
-let (coreSearchVersion, coreSearchVersionHash) = ("2.2.0", "350fb52d0bc1caf60e14270aa603aab1f4f2ae7a907eddf24e1b700fbd709f6d")
+let (coreSearchVersion, coreSearchVersionHash) = ("2.2.1", "e1c396e9bf60663b52389e750260028cf11663cefeeb215efed37f26c55a56b4")
 
 let mapboxCommonSDKVersion = Version("24.5.1")
 

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ Once you've installed the prerequisites, no additional steps are needed: Open th
 
 You can find the following documentation pages helpful:
 - [Search SDK for iOS guide](https://docs.mapbox.com/ios/search/guides/)
-- [MapboxSearch reference](https://docs.mapbox.com/ios/search/api/core/2.2.0/)
-- [MapboxSearchUI reference](https://docs.mapbox.com/ios/search/api/ui/2.2.0/)
+- [MapboxSearch reference](https://docs.mapbox.com/ios/search/api/core/2.2.1/)
+- [MapboxSearchUI reference](https://docs.mapbox.com/ios/search/api/ui/2.2.1/)
 
 ## Project structure overview
 
@@ -110,13 +110,13 @@ MapboxSearchDemoApplication provides a Demo app wih MapboxSearchUI.framework pre
 ##### MapboxSearch
 To integrate latest preview version of `MapboxSearch` into your Xcode project using CocoaPods, specify it in your `Podfile`:  
 ```
-pod 'MapboxSearch', ">= 2.2.0", "< 3.0"
+pod 'MapboxSearch', ">= 2.2.1", "< 3.0"
 ```
 
 ##### MapboxSearchUI
 To integrate latest preview version of `MapboxSearchUI` into your Xcode project using CocoaPods, specify it in your `Podfile`:  
 ```
-pod 'MapboxSearchUI', ">= 2.2.0", "< 3.0"
+pod 'MapboxSearchUI', ">= 2.2.1", "< 3.0"
 ```
 
 ### Swift Package Manager

--- a/Search Documentation.docc/Installation.md
+++ b/Search Documentation.docc/Installation.md
@@ -59,7 +59,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearchUI', ">= 2.2.0", "< 3.0"
+      pod 'MapboxSearchUI', ">= 2.2.1", "< 3.0"
     end
     ```
 
@@ -68,7 +68,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearch', ">= 2.2.0", "< 3.0"
+      pod 'MapboxSearch', ">= 2.2.1", "< 3.0"
     end
     ```
 

--- a/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
+++ b/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
@@ -1,2 +1,2 @@
 /// Mapbox Search SDK version variable
-public let mapboxSearchSDKVersion = "2.2.0"
+public let mapboxSearchSDKVersion = "2.2.1"


### PR DESCRIPTION
### Description

- Update dependencies for v2.2.1
  - MapboxCommon 24.5.1
  - MapboxCoreSearch 2.2.1 (Note: [podspec 2.2.2](https://github.com/CocoaPods/Specs/blob/master/Specs/6/8/5/MapboxCoreSearch/2.2.2/MapboxCoreSearch.podspec.json) points to framework of 2.2.1, see comments below)
- Related: https://github.com/mapbox/change-management/issues/4077

### Checklist
- [x] Update `CHANGELOG`
