### PR TITLE
Support PlaceAutocompleteResult.boundingBox, PlaceAutocompleteSuggestion.categoryIds, PlaceAutocompleteResult.categoryIds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 Guide: https://keepachangelog.com/en/1.0.0/
 -->
 
+## Unreleased
+
+- [Core] Added an optional property `SearchResult.boundingBox` which represents the geographical boundaries of a location.
+- [PlaceAutocomplete] Added new properties `PlaceAutocomplete.Suggestion.categoryIds`, `PlaceAutocomplete.Result.categoryIds`, and `PlaceAutocomplete.Result.boundingBox`.
+
 ## 2.14.0-alpha.2
 
 - [Core] Update dependencies.

--- a/MapboxSearch.xcodeproj/project.pbxproj
+++ b/MapboxSearch.xcodeproj/project.pbxproj
@@ -134,7 +134,7 @@
 		149948ED290A8DCA00E7E619 /* Swifter in Frameworks */ = {isa = PBXBuildFile; productRef = 149948EC290A8DCA00E7E619 /* Swifter */; };
 		149948EF290A8DD500E7E619 /* Swifter in Frameworks */ = {isa = PBXBuildFile; productRef = 149948EE290A8DD500E7E619 /* Swifter */; };
 		149948F1290A8DF900E7E619 /* Swifter in Frameworks */ = {isa = PBXBuildFile; productRef = 149948F0290A8DF900E7E619 /* Swifter */; settings = {ATTRIBUTES = (Required, ); }; };
-		14A0B83D2A5FF20B00D281F1 /* PlaceAutocomplet.Result+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A0B83B2A5FF1B300D281F1 /* PlaceAutocomplet.Result+Tests.swift */; };
+		14A0B83D2A5FF20B00D281F1 /* PlaceAutocomplete.Result+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A0B83B2A5FF1B300D281F1 /* PlaceAutocomplete.Result+Tests.swift */; };
 		14F71865299FD4BD00D5BC2E /* PlaceAutocomplete+PlaceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F71864299FD4BD00D5BC2E /* PlaceAutocomplete+PlaceType.swift */; };
 		14F7186B29A1361700D5BC2E /* PlaceAutocompleteMainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F7186929A1341A00D5BC2E /* PlaceAutocompleteMainViewController.swift */; };
 		14F7186D29A139BF00D5BC2E /* PlaceAutocompleteDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F7186C29A139BF00D5BC2E /* PlaceAutocompleteDetailsViewController.swift */; };
@@ -660,7 +660,7 @@
 		148DE66B285757AA0085684D /* AddressAutofill+Result.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddressAutofill+Result.swift"; sourceTree = "<group>"; };
 		148DE670285777180085684D /* NSLocking+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSLocking+Extensions.swift"; sourceTree = "<group>"; };
 		148DE68A285A18900085684D /* AddressAutofill+AddressComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddressAutofill+AddressComponent.swift"; sourceTree = "<group>"; };
-		14A0B83B2A5FF1B300D281F1 /* PlaceAutocomplet.Result+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaceAutocomplet.Result+Tests.swift"; sourceTree = "<group>"; };
+		14A0B83B2A5FF1B300D281F1 /* PlaceAutocomplete.Result+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaceAutocomplete.Result+Tests.swift"; sourceTree = "<group>"; };
 		14B92D5D298BFD19006003C1 /* DiscoverViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverViewController.swift; sourceTree = "<group>"; };
 		14F71864299FD4BD00D5BC2E /* PlaceAutocomplete+PlaceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaceAutocomplete+PlaceType.swift"; sourceTree = "<group>"; };
 		14F7186929A1341A00D5BC2E /* PlaceAutocompleteMainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceAutocompleteMainViewController.swift; sourceTree = "<group>"; };
@@ -1567,7 +1567,7 @@
 			children = (
 				14FA65832953618800056E5B /* PlaceAutocomplete.Options+Tests.swift */,
 				2CA1E22029F09CD200A533CF /* PlaceAutocomplete.Suggestion+Tests.swift */,
