### PR TITLE
Release 2.2.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,7 +299,7 @@ commands:
       - run:
           name: Force update Homebrew
           command: cd "$(brew --repository)" && git fetch && git reset --hard origin/master
-      - run: brew update-reset
+      # - run: brew update-reset
       - run: brew upgrade carthage
 
   parse-release-version:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 Guide: https://keepachangelog.com/en/1.0.0/
 -->
 
+## 2.2.2
+
+- [Core] Update MapboxCommon and MapboxCoreSearch package dependencies
+
+**MapboxCommon**: v24.5.2
+**MapboxCoreSearch**: v2.2.3 (CocoaPods)
+
+- Fixed the code signing validation issue for MapboxCommon.xcframework binary "The signature of "MapboxCommon.xcframework" cannot be validated and may have been compromised".
+
 ## 2.2.1
 
 - [Core] Update MapboxCommon and MapboxCoreSearch package dependencies

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" == 2.2.1
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.5.1
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 24.5.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.5.1"
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "24.5.2"
 binary "https://api.mapbox.com/downloads/v2/carthage/search-core-sdk/MapboxCoreSearch.xcframework.json" "2.2.1"

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 ## License
 
-Mapbox Search for iOS version 2.2.1
+Mapbox Search for iOS version 2.2.2
 Mapbox Search iOS SDK
 
 Copyright © 2021 - 2024 Mapbox, Inc. All rights reserved.

--- a/MapboxSearch.podspec
+++ b/MapboxSearch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearch'
-  s.version          = '2.2.1'
+  s.version          = '2.2.2'
   s.summary          = 'Search SDK for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.
@@ -24,6 +24,6 @@ Some iOS platform specifics applies.
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency "MapboxCoreSearch", '2.2.2'
-  s.dependency "MapboxCommon", '24.5.1'
+  s.dependency "MapboxCoreSearch", '2.2.3'
+  s.dependency "MapboxCommon", '24.5.2'
 end

--- a/MapboxSearch.xcodeproj/project.pbxproj
+++ b/MapboxSearch.xcodeproj/project.pbxproj
@@ -3552,7 +3552,7 @@
 			repositoryURL = "https://github.com/mapbox/mapbox-common-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 24.5.1;
+				version = 24.5.2;
 			};
 		};
 		042BEB182C2DE30E0004CD7B /* XCRemoteSwiftPackageReference "mapbox-maps-ios" */ = {
@@ -3560,7 +3560,7 @@
 			repositoryURL = "https://github.com/mapbox/mapbox-maps-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 11.5.4;
+				version = 11.5.5;
 			};
 		};
 		149948E5290A8ACE00E7E619 /* XCRemoteSwiftPackageReference "swifter" */ = {

--- a/MapboxSearchUI.podspec
+++ b/MapboxSearchUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MapboxSearchUI'
-  s.version          = '2.2.1'
+  s.version          = '2.2.2'
   s.summary          = 'Search UI for Mapbox Search API'
 
 # This description is used to generate tags and improve search results.
@@ -23,5 +23,5 @@ Card style custom UI with full search functionality powered by Mapbox Search API
 
   s.vendored_frameworks = "**/#{s.name}.xcframework"
 
-  s.dependency 'MapboxSearch', "2.2.1"
+  s.dependency 'MapboxSearch', "2.2.2"
 end

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import Foundation
 
 let (coreSearchVersion, coreSearchVersionHash) = ("2.2.1", "e1c396e9bf60663b52389e750260028cf11663cefeeb215efed37f26c55a56b4")
 
-let mapboxCommonSDKVersion = Version("24.5.1")
+let mapboxCommonSDKVersion = Version("24.5.2")
 
 let package = Package(
     name: "MapboxSearch",

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ Once you've installed the prerequisites, no additional steps are needed: Open th
 
 You can find the following documentation pages helpful:
 - [Search SDK for iOS guide](https://docs.mapbox.com/ios/search/guides/)
-- [MapboxSearch reference](https://docs.mapbox.com/ios/search/api/core/2.2.1/)
-- [MapboxSearchUI reference](https://docs.mapbox.com/ios/search/api/ui/2.2.1/)
+- [MapboxSearch reference](https://docs.mapbox.com/ios/search/api/core/2.2.2/)
+- [MapboxSearchUI reference](https://docs.mapbox.com/ios/search/api/ui/2.2.2/)
 
 ## Project structure overview
 
@@ -110,13 +110,13 @@ MapboxSearchDemoApplication provides a Demo app wih MapboxSearchUI.framework pre
 ##### MapboxSearch
 To integrate latest preview version of `MapboxSearch` into your Xcode project using CocoaPods, specify it in your `Podfile`:  
 ```
-pod 'MapboxSearch', ">= 2.2.1", "< 3.0"
+pod 'MapboxSearch', ">= 2.2.2", "< 3.0"
 ```
 
 ##### MapboxSearchUI
 To integrate latest preview version of `MapboxSearchUI` into your Xcode project using CocoaPods, specify it in your `Podfile`:  
 ```
-pod 'MapboxSearchUI', ">= 2.2.1", "< 3.0"
+pod 'MapboxSearchUI', ">= 2.2.2", "< 3.0"
 ```
 
 ### Swift Package Manager

--- a/Search Documentation.docc/Installation.md
+++ b/Search Documentation.docc/Installation.md
@@ -59,7 +59,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearchUI', ">= 2.2.1", "< 3.0"
+      pod 'MapboxSearchUI', ">= 2.2.2", "< 3.0"
     end
     ```
 
@@ -68,7 +68,7 @@ To add the Mapbox Search SDK dependency with CocoaPods, you will need to configu
     ```ruby
     use_frameworks!
     target "TargetNameForYourApp" do
-      pod 'MapboxSearch', ">= 2.2.1", "< 3.0"
+      pod 'MapboxSearch', ">= 2.2.2", "< 3.0"
     end
     ```
 

--- a/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
+++ b/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
@@ -1,2 +1,2 @@
 /// Mapbox Search SDK version variable
-public let mapboxSearchSDKVersion = "2.2.1"
+public let mapboxSearchSDKVersion = "2.2.2"


### PR DESCRIPTION
### Description
Release 2.2.2

- `MapboxCoreSearch` update is not required since `2.2.1` is binary compatible with `Common` `24.5.2` and does not have signing.

### Checklist
- [x] Update `CHANGELOG`
