### PR TITLE
Fix framework resources access

### DIFF
--- a/Sources/MapboxSearchUI/Helpers/Bundle+Extensions.swift
+++ b/Sources/MapboxSearchUI/Helpers/Bundle+Extensions.swift
@@ -15,9 +15,6 @@ extension Bundle {
 #if SWIFT_PACKAGE
     static let mapboxSearchUI = module
 #else
-    static let mapboxSearchUI = Bundle(url: Bundle(for: MapboxSearchController.self).url(
-        forResource: "MapboxSearchUIResources",
-        withExtension: "bundle"
-    )!)!
+    static let mapboxSearchUI = Bundle(for: MapboxSearchController.self)
 #endif
 }


### PR DESCRIPTION
### Description

The framework don't use the resource bundle anymore, so `mapboxSearchUI` changed