-				14A0B83B2A5FF1B300D281F1 /* PlaceAutocomplet.Result+Tests.swift */,
+				14A0B83B2A5FF1B300D281F1 /* PlaceAutocomplete.Result+Tests.swift */,
 				2CA1E22229F0A47600A533CF /* PlaceAutocompleteTests.swift */,
 			);
 			path = "Place Autocomplete";
@@ -2863,7 +2863,7 @@
 				FE7C73B3256687310047CA20 /* IndexableRecordStub.swift in Sources */,
 				FEEDD3A42508E24900DC0A98 /* SearchErrorTests.swift in Sources */,
 				FE8F821C256D509600A100D4 /* RoutablePointTests.swift in Sources */,
-				14A0B83D2A5FF20B00D281F1 /* PlaceAutocomplet.Result+Tests.swift in Sources */,
+				14A0B83D2A5FF20B00D281F1 /* PlaceAutocomplete.Result+Tests.swift in Sources */,
 				14FA658229535ABC00056E5B /* AdministrativeUnits+Tests.swift in Sources */,
 				FEB0AA8325CAC3EF002F0D1F /* CoreResultTypeTests.swift in Sources */,
 				FE4655A12566B619007ECC6A /* SearchResultSuggestionImplTests.swift in Sources */,

--- a/Sources/MapboxSearch/InternalAPI/CoreBoundingBox.swift
+++ b/Sources/MapboxSearch/InternalAPI/CoreBoundingBox.swift
@@ -13,3 +13,9 @@ extension CoreBoundingBox {
         return log2(Swift.min(longitudeZoom, latitudeZoom))
     }
 }
+
+extension BoundingBox {
+    init(_ coreBoundingBox: CoreBoundingBox) {
+        self.init(coreBoundingBox.min, coreBoundingBox.max)
+    }
+}

--- a/Sources/MapboxSearch/InternalAPI/CoreSearchResultProtocol.swift
+++ b/Sources/MapboxSearch/InternalAPI/CoreSearchResultProtocol.swift
@@ -68,6 +68,8 @@ protocol CoreSearchResultProtocol {
     var brand: [String]? { get }
 
     var brandID: String? { get }
+
+    var boundingBox: CoreBoundingBox? { get }
 }
 
 extension CoreSearchResult: CoreSearchResultProtocol {
@@ -94,4 +96,7 @@ extension CoreSearchResult: CoreSearchResultProtocol {
     var addressDescription: String? { descrAddress }
 
     var externalIds: [String: String]? { externalIDs }
+
+    var boundingBox: CoreBoundingBox? { bbox }
+
 }

--- a/Sources/MapboxSearch/PublicAPI/FavoriteRecord.swift
+++ b/Sources/MapboxSearch/PublicAPI/FavoriteRecord.swift
@@ -75,6 +75,9 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
     /// Original search request.
     public let searchRequest: SearchRequestOptions
 
+    /// Optional bounding box that represents the geographical boundaries of a location, e.g., a building.
+    public let boundingBox: BoundingBox?
+
     /// Associated metadata
     public var metadata: SearchResultMetadata?
 
@@ -97,6 +100,7 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
     ///   - metadata: Associated metadata
     ///   - resultType: Favorite result type
     ///   - descriptionText: Address formatted with the medium style
+    ///   - boundingBox: Bounding box that represents the geographical boundaries of a location
     public init(
         id: String? = nil,
         mapboxId: String? = nil,
@@ -114,7 +118,8 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
         resultType: SearchResultType,
         searchRequest: SearchRequestOptions,
         metadata: SearchResultMetadata? = nil,
-        descriptionText: String? = nil
+        descriptionText: String? = nil,
+        boundingBox: BoundingBox? = nil
     ) {
         self.id = id ?? UUID().uuidString
         self.mapboxId = mapboxId
@@ -133,6 +138,7 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
         self.metadata = metadata
         self.searchRequest = searchRequest
         self.descriptionText = descriptionText ?? address?.formattedAddress(style: .medium)
+        self.boundingBox = boundingBox
     }
 
     /// Build Favorite record from SearchResult
@@ -161,7 +167,9 @@ public struct FavoriteRecord: IndexableRecord, SearchResult, Codable, Equatable 
             routablePoints: searchResult.routablePoints,
             resultType: searchResult.type,
             searchRequest: searchResult.searchRequest,
-            metadata: searchResult.metadata
+            metadata: searchResult.metadata,
+            descriptionText: searchResult.descriptionText,
+            boundingBox: searchResult.boundingBox
         )
     }
 }

