### PR TITLE
Fix framework and docs build without Carthage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,6 +189,7 @@ jobs:
       - checkout
       - setup-authentication
       - parse-release-version
+      - run: brew install xcodegen
       - run: make ios
       - persist_to_workspace:
           root: Products

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 build/
 DerivedData/
 MapboxSearchFramework.xcodeproj
+jazzy-theme/
 
 ## Various settings
 *.pbxuser

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 ## Build generated
 build/
 DerivedData/
+MapboxSearchFramework.xcodeproj
 
 ## Various settings
 *.pbxuser
@@ -79,6 +80,7 @@ fastlane/test_output
 .DS_Store
 .mapbox
 *framework.zip
+libraries
 Products/
 /Carthage/.resolved.md5
 /docs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GEM
     faraday_middleware (1.2.1)
       faraday (~> 1.0)
     fastimage (2.4.0)
-    fastlane (2.227.1)
+    fastlane (2.228.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.8, < 3.0.0)
       artifactory (~> 3.0)
@@ -192,12 +192,12 @@ GEM
       google-apis-core (>= 0.11.0, < 2.a)
     google-apis-storage_v1 (0.31.0)
       google-apis-core (>= 0.11.0, < 2.a)
-    google-cloud-core (1.8.0)
+    google-cloud-core (1.7.1)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
     google-cloud-env (1.6.0)
       faraday (>= 0.17.3, < 3.0)
-    google-cloud-errors (1.5.0)
+    google-cloud-errors (1.4.0)
     google-cloud-storage (1.47.0)
       addressable (~> 2.8)
       digest-crc (~> 0.4)
@@ -319,4 +319,4 @@ DEPENDENCIES
   jazzy (~> 0.14.4)
 
 BUNDLED WITH
-   2.6.7
+   2.4.13

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ dependencies deps:
 	xcodebuild -resolvePackageDependencies -project MapboxSearch.xcodeproj
     
 generate-xcodeproj:
