### PR TITLE
Fix instructions for using SPM to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,16 @@ You can install MapboxSearch and/or MapboxSearchUI packages with Swift Package M
 
 ### Swift Package Manager
 
-Add the MapboxSearch dependency to your Package.swift or use the Xcode > Project settings > Package Dependencies tab.
+1. Set up .netrc file for sdk registry access
+    1. Create .netrc file in user home directory (`$HOME/.netrc`, e.g. `/Users/victorprivalov/.netrc`)
+    2. File content:
+    ```
+    machine api.mapbox.com
+    login mapbox
+    password sk.ey_Your_Access_Token_With_Read_permission
+    ```
+
+2. Add the MapboxSearch dependency to your Package.swift or use the Xcode > Project settings > Package Dependencies tab.
 ```swift
 dependencies: [
     .package(url: "https://github.com/mapbox/mapbox-search-ios.git")


### PR DESCRIPTION
The instructions for adding `mapbox-search-ios.git` do not mention needing to have an `.netrc` file created. As a result adding the package fails for anyone who does not have this file set up. This PR explicitly adds instructions to create the `.netrc` file for SPM users.