--- a/Sources/MapboxSearch/PublicAPI/HistoryRecord.swift
+++ b/Sources/MapboxSearch/PublicAPI/HistoryRecord.swift
@@ -91,6 +91,9 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
     /// Coordinates of building entries
     public var routablePoints: [RoutablePoint]?
 
+    /// Optional bounding box that represents the geographical boundaries of a location, e.g., a building.
+    public let boundingBox: BoundingBox?
+
     /// History record constructor
     /// - Parameters:
     ///   - id: UUID used by default
@@ -111,6 +114,7 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
     ///   - searchRequest: The original search request
     ///   - routablePoints: Coordinates of building entries
     ///   - descriptionText: Address formatted with the medium style
+    ///   - boundingBox: Bounding box that represents the geographical boundaries of a location
     public init(
         id: String = UUID().uuidString,
         mapboxId: String?,
@@ -129,7 +133,8 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
         categoryIds: [String]? = nil,
         searchRequest: SearchRequestOptions,
         routablePoints: [RoutablePoint]? = nil,
-        descriptionText: String? = nil
+        descriptionText: String? = nil,
+        boundingBox: BoundingBox? = nil
     ) {
         self.id = id
         self.mapboxId = mapboxId
@@ -149,6 +154,7 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
         self.searchRequest = searchRequest
         self.routablePoints = routablePoints
         self.descriptionText = descriptionText ?? address?.formattedAddress(style: .medium)
+        self.boundingBox = boundingBox
     }
 
     /// Construct `HistoryRecord` based on concrete `SearchResult`
@@ -179,5 +185,6 @@ public struct HistoryRecord: IndexableRecord, SearchResult, Codable, Hashable {
         self.searchRequest = searchResult.searchRequest
         self.routablePoints = searchResult.routablePoints
         self.descriptionText = searchResult.descriptionText
+        self.boundingBox = searchResult.boundingBox
     }
 }

--- a/Sources/MapboxSearch/PublicAPI/Search Results/SearchResult.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/SearchResult.swift
@@ -62,6 +62,9 @@ public protocol SearchResult {
 
     /// Additional search result data, such as phone number, website and other
     var metadata: SearchResultMetadata? { get }
+
+    /// Optional bounding box that represents the geographical boundaries of a location, e.g., a building.
+    var boundingBox: BoundingBox? { get }
 }
 
 extension SearchResult {

--- a/Sources/MapboxSearch/PublicAPI/Search Results/ServerSearchResult.swift
+++ b/Sources/MapboxSearch/PublicAPI/Search Results/ServerSearchResult.swift
@@ -64,6 +64,8 @@ class ServerSearchResult: SearchResult, SearchResultSuggestion, CoreResponseProv
         }
     }
 