+	scripts/xcodegen_prepare_dependecies.sh
 	xcodegen generate
 
 offline:

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,15 @@ VERSION ?= $(shell git describe --tags $(shell git rev-list --tags='v*' --max-co
 VERSION_STRIPPED ?= $(VERSION:v%=%)
 MARKETING_VERSION := $(shell echo "${VERSION}" | perl -nle 'print $$v if ($$v)=/([0-9]+([.][0-9]+)+)/')
 
-build products ios: dependencies
+build products ios: generate-xcodeproj
 	$(CURRENT_DIR)/scripts/build.sh
 
 dependencies deps:
 	swift package resolve
 	xcodebuild -resolvePackageDependencies -project MapboxSearch.xcodeproj
+    
+generate-xcodeproj:
+	xcodegen generate
 
 offline:
 	aws s3 cp s3://vng-temp/HERE/luxembourg.tgz - | tar -xz -C Demo/offline/
@@ -30,7 +33,7 @@ codecov:
 	scripts/coverage/gather_coverage.sh "^MapboxSearch$$" coverage
 	scripts/coverage/upload_codecov.sh coverage/MapboxSearch.framework.coverage.txt
 
-generate-docs: dependencies
+generate-docs: generate-xcodeproj
 	VERSION="${VERSION}" $(CURRENT_DIR)/scripts/generate_docs.sh
 
 release-docs: generate-docs

--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,10 @@ let package = Package(
             name: "MapboxSearch",
             targets: ["MapboxSearch"]
         ),
-        .library(name: "MapboxSearchUI",
-                 targets: ["MapboxSearchUI"])
+        .library(
+            name: "MapboxSearchUI",
+            targets: ["MapboxSearchUI"]
+        )
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.

--- a/project.yml
+++ b/project.yml
@@ -1,0 +1,72 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Kila2/XcodeGen/master/Assets/json-schema/project.json
+
+name: MapboxSearchFramework
+options:
+  bundleIdPrefix: com.mapbox
+  deploymentTarget:
+    iOS: 12.0
+
+packages:
+  MapboxCommon:
+    url: "https://github.com/mapbox/mapbox-common-ios.git"
+    exactVersion: "24.15.0-rc.1"
+
+targets:
+  MapboxSearch:
+    type: framework
+    supportedDestinations: [iOS]
+    settings:
+      base:
+        MACH_O_TYPE: mh_dylib
+        PRODUCT_NAME: $(TARGET_NAME:c99extidentifier)
+        PRODUCT_BUNDLE_IDENTIFIER: com.mapbox.mapboxsearch
+        SKIP_INSTALL: NO
+        DEFINES_MODULE: YES
+        LD_RUNPATH_SEARCH_PATHS: $(inherited) @executable_path/Frameworks @loader_path/Frameworks $(PROJECT_DIR)/libraries
+        LIBRARY_SEARCH_PATHS: $(inherited) $(PROJECT_DIR)/libraries
+        SWIFT_EMIT_PRIVATE_MODULE_INTERFACE: YES
+        SWIFT_INSTALL_OBJC_HEADER: NO
+        SWIFT_TREAT_WARNINGS_AS_ERRORS: NO
+        BUILD_LIBRARY_FOR_DISTRIBUTION: YES
+        CODE_SIGN_STYLE: Automatic
+        STRIP_STYLE: non-global
+        STRIPFLAGS: -rS
+    sources:
+      - path: "Sources/MapboxSearch"
+    resources: 
+      - path: "Resources"
+        excludes:
+          - "**/*.xcprivacy"
+    dependencies:
+      - package: MapboxCommon
+        product: MapboxCommon
+      - framework: libraries/MapboxCoreSearch.xcframework
+        embed: false
+        
+  MapboxSearchUI:
+    type: framework
+    supportedDestinations: [iOS]
+    settings:
+      base:
+        MACH_O_TYPE: mh_dylib
+        PRODUCT_NAME: $(TARGET_NAME:c99extidentifier)
+        PRODUCT_BUNDLE_IDENTIFIER: com.mapbox.mapboxsearchui
+        SKIP_INSTALL: NO
+        DEFINES_MODULE: YES
+        LD_RUNPATH_SEARCH_PATHS: $(inherited) @executable_path/Frameworks @loader_path/Frameworks $(PROJECT_DIR)/libraries
+        LIBRARY_SEARCH_PATHS: $(inherited) $(PROJECT_DIR)/libraries
+        SWIFT_EMIT_PRIVATE_MODULE_INTERFACE: YES
+        SWIFT_INSTALL_OBJC_HEADER: NO
+        SWIFT_TREAT_WARNINGS_AS_ERRORS: NO
+        BUILD_LIBRARY_FOR_DISTRIBUTION: YES
+        CODE_SIGN_STYLE: Automatic
+        STRIP_STYLE: non-global
+        STRIPFLAGS: -rS
+    sources:
+      - path: "Sources/MapboxSearchUI"
+    resources: 
+      - path: "Resources/"
+        excludes:
+          - "**/*.xcprivacy"
+    dependencies:
+      - target: MapboxSearch

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -26,8 +26,8 @@ pushd "${PROJECT_ROOT}" > /dev/null
 SIMULATOR_ARCHIVE_NAME="${RESULT_PRODUCTS_DIR}/Search-iphonesimulator.xcarchive"
 DEVICE_ARCHIVE_NAME="${RESULT_PRODUCTS_DIR}/Search-iphoneos.xcarchive"
 
-xcodebuild archive -scheme "MapboxSearchUI" -destination "generic/platform=iOS Simulator" SKIP_INSTALL=NO ${MARKETING_VERSION:+MARKETING_VERSION=${MARKETING_VERSION}} -archivePath "${SIMULATOR_ARCHIVE_NAME}" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
-xcodebuild archive -scheme "MapboxSearchUI" -destination "generic/platform=iOS" SKIP_INSTALL=NO ${MARKETING_VERSION:+MARKETING_VERSION=${MARKETING_VERSION}}  -archivePath "${DEVICE_ARCHIVE_NAME}" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+xcodebuild archive -project MapboxSearchFramework.xcodeproj -scheme "MapboxSearchUI" -destination "generic/platform=iOS Simulator" SKIP_INSTALL=NO ${MARKETING_VERSION:+MARKETING_VERSION=${MARKETING_VERSION}} -archivePath "${SIMULATOR_ARCHIVE_NAME}" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+xcodebuild archive -project MapboxSearchFramework.xcodeproj -scheme "MapboxSearchUI" -destination "generic/platform=iOS" SKIP_INSTALL=NO ${MARKETING_VERSION:+MARKETING_VERSION=${MARKETING_VERSION}}  -archivePath "${DEVICE_ARCHIVE_NAME}" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
 
 for frameworkName in "MapboxSearch" "MapboxSearchUI"
 do

--- a/scripts/generate_docs.sh
+++ b/scripts/generate_docs.sh
@@ -14,7 +14,7 @@ bundle exec jazzy \
   --copyright "${COPYRIGHT_TEXT}" \
   --theme "${JAZZY_THEME}" \
   --module-version "${VERSION}" \
-  --build-tool-arguments -scheme,MapboxSearch \
+  --build-tool-arguments -scheme,MapboxSearch,-project,MapboxSearchFramework.xcodeproj \
   --module MapboxSearch \
   --output docs/MapboxSearch
 
@@ -25,7 +25,7 @@ bundle exec jazzy \
   --copyright "${COPYRIGHT_TEXT}" \
   --theme "${JAZZY_THEME}" \
   --module-version "${VERSION}" \
-  --build-tool-arguments -scheme,MapboxSearchUI \
+  --build-tool-arguments -scheme,MapboxSearchUI,-project,MapboxSearchFramework.xcodeproj \
   --module MapboxSearchUI \
   --output docs/MapboxSearchUI
 

--- a/scripts/xcodegen_prepare_dependecies.sh
+++ b/scripts/xcodegen_prepare_dependecies.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+BASEDIR=$(dirname "$0")
+PROJECT_ROOT="$(cd "${BASEDIR}/.." && pwd)"
+PACKAGE_FILE="${PROJECT_ROOT}/Package.swift"
+PROJECT_YML="${PROJECT_ROOT}/project.yml"
+
+if [ ! -f "$PACKAGE_FILE" ]; then
+  echo "$PACKAGE_FILE not found in current directory"
+  exit 1
+fi
+
+MAPBOX_COMMON_VERSION=$(grep 'let mapboxCommonSDKVersion = Version("' "$PACKAGE_FILE" | sed -E "s/.*Version\\(\"([^\"]+)\"\\).*/\\1/")
+if [ -z "$MAPBOX_COMMON_VERSION" ]; then
+  echo "Failed to extract MapboxCommon version from Package.swift"
+  exit 1
+fi
+
+echo "$PROJECT_YML"
+sed -i '' -E "/MapboxCommon:/,/exactVersion:/s/exactVersion: \"[^\"]+\"/exactVersion: \"$MAPBOX_COMMON_VERSION\"/" "$PROJECT_YML"
+echo "project.yml updated with MapboxCommon version $MAPBOX_COMMON_VERSION"
+
+CORE_SEARCH_VERSION=$(grep 'let (coreSearchVersion,' "$PACKAGE_FILE" | sed -E 's/.*= \("([^"]+)",.*/\1/')
+if [ -z "$CORE_SEARCH_VERSION" ]; then
+  echo "Failed to extract CoreSearch version from Package.swift"
+  exit 1
+fi
+
+URL="https://api.mapbox.com/downloads/v2/search-core-sdk/releases/ios/packages/$CORE_SEARCH_VERSION/MapboxCoreSearch.xcframework.zip"
+
+TARGET_DIR="$PROJECT_ROOT/libraries"
+FRAMEWORK_NAME="MapboxCoreSearch.xcframework"
+rm -rf "$TARGET_DIR"
+mkdir -p "$TARGET_DIR"
+curl -L --netrc -o "$TARGET_DIR/temp.zip" "$URL"
+git clean -fd -- "$TARGET_DIR/$FRAMEWORK_NAME"
+unzip -qq -o "$TARGET_DIR/temp.zip" -d "$TARGET_DIR"
+rm "$TARGET_DIR/temp.zip"
+
+echo "MapboxCoreSearch $CORE_SEARCH_VERSION is downloaded"


### PR DESCRIPTION
### Description
Fixes CI jobs that previously depended on the Carthage project.

The xcodegen was used instead.
NOTE: for MapboxCoreSearch, I used manual framework downloading since it is not distributed through SPM.