+    var boundingBox: BoundingBox?
+
     init?(coreResult: CoreSearchResultProtocol, response: CoreSearchResponseProtocol) {
         guard let center = coreResult.centerLocation else { return nil }
 
@@ -95,6 +97,7 @@ class ServerSearchResult: SearchResult, SearchResultSuggestion, CoreResponseProv
 
         self.brand = coreResult.brand
         self.brandID = coreResult.brandID
+        self.boundingBox = coreResult.boundingBox.map(BoundingBox.init)
 
         assert(!id.isEmpty)
         assert(!name.isEmpty)

--- a/Sources/MapboxSearch/PublicAPI/SearchOptions.swift
+++ b/Sources/MapboxSearch/PublicAPI/SearchOptions.swift
@@ -217,7 +217,7 @@ public struct SearchOptions {
     /// - 5th to 7th: `coffee` POIs
     /// - 8th to 10th: `parking_lot` POI
     /// - Note: ``ApiType/searchBox`` only.
-    public var ensureResultsPerCategory: Bool? = nil
+    public var ensureResultsPerCategory: Bool?
 
     init(coreSearchOptions options: CoreSearchOptions) {
         let proximity = options.proximity.map { CLLocationCoordinate2D(

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/Models/PlaceAutocomplete+Result.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/Models/PlaceAutocomplete+Result.swift
@@ -35,6 +35,9 @@ extension PlaceAutocomplete {
         /// Type representing address components.
         public let address: AddressComponents?
 
+        /// Optional bounding box that represents the geographical boundaries of a location, e.g., a building.
+        public let boundingBox: BoundingBox?
+
         /// Business phone number
         public let phone: String?
 

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/Models/PlaceAutocomplete+Result.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/Models/PlaceAutocomplete+Result.swift
@@ -32,6 +32,9 @@ extension PlaceAutocomplete {
         /// Poi categories. Always empty for non-POI suggestions.
         public let categories: [String]
 
+        /// Canonical POI category IDs. Always empty for non-POI search suggestions.
+        public let categoryIds: [String]
+
         /// Type representing address components.
         public let address: AddressComponents?
 

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/Models/PlaceAutocomplete+Suggestion.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/Models/PlaceAutocomplete+Suggestion.swift
@@ -30,6 +30,9 @@ extension PlaceAutocomplete {
         /// Poi categories. Always empty for non-POI suggestions.
         public let categories: [String]
 
+        /// Canonical POI category IDs. Always empty for non-POI search suggestions.
+        public let categoryIds: [String]
+
         /// List of points near `coordinate`, that represents entries to associated building.
         public let routablePoints: [RoutablePoint]
 
@@ -47,6 +50,7 @@ extension PlaceAutocomplete {
             estimatedTime: Measurement<UnitDuration>?,
             placeType: SearchResultType,
             categories: [String],
+            categoryIds: [String],
             routablePoints: [RoutablePoint],
             underlying: Underlying
         ) {
@@ -59,6 +63,7 @@ extension PlaceAutocomplete {
             self.estimatedTime = estimatedTime
             self.placeType = placeType
             self.categories = categories
+            self.categoryIds = categoryIds
             self.routablePoints = routablePoints
             self.underlying = underlying
         }
@@ -83,6 +88,7 @@ extension PlaceAutocomplete.Suggestion {
             estimatedTime: estimatedTime,
             routablePoints: underlyingResult.routablePoints ?? [],
             categories: underlyingResult.categories ?? [],
+            categoryIds: underlyingResult.categoryIds ?? [],
             address: AddressComponents(searchResult: underlyingResult),
             boundingBox: underlyingResult.boundingBox,
             phone: underlyingResult.metadata?.phone,
@@ -123,6 +129,7 @@ extension PlaceAutocomplete.Suggestion {
             estimatedTime: searchResultType.estimatedTime,
             placeType: searchResultType.type,
             categories: searchResultType.categories ?? [],
+            categoryIds: searchResultType.categoryIds ?? [],
             routablePoints: searchResultType.routablePoints ?? [],
             underlying: .result(searchResult)
         )
@@ -152,6 +159,7 @@ extension PlaceAutocomplete.Suggestion {
             estimatedTime: searchSuggestion.estimatedTime,
             placeType: type,
             categories: searchSuggestion.categories ?? [],
+            categoryIds: searchSuggestion.categoryIDs ?? [],
             routablePoints: searchSuggestion.routablePoints?.map(RoutablePoint.init) ?? [],
             underlying: .suggestion(searchSuggestion, options)
         )

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/Models/PlaceAutocomplete+Suggestion.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/Models/PlaceAutocomplete+Suggestion.swift
@@ -84,6 +84,7 @@ extension PlaceAutocomplete.Suggestion {
             routablePoints: underlyingResult.routablePoints ?? [],
             categories: underlyingResult.categories ?? [],
             address: AddressComponents(searchResult: underlyingResult),
+            boundingBox: underlyingResult.boundingBox,
             phone: underlyingResult.metadata?.phone,
             website: underlyingResult.metadata?.website,
             reviewCount: underlyingResult.metadata?.reviewCount,

--- a/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/PlaceAutocomplete.swift
+++ b/Sources/MapboxSearch/PublicAPI/Use Cases/Place Autocomplete/PlaceAutocomplete.swift
@@ -335,6 +335,7 @@ extension PlaceAutocomplete {
                 estimatedTime: result.estimatedTime,
                 placeType: placeTypes ?? .POI,
                 categories: categories,
+                categoryIds: result.categoryIDs ?? [],
                 routablePoints: routablePoints,
                 underlying: underlying
             )

--- a/Tests/MapboxSearchTests/Common/Data Samples/CoreSearchResultStub+Samples.swift
+++ b/Tests/MapboxSearchTests/Common/Data Samples/CoreSearchResultStub+Samples.swift
@@ -93,7 +93,8 @@ extension CoreSearchResultStub {
             languages: ["en"],
             centerLocation: center,
             categories: ["cafe"],
-            icon: Maki.alcoholShop.name
+            icon: Maki.alcoholShop.name,
+            boundingBox: .init(min: .sample1, max: .sample2)
         )
         return result
     }

--- a/Tests/MapboxSearchTests/Common/Data Samples/CoreSearchResultStub+Samples.swift
+++ b/Tests/MapboxSearchTests/Common/Data Samples/CoreSearchResultStub+Samples.swift
@@ -34,17 +34,22 @@ extension CoreSearchResultStub {
         return results
     }
 
-    static func makeSuggestion(metadata: CoreResultMetadata? = nil) -> CoreSearchResultStub {
+    static func makeSuggestion(
+        centerLocation: CLLocation? = .sample1,
+        metadata: CoreResultMetadata? = nil
+    ) -> CoreSearchResultStub {
         let result = CoreSearchResultStub(
             id: UUID().uuidString,
             mapboxId: "",
             type: .place,
             names: ["Some Place Name"],
             languages: ["en"],
-            centerLocation: nil,
+            centerLocation: centerLocation,
             categories: ["cafe"],
+            categoryIDs: ["cafe-ID"],
             icon: Maki.alcoholShop.name,
-            metadata: metadata
+            metadata: metadata,
+            boundingBox: .init(min: .sample1, max: .sample2)
         )
         return result
     }

--- a/Tests/MapboxSearchTests/Common/Data Samples/SearchResultStub+Samples.swift
+++ b/Tests/MapboxSearchTests/Common/Data Samples/SearchResultStub+Samples.swift
@@ -16,6 +16,7 @@ extension SearchResultStub {
         distance: 100.0,
         address: .fullAddress,
         metadata: .pizzaMetadata,
-        dataLayerIdentifier: "sample-data-layer-identifier"
+        dataLayerIdentifier: "sample-data-layer-identifier",
+        boundingBox: BoundingBox(.sample1, .sample2)
     )
 }

--- a/Tests/MapboxSearchTests/Common/Models/Search Result/ServerSearchResultTests.swift
+++ b/Tests/MapboxSearchTests/Common/Models/Search Result/ServerSearchResultTests.swift
@@ -111,4 +111,18 @@ class ServerSearchResultTests: XCTestCase {
         ))
         XCTAssertEqual(result.categoryIds, expectedCategoryIds)
     }
+
+    func testServerSearchResultBoundingBox() {
+        let coreResult = CoreSearchResultStub(
+            id: UUID().uuidString,
+            mapboxId: "",
+            type: .address,
+            boundingBox: CoreBoundingBox(min: .sample1, max: .sample2)
+        )
+        let result = ServerSearchResult(
+            coreResult: coreResult,
+            response: CoreSearchResponseStub.failureSample
+        )
+        XCTAssertEqual(result?.boundingBox, BoundingBox(.sample1, .sample2))
+    }
 }

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/CoreSearchResultStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/CoreSearchResultStub.swift
@@ -24,7 +24,8 @@ class CoreSearchResultStub: CoreSearchResultProtocol {
         serverIndex: NSNumber? = 1,
         distance: NSNumber? = nil,
         metadata: CoreResultMetadata? = nil,
-        estimatedTime: Measurement<UnitDuration>? = nil
+        estimatedTime: Measurement<UnitDuration>? = nil,
+        boundingBox: CoreBoundingBox? = nil
     ) {
         self.id = id
         self.mapboxId = mapboxId
@@ -47,6 +48,7 @@ class CoreSearchResultStub: CoreSearchResultProtocol {
         self.distance = distance
         self.metadata = metadata
         self.estimatedTime = estimatedTime
+        self.boundingBox = boundingBox
     }
 
     convenience init(dataProviderRecord: TestDataProviderRecord) {
@@ -57,7 +59,8 @@ class CoreSearchResultStub: CoreSearchResultProtocol {
             names: [dataProviderRecord.name],
             languages: ["en"],
             categories: dataProviderRecord.categories,
-            categoryIDs: dataProviderRecord.categoryIds
+            categoryIDs: dataProviderRecord.categoryIds,
+            boundingBox: dataProviderRecord.boundingBox.map(CoreBoundingBox.init(boundingBox:))
         )
     }
 
@@ -87,6 +90,7 @@ class CoreSearchResultStub: CoreSearchResultProtocol {
     var externalIds: [String: String]?
     var brand: [String]?
     var brandID: String?
+    var boundingBox: CoreBoundingBox?
 
     var distanceToProximity: CLLocationDistance? {
         distance.map(\.doubleValue)
@@ -122,6 +126,9 @@ extension CoreSearchResultStub: Equatable {
             && lhs.action == rhs.action
             && lhs.serverIndex == rhs.serverIndex
             && lhs.distance == rhs.distance
+            && lhs.brand == rhs.brand
+            && lhs.brandID == rhs.brandID
+            && lhs.boundingBox == rhs.boundingBox
     }
 }
 
@@ -155,7 +162,7 @@ extension CoreSearchResultProtocol {
             userRecordPriority: 100,
             action: action,
             serverIndex: serverIndex,
-            bbox: nil
+            bbox: boundingBox
         )
     }
 }

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/PlaceAutocompleteSuggestionStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/PlaceAutocompleteSuggestionStub.swift
@@ -17,6 +17,7 @@ extension PlaceAutocomplete.Suggestion {
             estimatedTime: nil,
             placeType: placeType,
             categories: ["coffee"],
+            categoryIds: ["cat-ID-1", "cat-ID-2"],
             routablePoints: routablePoints,
             underlying: underlying
         )

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/SearchResultStub.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/SearchResultStub.swift
@@ -19,7 +19,8 @@ class SearchResultStub: SearchResult {
         address: Address? = nil,
         metadata: SearchResultMetadata?,
         searchRequest: SearchRequestOptions = .init(query: "Sample", proximity: nil),
-        dataLayerIdentifier: String = "unit-test-stub"
+        dataLayerIdentifier: String = "unit-test-stub",
+        boundingBox: BoundingBox? = .init(.init(latitude: 1.0, longitude: 2.0), .init(latitude: 2.0, longitude: 3.0))
     ) {
         self.id = id
         self.mapboxId = mapboxId
@@ -38,6 +39,7 @@ class SearchResultStub: SearchResult {
         self.metadata = metadata
         self.dataLayerIdentifier = dataLayerIdentifier
         self.searchRequest = searchRequest
+        self.boundingBox = boundingBox
     }
 
     var dataLayerIdentifier: String
@@ -69,6 +71,7 @@ class SearchResultStub: SearchResult {
     var address: Address?
     var descriptionText: String?
     var searchRequest: SearchRequestOptions
+    var boundingBox: BoundingBox?
 }
 
 // MARK: - SearchResultStub

--- a/Tests/MapboxSearchTests/Common/Stubs&Models/TestDataProviderRecord.swift
+++ b/Tests/MapboxSearchTests/Common/Stubs&Models/TestDataProviderRecord.swift
@@ -22,6 +22,7 @@ struct TestDataProviderRecord: IndexableRecord, SearchResult {
     var descriptionText: String?
     var searchRequest: SearchRequestOptions = .init(query: "Sample", proximity: nil)
     var makiIcon: String? { iconName }
+    var boundingBox: BoundingBox?
 
     static func testData(count: Int) -> [TestDataProviderRecord] {
         var results = [TestDataProviderRecord]()

--- a/Tests/MapboxSearchTests/Legacy/FavoriteRecordTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/FavoriteRecordTests.swift
@@ -17,6 +17,7 @@ class FavoriteRecordTests: XCTestCase {
         XCTAssertEqual(record.icon, .bar)
         XCTAssertEqual(record.type, resultStub.type)
         XCTAssertEqual(record.distance, 100.0)
+        XCTAssertEqual(record.boundingBox, record.boundingBox)
 
         XCTAssertNil(record.additionalTokens)
     }

--- a/Tests/MapboxSearchTests/Legacy/HistoryRecordTests.swift
+++ b/Tests/MapboxSearchTests/Legacy/HistoryRecordTests.swift
@@ -80,5 +80,6 @@ class HistoryRecordTests: XCTestCase {
         XCTAssertEqual(record.metadata, result.metadata)
         XCTAssertEqual(record.routablePoints, result.routablePoints)
         XCTAssertEqual(record.distance, 100.0)
+        XCTAssertEqual(record.boundingBox, result.boundingBox)
     }
 }

--- a/Tests/MapboxSearchTests/Use Cases/Place Autocomplete/PlaceAutocomplete.Result+Tests.swift
+++ b/Tests/MapboxSearchTests/Use Cases/Place Autocomplete/PlaceAutocomplete.Result+Tests.swift
@@ -23,4 +23,15 @@ final class PlaceAutocompleteResultTests: XCTestCase {
         XCTAssertEqual(result.address?.countryISO1, "US")
         XCTAssertEqual(result.address?.countryISO2, "US-NY")
     }
+
+    func testCreateFromCoreSearchResult() throws {
+        let coreResult = CoreSearchResultStub.makeSuggestion()
+        let response = CoreSearchResponseStub.successSample(results: [coreResult])
+        let searchResult = ServerSearchResult(coreResult: coreResult, response: response)!
+        let result = try PlaceAutocomplete.Suggestion.from(searchResult)
+            .result(for: searchResult)
+        XCTAssertEqual(result.boundingBox, BoundingBox(.sample1, .sample2))
+        XCTAssertEqual(result.categories, coreResult.categories)
+        XCTAssertEqual(result.categoryIds, coreResult.categoryIDs)
+    }
 }

--- a/Tests/MapboxSearchTests/Use Cases/Place Autocomplete/PlaceAutocomplete.Suggestion+Tests.swift
+++ b/Tests/MapboxSearchTests/Use Cases/Place Autocomplete/PlaceAutocomplete.Suggestion+Tests.swift
@@ -32,14 +32,18 @@ final class PlaceAutocompleteSuggestionTests: XCTestCase {
             options: options
         )
         XCTAssertNotNil(suggestion)
-        guard case .suggestion = suggestion!.underlying else {
+        guard let suggestion,
+            case .suggestion = suggestion.underlying else {
             XCTFail("Should have underlying suggestion")
             return
         }
+
+        XCTAssertEqual(suggestion.categories, coreSuggestion.categories)
+        XCTAssertEqual(suggestion.categoryIds, coreSuggestion.categoryIDs)
     }
 
     func testCreationFromCoreSuggestionIfIncorrectCoordinate() {
-        let coreSuggestion = CoreSearchResultStub.makeSuggestion()
+        let coreSuggestion = CoreSearchResultStub.makeSuggestion(centerLocation: nil)
 
         XCTAssertThrowsError(
             try PlaceAutocomplete.Suggestion.from(


### PR DESCRIPTION
### Description
Fixes [NAVIOS-2258](https://mapbox.atlassian.net/browse/NAVIOS-2258)

### Checklist
- [x] Update `CHANGELOG`

Support properties added in v2.9.0 Native Search SDK.
These properties are already supported on Android in mapbox/mapbox-search-android#331 and mapbox/mapbox-search-android#325

[NAVIOS-2258]: https://mapbox.atlassian.net/browse/NAVIOS-2258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